### PR TITLE
Add uuid to each template | allow for name updates

### DIFF
--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -215,7 +215,7 @@ if dataset_key is not None:
 
     dataset_templates = template_collection.get_dataset(dataset_key, conf_option.name if conf_option else None)
 
-    template_list = dataset_templates.all_names
+    template_list = dataset_templates.all_template_names
     num_templates = len(template_list)
     st.sidebar.write(
         "No of Templates created for "
@@ -253,7 +253,7 @@ if dataset_key is not None:
                 )
                 new_template_submitted = st.form_submit_button("Create")
                 if new_template_submitted:
-                    if new_template_name in dataset_templates.all_names:
+                    if new_template_name in dataset_templates.all_template_names:
                         st.error(
                             f"A template with the name {new_template_name} already exists "
                             f"for dataset {state.templates_key}."
@@ -272,7 +272,7 @@ if dataset_key is not None:
                     state.new_template_name = None
 
             dataset_templates = template_collection.get_dataset(*state.templates_key)
-            template_list = dataset_templates.all_names
+            template_list = dataset_templates.all_template_names
             if state.template_name:
                 index = template_list.index(state.template_name)
             else:
@@ -302,7 +302,7 @@ if dataset_key is not None:
 
                 if st.form_submit_button("Save"):
                     if (
-                        updated_template_name in dataset_templates.all_names
+                        updated_template_name in dataset_templates.all_template_names
                         and updated_template_name != state.template_name
                     ):
                         st.error(
@@ -315,6 +315,7 @@ if dataset_key is not None:
                         dataset_templates.update_template(
                             state.template_name, updated_template_name, state.jinja, state.reference
                         )
+                        # Update the state as well
                         state.template_name = updated_template_name
     #
     # Displays template output on current example if a template is selected

--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -215,7 +215,7 @@ if dataset_key is not None:
 
     dataset_templates = template_collection.get_dataset(dataset_key, conf_option.name if conf_option else None)
 
-    template_list = dataset_templates.keys
+    template_list = dataset_templates.all_names
     num_templates = len(template_list)
     st.sidebar.write(
         "No of Templates created for "
@@ -253,9 +253,9 @@ if dataset_key is not None:
                 )
                 new_template_submitted = st.form_submit_button("Create")
                 if new_template_submitted:
-                    if new_template_name in dataset_templates.keys:
+                    if new_template_name in dataset_templates.all_names:
                         st.error(
-                            f"A template with the name {state.new_template_name} already exists "
+                            f"A template with the name {new_template_name} already exists "
                             f"for dataset {state.templates_key}."
                         )
                     elif new_template_name == "":
@@ -272,7 +272,7 @@ if dataset_key is not None:
                     state.new_template_name = None
 
             dataset_templates = template_collection.get_dataset(*state.templates_key)
-            template_list = dataset_templates.keys
+            template_list = dataset_templates.all_names
             if state.template_name:
                 index = template_list.index(state.template_name)
             else:
@@ -291,6 +291,7 @@ if dataset_key is not None:
             # If template is selected, displays template editor
             #
             with st.form("edit_template_form"):
+                updated_template_name = st.text_area("Name", height=40, value=template.name)
                 state.jinja = st.text_area("Template", height=40, value=template.jinja)
 
                 state.reference = st.text_area(
@@ -300,9 +301,21 @@ if dataset_key is not None:
                 )
 
                 if st.form_submit_button("Save"):
-                    template.jinja = state.jinja
-                    template.reference = state.reference
-                    dataset_templates.update_template(template.name, state.jinja, state.reference)
+                    if (
+                        updated_template_name in dataset_templates.all_names
+                        and updated_template_name != state.template_name
+                    ):
+                        st.error(
+                            f"A template with the name {updated_template_name} already exists "
+                            f"for dataset {state.templates_key}."
+                        )
+                    elif updated_template_name == "":
+                        st.error("Need to provide a template name.")
+                    else:
+                        dataset_templates.update_template(
+                            state.template_name, updated_template_name, state.jinja, state.reference
+                        )
+                        state.template_name = updated_template_name
     #
     # Displays template output on current example if a template is selected
     # (in second column)

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -110,7 +110,7 @@ class DatasetTemplates:
         """
         List of all templates names for this dataset
         """
-        return [template.name for template in self.templates.values()]
+        return sorted([template.name for template in self.templates.values()])
 
     @property
     def folder_path(self) -> str:

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -99,7 +99,7 @@ class DatasetTemplates:
         self.name_to_id_mapping = {}
         self.sync_mapping()
 
-    def sync_mapping(self) -> Dict:
+    def sync_mapping(self) -> None:
         """
         Re-compute the name_to_id_mapping to ensure it is in sync with self.templates
         """
@@ -108,7 +108,7 @@ class DatasetTemplates:
     @property
     def all_template_names(self) -> List[str]:
         """
-        List of all templates names for this dataset
+        Sorted list of all templates names for this dataset
         """
         return sorted([template.name for template in self.templates.values()])
 

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -106,7 +106,7 @@ class DatasetTemplates:
         self.name_to_id_mapping = {template.name: template.id for template in self.templates.values()}
 
     @property
-    def all_names(self) -> List[str]:
+    def all_template_names(self) -> List[str]:
         """
         List of all templates names for this dataset
         """
@@ -176,7 +176,7 @@ class DatasetTemplates:
         """
 
         # Even if we have an ID, we want to check for duplicate names
-        if template_name not in self.all_names:
+        if template_name not in self.all_template_names:
             raise ValueError(f"No template with name {template_name} for dataset {self.dataset_name} exists.")
 
         del self.templates[self.name_to_id_mapping[template_name]]
@@ -192,7 +192,8 @@ class DatasetTemplates:
         """
         Updates a pre-existing template and writes changes
 
-        :param template: template to be updated
+        :param current_template_name: current name of the template stored in self.templates
+        :param new_template_name: new name for the template
         :param jinja: new jinja entry
         :param reference: new reference entry
         """
@@ -243,6 +244,7 @@ class Template(yaml.YAMLObject):
         behavior, e.g., text passage and instructions, and the output should be
         a desired response.
 
+        :param id: unique identifier to use as key in the yaml file
         :param name: unique name (per dataset) for template
         :param jinja: template expressed in Jinja
         :param reference: string metadata describing author or paper reference

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -95,18 +95,9 @@ class DatasetTemplates:
         # dictionary is keyed by template name.
         self.templates: Dict = self.read_from_file()
 
-        self.rewrite()
-
         # Mapping from template name to template id
         self.name_to_id_mapping = {}
         self.sync_mapping()
-
-    def rewrite(self):
-        new_dict = {}
-        for template in self.templates.values():
-            new_dict[template.id] = template
-        self.templates = new_dict
-        self.write_to_file()
 
     def sync_mapping(self) -> Dict:
         """

--- a/templates/acronym_identification/templates.yaml
+++ b/templates/acronym_identification/templates.yaml
@@ -1,2 +1,0 @@
-dataset: acronym_identification
-templates: {}

--- a/templates/ade_corpus_v2/Ade_corpus_v2_classification/templates.yaml
+++ b/templates/ade_corpus_v2/Ade_corpus_v2_classification/templates.yaml
@@ -1,7 +1,8 @@
 dataset: ade_corpus_v2
 subset: Ade_corpus_v2_classification
 templates:
-    Test1: !Template
-        jinja: '{{text}} Is this sentence ADE-related or not?||| {{["Not-Related", "Related"][label]}}'
-        name: Test1
-        reference: ''
+  7670c23f-d76e-4491-bad3-55ea6b0073f7: !Template
+    id: 7670c23f-d76e-4491-bad3-55ea6b0073f7
+    jinja: '{{text}} Is this sentence ADE-related or not?||| {{["Not-Related", "Related"][label]}}'
+    name: Test1
+    reference: ''

--- a/templates/adversarial_qa/adversarialQA/templates.yaml
+++ b/templates/adversarial_qa/adversarialQA/templates.yaml
@@ -1,7 +1,8 @@
 dataset: adversarial_qa
 subset: adversarialQA
 templates:
-  test1: !Template
+  4b58b6af-7540-4279-a628-d03e26ac78a6: !Template
+    id: 4b58b6af-7540-4279-a628-d03e26ac78a6
     jinja: "{{context}} \n{{question}}||| \n{{answers.text}}"
     name: test1
     reference: test template

--- a/templates/ag_news/templates.yaml
+++ b/templates/ag_news/templates.yaml
@@ -1,12 +1,14 @@
 dataset: ag_news
 templates:
-  Test1: !Template
+  b401b0ee-6ffe-4a91-8e15-77ee073cd858: !Template
+    id: b401b0ee-6ffe-4a91-8e15-77ee073cd858
     jinja: "{{text}} \nIs this a piece of news regarding world politics, sports, business,\
       \ or technology? ||| \n{{[\"World politics\", \"Sport\", \"Business\", \"Technology\"\
       ][label] }}"
     name: Test1
     reference: example template_1
-  basic: !Template
+  d2453fb2-4015-440d-9832-4934b95f6e65: !Template
+    id: d2453fb2-4015-440d-9832-4934b95f6e65
     jinja: "{{text}} \nIs this text an example of news about world politics, sports,\
       \ business, or technology? ||| \n{{[\"World politics\", \"Sport\", \"Business\"\
       , \"Technology\"][label] }}"

--- a/templates/amazon_polarity/templates.yaml
+++ b/templates/amazon_polarity/templates.yaml
@@ -1,6 +1,7 @@
 dataset: amazon_polarity
 templates:
-  Template 1: !Template
+  1e90a24a-1182-43dd-9445-22f2e56e5761: !Template
+    id: 1e90a24a-1182-43dd-9445-22f2e56e5761
     jinja: 'Title: {{title}}
 
       Review: {{review}}
@@ -10,29 +11,8 @@ templates:
       {{["Negative", "Positive"][label]}}'
     name: Template 1
     reference: ''
-  Template 2: !Template
-    jinja: 'Is this product review positive?
-
-      Title: {{title}}
-
-      Review: {{content}}
-
-      Answer: |||
-
-      {{["No", "Yes"][label]}}'
-    name: Template 2
-    reference: ''
-  Template 3: !Template
-    jinja: 'Title: {{title}}
-
-      Review: {{content}}
-
-      Is this product review negative?|||
-
-      {{["Yes", "No"][label]}}'
-    name: Template 3
-    reference: ''
-  Template 4: !Template
+  3a48f287-6a4b-4df0-ab2d-2eaf6cb8e53d: !Template
+    id: 3a48f287-6a4b-4df0-ab2d-2eaf6cb8e53d
     jinja: 'Based on this review, would the user recommend this product?
 
       ===
@@ -45,7 +25,32 @@ templates:
     name: Template 4
     reference: 'Reformulation equivalent to sent analysis: would the user recommend
       this product?'
-  Template 5: !Template
+  592caf8f-f8ff-426a-a61b-b7e95ed510b6: !Template
+    id: 592caf8f-f8ff-426a-a61b-b7e95ed510b6
+    jinja: 'Is this product review positive?
+
+      Title: {{title}}
+
+      Review: {{content}}
+
+      Answer: |||
+
+      {{["No", "Yes"][label]}}'
+    name: Template 2
+    reference: ''
+  745b9c05-10df-4a7e-81ad-1b88cefcb166: !Template
+    id: 745b9c05-10df-4a7e-81ad-1b88cefcb166
+    jinja: 'Title: {{title}}
+
+      Review: {{content}}
+
+      Is this product review negative?|||
+
+      {{["Yes", "No"][label]}}'
+    name: Template 3
+    reference: ''
+  8abb5377-5dd3-4402-92a5-0d81adb6a325: !Template
+    id: 8abb5377-5dd3-4402-92a5-0d81adb6a325
     jinja: 'Title: {{title}}
 
       Review: {{content}}
@@ -55,7 +60,8 @@ templates:
       {{["Negative", "Positive"][label]}}'
     name: Template 5
     reference: ''
-  Template 6: !Template
+  9df70cdf-f8ed-4e79-8e2f-b4668058d637: !Template
+    id: 9df70cdf-f8ed-4e79-8e2f-b4668058d637
     jinja: 'Is there a negative or positive tone to this product review?
 
       ===

--- a/templates/boolq/templates.yaml
+++ b/templates/boolq/templates.yaml
@@ -1,6 +1,22 @@
 dataset: boolq
 templates:
-  Boolq GPT3: !Template
+  9bd5fbaa-e7a2-4847-a7a1-500591d90bb4: !Template
+    id: 9bd5fbaa-e7a2-4847-a7a1-500591d90bb4
+    jinja: '{{passage}} {{question}}? |||
+
+      {% if answer == true %}
+
+      Yes
+
+      {% else %}
+
+      No
+
+      {% endif %}'
+    name: LM style
+    reference: Concatenate passage and question. Transform True/False into Yes/No.
+  c746b16d-212d-4f1f-9988-9fee99584f25: !Template
+    id: c746b16d-212d-4f1f-9988-9fee99584f25
     jinja: '{{passage}}
 
       Question: {{question}}?
@@ -18,7 +34,27 @@ templates:
       {% endif %}'
     name: Boolq GPT3
     reference: Take from GPT3 - Figure G29
-  Exercise style: !Template
+  dc7caf4f-b109-4a82-86a0-2798a5437283: !Template
+    id: dc7caf4f-b109-4a82-86a0-2798a5437283
+    jinja: '{{passage}}
+
+      {{question}}?
+
+      Answer by yes or no. |||
+
+      {% if answer == true %}
+
+      Yes
+
+      {% else %}
+
+      No
+
+      {% endif %}'
+    name: yes/no
+    reference: Yes or no
+  fbba0375-4220-4483-8bbe-0fd630330611: !Template
+    id: fbba0375-4220-4483-8bbe-0fd630330611
     jinja: 'Answer the question based on the passage.
 
       ===
@@ -41,35 +77,3 @@ templates:
     name: Exercise style
     reference: Prompt in the style of task description + instance. Mapped True/False
       into Yes/No
-  LM style: !Template
-    jinja: '{{passage}} {{question}}? |||
-
-      {% if answer == true %}
-
-      Yes
-
-      {% else %}
-
-      No
-
-      {% endif %}'
-    name: LM style
-    reference: Concatenate passage and question. Transform True/False into Yes/No.
-  yes/no: !Template
-    jinja: '{{passage}}
-
-      {{question}}?
-
-      Answer by yes or no. |||
-
-      {% if answer == true %}
-
-      Yes
-
-      {% else %}
-
-      No
-
-      {% endif %}'
-    name: yes/no
-    reference: Yes or no

--- a/templates/drop/templates.yaml
+++ b/templates/drop/templates.yaml
@@ -1,6 +1,14 @@
 dataset: drop
 templates:
-  DROP GPT3: !Template
+  1ad4b078-988b-48c0-b153-3a837a980ac2: !Template
+    id: 1ad4b078-988b-48c0-b153-3a837a980ac2
+    jinja: "Extract all the text in the passage answering the question.\n===\nPassage:\
+      \ {{passage}}\nQuestion: {{question}} \nAnswer: |||\n{% for span in answers_spans.spans\
+      \ %}- {{span}}\n{% endfor %}"
+    name: Span extraction
+    reference: Listing spans answering the questions (generative span extraction)
+  ab58cc42-a558-4709-8a73-30194fcf9fa2: !Template
+    id: ab58cc42-a558-4709-8a73-30194fcf9fa2
     jinja: 'Passage: {{passage}}
 
       Question: {{question}}
@@ -8,9 +16,3 @@ templates:
       Answer: ||| {{ answers_spans.spans | join(", ") }}'
     name: DROP GPT3
     reference: Prompt format from GPT3 - Table G20
-  Span extraction: !Template
-    jinja: "Extract all the text in the passage answering the question.\n===\nPassage:\
-      \ {{passage}}\nQuestion: {{question}} \nAnswer: |||\n{% for span in answers_spans.spans\
-      \ %}- {{span}}\n{% endfor %}"
-    name: Span extraction
-    reference: Listing spans answering the questions (generative span extraction)

--- a/templates/glue/cola/templates.yaml
+++ b/templates/glue/cola/templates.yaml
@@ -1,8 +1,9 @@
 dataset: glue
 subset: cola
 templates:
-    jinja_example: !Template
-        jinja: '{{sentence}} \nIs this example grammatically correct? ||| {{ ["No", "Yes"][label]
-          }}'
-        name: jinja_example
-        reference: A sample glue template
+  39a701ff-bb4b-48ac-8c0a-8c61bf0d4b8d: !Template
+    id: 39a701ff-bb4b-48ac-8c0a-8c61bf0d4b8d
+    jinja: '{{sentence}} \nIs this example grammatically correct? ||| {{ ["No", "Yes"][label]
+      }}'
+    name: jinja_example
+    reference: A sample glue template

