### PR TITLE
feat: draft augmentation API with back-translation strategy #10

### DIFF
--- a/.github/workflows/check_templates.yml
+++ b/.github/workflows/check_templates.yml
@@ -23,3 +23,6 @@ jobs:
       - name: Check templates
         run: |
           pytest test/test_templates.py
+      - name: Test augmentation
+        run: |
+          pytest test/test_augmentation.py

--- a/promptsource/augmentation.py
+++ b/promptsource/augmentation.py
@@ -1,0 +1,38 @@
+"""A Draft of data augmentation for prompt/output instance.
+
+This simple and stupid draft is meant to be a pot of stone soup.
+
+Example:
+    `augment("Business")` returns `"Enterprises"`
+
+Note:
+    The back-translation strategy uses two different models for increasing the diversity.
+    The risk of distortion is as the above example shown.
+
+Todo:
+    * Speed and memory-footprint
+    * Refactoring for a better implementation of Strategy pattern
+    * API for batch processing
+    * Special tokens that indicate augmentation invariants
+"""
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer, pipeline
+
+
+en_fr_translator = pipeline("translation_en_to_fr")
+fr_en_model_name = "Helsinki-NLP/opus-mt-ROMANCE-en"
+fr_en_translator = pipeline(
+    model=AutoModelForSeq2SeqLM.from_pretrained(fr_en_model_name),
+    tokenizer=AutoTokenizer.from_pretrained(fr_en_model_name),
+    task="translation_fr_to_en",
+)
+
+
+def _back_translation_strategy(text: str) -> str:
+    return fr_en_translator(en_fr_translator(text)[0]["translation_text"])[0]["translation_text"]
+
+
+def _noop_strategy(text: str) -> str:
+    return text
+
+
+augment = _back_translation_strategy

