### PR TITLE
Removing community datasets from dataset list

### DIFF
--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -87,7 +87,7 @@ def save_data(message="Done!"):
 #
 # Loads dataset information
 #
-dataset_list = datasets.list_datasets()
+dataset_list = datasets.list_datasets(with_community_datasets=False)
 
 #
 # Initializes state


### PR DESCRIPTION
Removing community datasets from the datasets list. Most of them don't work, and there are also duplicates from the non-community datasets. We go from 884 datasets to 663 datasets.