--- a/templates/movie_rationales/templates.yaml
+++ b/templates/movie_rationales/templates.yaml
@@ -1,6 +1,27 @@
 dataset: movie_rationales
 templates:
-  Evidences + review: !Template
+  3ea71512-c48a-4898-8e29-6169a7a00752: !Template
+    id: 3ea71512-c48a-4898-8e29-6169a7a00752
+    jinja: "Review: {{review}} \n===\nIs this review negative or positive? |||\n{{[\"\
+      Negative\", \"Positive\"][label]}}"
+    name: Standard binary sentiment analysis
+    reference: Standard binary sentiment analysis
+  5aaa7d8b-631a-4972-aeca-20a4e0518a60: !Template
+    id: 5aaa7d8b-631a-4972-aeca-20a4e0518a60
+    jinja: 'Evidences:
+
+      {% for evid in evidences %}- {{evid}}
+
+      {% endfor %}
+
+      ===
+
+      Based on these review excerpts, is the review positive or negative? ||| {{["Negative",
+      "Positive"][label]}}'
+    name: Evidences sentiment classification
+    reference: Only taking the evidences as input
+  b953c90c-722a-487e-ab8d-c83ae45de139: !Template
+    id: b953c90c-722a-487e-ab8d-c83ae45de139
     jinja: 'Review: {{review}}
 
 