--- a/promptsource/augmentation.py
+++ b/promptsource/augmentation.py
@@ -15,9 +15,14 @@ Todo:
     * API for batch processing
     * Special tokens that indicate augmentation invariants
 """
+import re
+from typing import Iterable, Mapping
+
+from jinja2 import Environment
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer, pipeline
 
 
+jinja_env = Environment()
 en_fr_translator = pipeline("translation_en_to_fr")
 fr_en_model_name = "Helsinki-NLP/opus-mt-ROMANCE-en"
 fr_en_translator = pipeline(
@@ -26,13 +31,56 @@ fr_en_translator = pipeline(
     task="translation_fr_to_en",
 )
 
-
-def _back_translation_strategy(text: str) -> str:
-    return fr_en_translator(en_fr_translator(text)[0]["translation_text"])[0]["translation_text"]
+CONST_REGEX = re.compile(r"(?P<cnst>{{\"[^\"]*\"}})")
 
 
-def _noop_strategy(text: str) -> str:
+def _decorate_constants(tmpl_rows: Iterable[str]) -> (Iterable[str], Mapping[str, str]):
+    decorated_tmpl_rows = []
+    cnst_dict = {}
+    for i, tmpl_row in enumerate(tmpl_rows):
+        decorated_tmpl_row = ""
+        offset = 0
+        for j, mo in enumerate(CONST_REGEX.finditer(tmpl_row)):
+            # The format of special tokens below should be general enough, but it seems making translations worse.
+            cnst_key = f"x_cnst_{i}_{j}"
+            cnst_val = mo.group()
+            cnst_dict[cnst_key] = cnst_val
+            end, shift = mo.span()
+            decorated_tmpl_row += f"{tmpl_row[offset:end]}{cnst_key}"
+            offset = shift
+        decorated_tmpl_row += tmpl_row[offset:]
+        decorated_tmpl_rows.append(decorated_tmpl_row)
+    return decorated_tmpl_rows, cnst_dict
+
+
+def _decorate_text_var(tmpl_str: str) -> str:
+    tmpl = jinja_env.from_string(tmpl_str)
+    return tmpl.render(text="x_txt")
+
+
+def _get_translation(item: Mapping[str, str]) -> str:
+    return item["translation_text"]
+
+
+def _restore_constants_and_text_var(decorated_text: str, cnst_dict: Mapping[str, str]) -> str:
+    for k, v in cnst_dict.items():
+        decorated_text = decorated_text.replace(k, v)
+    return decorated_text.replace("x_txt", "{{text}}")
+
+
+def back_translation_strategy(text: str) -> str:
+    tmpl_str, fld_str = text.split(" |||")
+    tmpl_rows = tmpl_str.splitlines()
+    altered_tmpl_rows, cnst_map = _decorate_constants(tmpl_rows)
+    altered_tmpl_rows = list(map(_decorate_text_var, altered_tmpl_rows))
+    fr_altered_tmpl_rows = list(map(_get_translation, en_fr_translator(altered_tmpl_rows)))
+    en_altered_tmpl_str = "\n".join(map(_get_translation, fr_en_translator(fr_altered_tmpl_rows)))
+    en_restored_tmpl_str = _restore_constants_and_text_var(en_altered_tmpl_str, cnst_map)
+    return en_restored_tmpl_str + " |||" + fld_str
+
+
+def noop_strategy(text: str) -> str:
     return text
 
 
-augment = _back_translation_strategy
+augment = back_translation_strategy

--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -2,6 +2,7 @@ import textwrap
 
 import pandas as pd
 import streamlit as st
+from augmentation import augment
 from jinja2 import TemplateSyntaxError
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
@@ -9,7 +10,6 @@ from pygments.lexers import DjangoLexer
 from session import _get_state
 from utils import get_dataset, get_dataset_confs, list_datasets, removeHyphen, renameDatasetColumn, render_features
 
-from augmentation import augment
 from templates import Template, TemplateCollection
 
 
@@ -444,8 +444,7 @@ else:
                             st.write("Y")
                             show_text(prompt[1], width=40)
                         st.write("Augmented Prompt (demo)")
-                        aug_subject = template.jinja.split("|||")[0].replace("{{text}}", "").strip()
-                        show_text(augment(aug_subject), width=40)
+                        show_text(augment(template.jinja), width=40)
 
 #
 # Must sync state at end

--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -9,6 +9,7 @@ from pygments.lexers import DjangoLexer
 from session import _get_state
 from utils import get_dataset, get_dataset_confs, list_datasets, removeHyphen, renameDatasetColumn, render_features
 
+from augmentation import augment
 from templates import Template, TemplateCollection
 
 
@@ -442,7 +443,9 @@ else:
                         if len(prompt) > 1:
                             st.write("Y")
                             show_text(prompt[1], width=40)
-
+                        st.write("Augmented Prompt (demo)")
+                        aug_subject = template.jinja.split("|||")[0].replace("{{text}}", "").strip()
+                        show_text(augment(aug_subject), width=40)
 
 #
 # Must sync state at end

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,13 @@ black
 datasets==1.7.0
 flake8
 isort
+jinja2
 pytest
 pyyaml>=5
+sentencepiece
 streamlit>=0.82.0
-jinja2
+torch
+transformers
 ##############################################################
 # Dependencies in this section are added for specific datasets
 ##############################################################

--- a/test/test_augmentation.py
+++ b/test/test_augmentation.py
@@ -1,0 +1,19 @@
+import promptsource.augmentation as aug
+
+CASE_AG_NEWS_1 = (
+    "{{text}}"
+    "\nIs this a piece of news regarding "
+    "{{\"world politics\"}}, {{\"sports\"}}, {{\"business\"}}, or {{\"science and technology\"}}? |||"
+    "\n{{ [\"World politics\", \"Sports\", \"Business\", \"Science and technology\"][label] }}"
+)
+
+
+def test_back_translation_strategy():
+    aug_tmpl = aug.back_translation_strategy(CASE_AG_NEWS_1)
+    assert aug_tmpl == CASE_AG_NEWS_1.replace(
+        "a piece of news regarding",
+        "a new one about"
+    ).replace(
+        ", or",
+        " or"
+    )


### PR DESCRIPTION
close: #10 

As per @VictorSanh's request, this PR provides a draft of back-translation based data augmentation. Its API is too simple to be really useful, such that the PR itself is also a draft.

As the docstring says:

```
This simple and stupid draft is meant to be a pot of stone soup.
Example:
    `augment("Business")` returns `"Enterprises"`
Note:
    The back-translation strategy uses two different models for increasing the diversity.
    The risk of distortion is as the above example shown.
Todo:
    * Speed and memory-footprint
    * Refactoring for a better implementation of Strategy pattern
    * API for batch processing
    * Special tokens that indicate augmentation invariants
```

Any suggestion/patch is welcome!

---
~@tianjianjiang 's first question is: suppose we want template-instance-augmentation being 1-to-many-to-many, shall we have separate yaml files for instances and augmentations?~
Without further ado, this PR only demonstrates what will happen to the prompt being augmented by back-translation. For example:
```
Is this a piece of news regarding world politics, sports, business, or science and technology?
```
becomes
```
Is this news about global politics, sports, business, or science and technology? 
```
Please kindly note that we probably don't want `world politics` being altered as `global politics`. See #49 and #55.