@@ -16,20 +37,8 @@ templates:
       this review is negative or positive. ||| {{["Negative", "Positive"][label]}}'
     name: Evidences + review
     reference: Classification based both on evidences and review
-  Evidences sentiment classification: !Template
-    jinja: 'Evidences:
-
-      {% for evid in evidences %}- {{evid}}
-
-      {% endfor %}
-
-      ===
-
-      Based on these review excerpts, is the review positive or negative? ||| {{["Negative",
-      "Positive"][label]}}'
-    name: Evidences sentiment classification
-    reference: Only taking the evidences as input
-  Generate evidences: !Template
+  e517bce9-5820-4f20-ad86-b2e3db9e6731: !Template
+    id: e517bce9-5820-4f20-ad86-b2e3db9e6731
     jinja: 'Review: {{review}}
 
       ===
@@ -43,7 +52,8 @@ templates:
     name: Generate evidences
     reference: From the review, extract the spans of text that let us think that the
       review is positive or negative.
-  Generate evidences and sentiment: !Template
+  f11ea73a-3a03-43d8-90d8-4da3905161c2: !Template
+    id: f11ea73a-3a03-43d8-90d8-4da3905161c2
     jinja: 'Review: {{review}}
 
       ====
@@ -59,8 +69,3 @@ templates:
     name: Generate evidences and sentiment
     reference: From the review, determine whether it is negative or positive and extract
       the passages supporting this choice
-  Standard binary sentiment analysis: !Template
-    jinja: "Review: {{review}} \n===\nIs this review negative or positive? |||\n{{[\"\
-      Negative\", \"Positive\"][label]}}"
-    name: Standard binary sentiment analysis
-    reference: Standard binary sentiment analysis

--- a/templates/scitail/snli_format/templates.yaml
+++ b/templates/scitail/snli_format/templates.yaml
@@ -1,8 +1,9 @@
 dataset: scitail
 subset: snli_format
 templates:
-    Test1: !Template
-        jinja: "{{sentence1}} \n{{sentence2}}\nAre these sentences neutral or entailment\
-          \ to one another?|||\n{{gold_label}}"
-        name: Test1
-        reference: ''
+  707f9870-64dc-4f24-b4e3-3f26297ec28c: !Template
+    id: 707f9870-64dc-4f24-b4e3-3f26297ec28c
+    jinja: "{{sentence1}} \n{{sentence2}}\nAre these sentences neutral or entailment\
+      \ to one another?|||\n{{gold_label}}"
+    name: Test1
+    reference: ''

--- a/templates/trec/templates.yaml
+++ b/templates/trec/templates.yaml
@@ -1,0 +1,142 @@
+dataset: trec
+templates:
+  21d04668-c5b3-4418-bbb6-663f1ffdb97c: !Template
+    id: 21d04668-c5b3-4418-bbb6-663f1ffdb97c
+    jinja: '{{text}} Answer: ||| {{ ["Description", "Entity", "Abbreviation", "Person",
+      "Quantity", "Location"] [label_coarse] }}'
+    name: gao_et_al_2
+    reference: Adapted from Making Pre-trained Language Models Better Few-shot Learners.
+      Tianyu Gao, Adam Fisch, and Danqi Chen. ArXiv 2020. Table E.1.
+  71090d59-dd02-4cbd-8032-ad86179b9bd4: !Template
+    id: 71090d59-dd02-4cbd-8032-ad86179b9bd4
+    jinja: "{{text}}\n\nWhat is this question asking for?\n|||\n{{ [\"Manner\",\n\
+      \     \"Creative Piece\",\n     \"Animal\",\n      \"Expression abbreviated\"\
+      ,\n      \"Individual\",\n      \"Group\",\n      \"Title\",\n      \"Defintion\"\
+      ,\n      \"Date\",\n      \"Reason\",\n      \"Event\",\n      \"State\",\n\
+      \      \"Description\",\n      \"Count\",\n      \"Other\",\n      \"Letter\"\
+      ,\n      \"Religion\",\n      \"Food\",\n      \"Country\",\n      \"Color\"\
+      ,\n      \"Term\",\n      \"City\",\n      \"Organ of the body\",\n      \"\
+      Disease or medicine\",\n      \"Mountain\",\n      \"Price\",\n      \"Product\"\
+      ,\n      \"Period\",\n      \"Substance\",\n      \"Sport\",\n      \"Plant\"\
+      ,\n      \"Technique\",\n      \"Size\",\n      \"Instrument\",\n      \"Abbreviation\"\
+      ,\n      \"Speed\",\n      \"Word\",\n      \"Language\",\n      \"Percentage\"\
+      ,\n      \"Code\",\n      \"Distance\",\n      \"Temperature\",\n      \"Symbol\"\
+      ,\n      \"Order\",\n      \"Vehicle\",\n      \"Weight\",\n      \"Currency\"\
+      ] [label_fine] }}"
+    name: fine_grained_open_context_first
+    reference: Fine grained classes without providing choices, context first.
+  7a3ed4dd-af89-493c-8efb-c67622f63034: !Template
+    id: 7a3ed4dd-af89-493c-8efb-c67622f63034
+    jinja: '{{text}} : ||| {{ ["Description", "Entity", "Abbreviation", "Person",
+      "Quantity", "Location"] [label_coarse] }}'
+    name: gao_et_al_1
+    reference: Adapted from Making Pre-trained Language Models Better Few-shot Learners.
+      Tianyu Gao, Adam Fisch, and Danqi Chen. ArXiv 2020. Table B.1.
+  7a9e6f3c-1dee-45b0-a315-1badaf59a7b8: !Template
+    id: 7a9e6f3c-1dee-45b0-a315-1badaf59a7b8
+    jinja: "{% if label_coarse == 0 %}\nIs this question asking for a definition,\
+      \ a description, a manner of action, or a reason?\n{% elif label_coarse == 1\
+      \ %}\nIs this question asking for an animal, an organ of the body, a color,\
+      \ a creative piece, a currency, a disease or medicine, an event, a food, a musical\
+      \ instrument, a language, a letter, a plant, a product, a religion, a sport,\
+      \ a substance, a symbol, a technique, a term, a vehicle, a word, or other entity?\n\
+      {% elif label_coarse == 2 %}\nIs this question asking for an abbreviation or\
+      \ an expression abbreviated?\n{% elif label_coarse == 3 %}\nIs this question\
+      \ asking for a group, an individual, a title, or a description?\n{% elif label_coarse\
+      \ == 4 %}\nIs this question asking for a code, a count, a date, a distance,\
+      \ a price, an order, period of time, a percentage, a speed, a temperature, a\
+      \ size, a weight, or other number?\n{% else %}\nIs this question asking for\
+      \ a city, a country, a mountain, a state, or other location?\n{% endif %}\n\
+      {{text}}\n|||\n{{ [\"Manner\",\n     \"Creative Piece\",\n     \"Animal\",\n\
+      \      \"Expression abbreviated\",\n      \"Individual\",\n      \"Group\",\n\
+      \      \"Title\",\n      \"Defintion\",\n      \"Date\",\n      \"Reason\",\n\
+      \      \"Event\",\n      \"State\",\n      \"Description\",\n      \"Count\"\
+      ,\n      \"Other\",\n      \"Letter\",\n      \"Religion\",\n      \"Food\"\
+      ,\n      \"Country\",\n      \"Color\",\n      \"Term\",\n      \"City\",\n\
+      \      \"Organ of the body\",\n      \"Disease or medicine\",\n      \"Mountain\"\
+      ,\n      \"Price\",\n      \"Product\",\n      \"Period\",\n      \"Substance\"\
+      ,\n      \"Sport\",\n      \"Plant\",\n      \"Technique\",\n      \"Size\"\
+      ,\n      \"Instrument\",\n      \"Abbreviation\",\n      \"Speed\",\n      \"\
+      Word\",\n      \"Language\",\n      \"Percentage\",\n      \"Code\",\n     \
+      \ \"Distance\",\n      \"Temperature\",\n      \"Symbol\",\n      \"Order\"\
+      ,\n      \"Vehicle\",\n      \"Weight\",\n      \"Currency\"] [label_fine] }}"
+    name: fine_grained
+    reference: Fine grained labels with coarse-label specific options, context provided
+      first
+  861d1a48-1113-4f35-b777-2b2f12ab9d5d: !Template
+    id: 861d1a48-1113-4f35-b777-2b2f12ab9d5d
+    jinja: '{{text}}
+
+
+      Is this asking about a description, an entity, an abbreviation, a person, a
+      quantity, or a location?
+
+      |||
+
+      {{ ["Description", "Entity", "Abbreviation", "Person", "Quantity", "Location"]
+      [label_coarse] }}'
+    name: trec1
+    reference: Context then prompt
+  aad2def1-b694-40ee-9c26-3d1cf5c577da: !Template
+    id: aad2def1-b694-40ee-9c26-3d1cf5c577da
+    jinja: 'Is the following question asking about a description, an entity, an abbreviation,
+      a person, a quantity, or a location?
+
+
+      {{text}}
+
+      |||
+
+      {{ ["Description", "Entity", "Abbreviation", "Person", "Quantity", "Location"]
+      [label_coarse] }}'
+    name: trec2
+    reference: Prompt then context
+  cfa8fde0-8320-4050-8d6e-7619ab14adea: !Template
+    id: cfa8fde0-8320-4050-8d6e-7619ab14adea
+    jinja: "What is this question asking for?\n\n{{text}}\n|||\n{{ [\"Manner\",\n\
+      \     \"Creative Piece\",\n     \"Animal\",\n      \"Expression abbreviated\"\
+      ,\n      \"Individual\",\n      \"Group\",\n      \"Title\",\n      \"Defintion\"\
+      ,\n      \"Date\",\n      \"Reason\",\n      \"Event\",\n      \"State\",\n\
+      \      \"Description\",\n      \"Count\",\n      \"Other\",\n      \"Letter\"\
+      ,\n      \"Religion\",\n      \"Food\",\n      \"Country\",\n      \"Color\"\
+      ,\n      \"Term\",\n      \"City\",\n      \"Organ of the body\",\n      \"\
+      Disease or medicine\",\n      \"Mountain\",\n      \"Price\",\n      \"Product\"\
+      ,\n      \"Period\",\n      \"Substance\",\n      \"Sport\",\n      \"Plant\"\
+      ,\n      \"Technique\",\n      \"Size\",\n      \"Instrument\",\n      \"Abbreviation\"\
+      ,\n      \"Speed\",\n      \"Word\",\n      \"Language\",\n      \"Percentage\"\
+      ,\n      \"Code\",\n      \"Distance\",\n      \"Temperature\",\n      \"Symbol\"\
+      ,\n      \"Order\",\n      \"Vehicle\",\n      \"Weight\",\n      \"Currency\"\
+      ] [label_fine] }}"
+    name: fine_grained_open
+    reference: Fine grained classes without providing choices.
+  fa588c55-5c69-4fd0-a0b1-edbfa092f710: !Template
+    id: fa588c55-5c69-4fd0-a0b1-edbfa092f710
+    jinja: "{{text}}\n\n{% if label_coarse == 0 %}\nIs this question asking for a\
+      \ definition, a description, a manner of action, or a reason?\n{% elif label_coarse\
+      \ == 1 %}\nIs this question asking for an animal, an organ of the body, a color,\
+      \ a creative piece, a currency, a disease or medicine, an event, a food, a musical\
+      \ instrument, a language, a letter, a plant, a product, a religion, a sport,\
+      \ a substance, a symbol, a technique, a term, a vehicle, a word, or other entity?\n\
+      {% elif label_coarse == 2 %}\nIs this question asking for an abbreviation or\
+      \ an expression abbreviated?\n{% elif label_coarse == 3 %}\nIs this question\
+      \ asking for a group, an individual, a title, or a description?\n{% elif label_coarse\
+      \ == 4 %}\nIs this question asking for a code, a count, a date, a distance,\
+      \ a price, an order, period of time, a percentage, a speed, a temperature, a\
+      \ size, a weight, or other number?\n{% else %}\nIs this question asking for\
+      \ a city, a country, a mountain, a state, or other location?\n{% endif %}|||\n\
+      {{ [\"Manner\",\n     \"Creative Piece\",\n     \"Animal\",\n      \"Expression\
+      \ abbreviated\",\n      \"Individual\",\n      \"Group\",\n      \"Title\",\n\
+      \      \"Defintion\",\n      \"Date\",\n      \"Reason\",\n      \"Event\",\n\
+      \      \"State\",\n      \"Description\",\n      \"Count\",\n      \"Other\"\
+      ,\n      \"Letter\",\n      \"Religion\",\n      \"Food\",\n      \"Country\"\
+      ,\n      \"Color\",\n      \"Term\",\n      \"City\",\n      \"Organ of the\
+      \ body\",\n      \"Disease or medicine\",\n      \"Mountain\",\n      \"Price\"\
+      ,\n      \"Product\",\n      \"Period\",\n      \"Substance\",\n      \"Sport\"\
+      ,\n      \"Plant\",\n      \"Technique\",\n      \"Size\",\n      \"Instrument\"\
+      ,\n      \"Abbreviation\",\n      \"Speed\",\n      \"Word\",\n      \"Language\"\
+      ,\n      \"Percentage\",\n      \"Code\",\n      \"Distance\",\n      \"Temperature\"\
+      ,\n      \"Symbol\",\n      \"Order\",\n      \"Vehicle\",\n      \"Weight\"\
+      ,\n      \"Currency\"] [label_fine] }}"
+    name: fine_grained_context_first
+    reference: Fine grained labels with coarse-label specific options, context provided
+      first

--- a/templates/xnli/en/templates.yaml
+++ b/templates/xnli/en/templates.yaml
@@ -1,35 +1,40 @@
 dataset: xnli
 subset: en
 templates:
-  ANLI GPT3: !Template
-    jinja: "{{premise}}\nQuestion: {{hypothesis}}\nTrue, False or Neither? ||| \n\
-      {% if label == 0 %} \nTrue\n{% elif label == 1 %}\nNeither\n{% else %}\nFalse\n\
-      {% endif %}"
-    name: ANLI GPT3
-    reference: ANLI prompt format from Table G7 in the GPT3 paper
-  Concatenation: !Template
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\n\nDoes Sentence 2\
-      \ entails Sentence 1? Yes, No or Neutral? |||\n{% if label == 0 %} \nYes\n{%\
-      \ elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
-    name: Concatenation
-    reference: Concatenation of premise and hypothesis
-  Concatenation contraposition: !Template
+  4e122d26-7e79-49c0-961b-cf8ee134759e: !Template
+    id: 4e122d26-7e79-49c0-961b-cf8ee134759e
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\n\nDoes Sentence 2\
       \ contradicts Sentence 1? Yes, No or Neutral? |||\n{% if label == 0 %} \nNo\n\
       {% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
     name: Concatenation contraposition
     reference: Concatenation contraposition
-  Label binarization: !Template
-    jinja: "Sentence 1: {{premise}}\n\nSentence 2: {{hypothesis}}\n\nDoes Sentence\
-      \ 2 entails Sentence 1? Yes or No? |||\n{% if label == 0 %} \nYes\n{% else %}\n\
-      No\n{% endif %}"
-    name: Label binarization
-    reference: Grouping "neutral" and "contradiction" as a single label following
-      https://arxiv.org/pdf/1902.01007.pdf Section 4 - Implementation and evaluation
-  Label binarization contraposition: !Template
+  c62a3048-018e-4d93-bc46-645f3f763ee6: !Template
+    id: c62a3048-018e-4d93-bc46-645f3f763ee6
     jinja: "Sentence 1: {{premise}}\n\nSentence 2: {{hypothesis}}\n\nDoes Sentence\
       \ 2 contradicts Sentence 1? Yes or No? |||\n{% if label == 2 %} \nYes\n{% else\
       \ %}\nNo\n{% endif %}"
     name: Label binarization  contraposition
     reference: Inspired from https://arxiv.org/pdf/1902.01007.pdf Section 4 - Implementation
       and evaluation
+  d9e13133-267e-46c4-afad-c2379dcc5272: !Template
+    id: d9e13133-267e-46c4-afad-c2379dcc5272
+    jinja: "{{premise}}\nQuestion: {{hypothesis}}\nTrue, False or Neither? ||| \n\
+      {% if label == 0 %} \nTrue\n{% elif label == 1 %}\nNeither\n{% else %}\nFalse\n\
+      {% endif %}"
+    name: ANLI GPT3
+    reference: ANLI prompt format from Table G7 in the GPT3 paper
+  dd4276e6-aebd-44a3-b3cf-baf8a4c237f0: !Template
+    id: dd4276e6-aebd-44a3-b3cf-baf8a4c237f0
+    jinja: "Sentence 1: {{premise}}\n\nSentence 2: {{hypothesis}}\n\nDoes Sentence\
+      \ 2 entails Sentence 1? Yes or No? |||\n{% if label == 0 %} \nYes\n{% else %}\n\
+      No\n{% endif %}"
+    name: Label binarization
+    reference: Grouping "neutral" and "contradiction" as a single label following
+      https://arxiv.org/pdf/1902.01007.pdf Section 4 - Implementation and evaluation
+  e174f56a-b0af-4937-b6ae-1897cac26eba: !Template
+    id: e174f56a-b0af-4937-b6ae-1897cac26eba
+    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\n\nDoes Sentence 2\
+      \ entails Sentence 1? Yes, No or Neutral? |||\n{% if label == 0 %} \nYes\n{%\
+      \ elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
+    name: Concatenation
+    reference: Concatenation of premise and hypothesis


### PR DESCRIPTION
This PR introduces:
- a unique identifier for each template entry
- we can now update the name of a template without having to create a new entry in the yaml file
- reformatted the current yaml files to have the newly added ids. Nothing has been changed in the names/templates/references

Even if we use uuids as keys for the templates, we still use the names to index them in the UI. So there's a mapping between name and ids to allow to pass a name to update a template, and there's a sync function that ensures any updates in self.templates is applied to the mapping as well

NB: all git diffs for the templates are solely due to some re-ordering based on the new ids