### PR TITLE
Fixed XNLI prompts entailment direction

### DIFF
--- a/templates/xnli/en/templates.yaml
+++ b/templates/xnli/en/templates.yaml
@@ -3,29 +3,29 @@ subset: en
 templates:
   4e122d26-7e79-49c0-961b-cf8ee134759e: !Template
     id: 4e122d26-7e79-49c0-961b-cf8ee134759e
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\n\nDoes Sentence 1\
-      \ contradict Sentence 2? Yes, No or Neutral? |||\n{% if label == 0 %} \nNo\n\
-      {% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
+    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
+      \ 1 contradict Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \n\
+      No\n{% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
     name: Concatenation contraposition
     reference: Concatenation contraposition
   c62a3048-018e-4d93-bc46-645f3f763ee6: !Template
     id: c62a3048-018e-4d93-bc46-645f3f763ee6
-    jinja: "Sentence 1: {{premise}}\n\nSentence 2: {{hypothesis}}\n\nDoes Sentence\
+    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
       \ 1 contradict Sentence 2? Yes or No? |||\n{% if label == 2 %} \nYes\n{% else\
       \ %}\nNo\n{% endif %}"
-    name: Label binarization  contraposition
+    name: Label binarization contraposition
     reference: Inspired from https://arxiv.org/pdf/1902.01007.pdf Section 4 - Implementation
       and evaluation
   d9e13133-267e-46c4-afad-c2379dcc5272: !Template
     id: d9e13133-267e-46c4-afad-c2379dcc5272
-    jinja: "{{premise}}\nQuestion: {{hypothesis}}\nTrue, False or Neither? ||| \n\
+    jinja: "{{premise}}\nQuestion: {{hypothesis}} True, False, or Neither? ||| \n\
       {% if label == 0 %} \nTrue\n{% elif label == 1 %}\nNeither\n{% else %}\nFalse\n\
       {% endif %}"
     name: ANLI GPT3
     reference: ANLI prompt format from Table G7 in the GPT3 paper
   dd4276e6-aebd-44a3-b3cf-baf8a4c237f0: !Template
     id: dd4276e6-aebd-44a3-b3cf-baf8a4c237f0
-    jinja: "Sentence 1: {{premise}}\n\nSentence 2: {{hypothesis}}\n\nDoes Sentence\
+    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
       \ 1 entail Sentence 2? Yes or No? |||\n{% if label == 0 %} \nYes\n{% else %}\n\
       No\n{% endif %}"
     name: Label binarization
@@ -33,8 +33,8 @@ templates:
       https://arxiv.org/pdf/1902.01007.pdf Section 4 - Implementation and evaluation
   e174f56a-b0af-4937-b6ae-1897cac26eba: !Template
     id: e174f56a-b0af-4937-b6ae-1897cac26eba
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\n\nDoes Sentence 1\
-      \ entail Sentence 2? Yes, No or Neutral? |||\n{% if label == 0 %} \nYes\n{%\
-      \ elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
+    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
+      \ 1 entail Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \nYes\n\
+      {% elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
     name: Concatenation
     reference: Concatenation of premise and hypothesis

--- a/templates/xnli/en/templates.yaml
+++ b/templates/xnli/en/templates.yaml
@@ -4,14 +4,14 @@ templates:
   4e122d26-7e79-49c0-961b-cf8ee134759e: !Template
     id: 4e122d26-7e79-49c0-961b-cf8ee134759e
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\n\nDoes Sentence 2\
-      \ contradicts Sentence 1? Yes, No or Neutral? |||\n{% if label == 0 %} \nNo\n\
+      \ contradict Sentence 1? Yes, No or Neutral? |||\n{% if label == 0 %} \nNo\n\
       {% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
     name: Concatenation contraposition
     reference: Concatenation contraposition
   c62a3048-018e-4d93-bc46-645f3f763ee6: !Template
     id: c62a3048-018e-4d93-bc46-645f3f763ee6
     jinja: "Sentence 1: {{premise}}\n\nSentence 2: {{hypothesis}}\n\nDoes Sentence\
-      \ 2 contradicts Sentence 1? Yes or No? |||\n{% if label == 2 %} \nYes\n{% else\
+      \ 2 contradict Sentence 1? Yes or No? |||\n{% if label == 2 %} \nYes\n{% else\
       \ %}\nNo\n{% endif %}"
     name: Label binarization  contraposition
     reference: Inspired from https://arxiv.org/pdf/1902.01007.pdf Section 4 - Implementation
@@ -26,7 +26,7 @@ templates:
   dd4276e6-aebd-44a3-b3cf-baf8a4c237f0: !Template
     id: dd4276e6-aebd-44a3-b3cf-baf8a4c237f0
     jinja: "Sentence 1: {{premise}}\n\nSentence 2: {{hypothesis}}\n\nDoes Sentence\
-      \ 2 entails Sentence 1? Yes or No? |||\n{% if label == 0 %} \nYes\n{% else %}\n\
+      \ 2 entail Sentence 1? Yes or No? |||\n{% if label == 0 %} \nYes\n{% else %}\n\
       No\n{% endif %}"
     name: Label binarization
     reference: Grouping "neutral" and "contradiction" as a single label following
@@ -34,7 +34,7 @@ templates:
   e174f56a-b0af-4937-b6ae-1897cac26eba: !Template
     id: e174f56a-b0af-4937-b6ae-1897cac26eba
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\n\nDoes Sentence 2\
-      \ entails Sentence 1? Yes, No or Neutral? |||\n{% if label == 0 %} \nYes\n{%\
+      \ entail Sentence 1? Yes, No or Neutral? |||\n{% if label == 0 %} \nYes\n{%\
       \ elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
     name: Concatenation
     reference: Concatenation of premise and hypothesis

--- a/templates/xnli/en/templates.yaml
+++ b/templates/xnli/en/templates.yaml
@@ -3,15 +3,15 @@ subset: en
 templates:
   4e122d26-7e79-49c0-961b-cf8ee134759e: !Template
     id: 4e122d26-7e79-49c0-961b-cf8ee134759e
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\n\nDoes Sentence 2\
-      \ contradict Sentence 1? Yes, No or Neutral? |||\n{% if label == 0 %} \nNo\n\
+    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\n\nDoes Sentence 1\
+      \ contradict Sentence 2? Yes, No or Neutral? |||\n{% if label == 0 %} \nNo\n\
       {% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
     name: Concatenation contraposition
     reference: Concatenation contraposition
   c62a3048-018e-4d93-bc46-645f3f763ee6: !Template
     id: c62a3048-018e-4d93-bc46-645f3f763ee6
     jinja: "Sentence 1: {{premise}}\n\nSentence 2: {{hypothesis}}\n\nDoes Sentence\
-      \ 2 contradict Sentence 1? Yes or No? |||\n{% if label == 2 %} \nYes\n{% else\
+      \ 1 contradict Sentence 2? Yes or No? |||\n{% if label == 2 %} \nYes\n{% else\
       \ %}\nNo\n{% endif %}"
     name: Label binarization  contraposition
     reference: Inspired from https://arxiv.org/pdf/1902.01007.pdf Section 4 - Implementation
@@ -26,15 +26,15 @@ templates:
   dd4276e6-aebd-44a3-b3cf-baf8a4c237f0: !Template
     id: dd4276e6-aebd-44a3-b3cf-baf8a4c237f0
     jinja: "Sentence 1: {{premise}}\n\nSentence 2: {{hypothesis}}\n\nDoes Sentence\
-      \ 2 entail Sentence 1? Yes or No? |||\n{% if label == 0 %} \nYes\n{% else %}\n\
+      \ 1 entail Sentence 2? Yes or No? |||\n{% if label == 0 %} \nYes\n{% else %}\n\
       No\n{% endif %}"
     name: Label binarization
     reference: Grouping "neutral" and "contradiction" as a single label following
       https://arxiv.org/pdf/1902.01007.pdf Section 4 - Implementation and evaluation
   e174f56a-b0af-4937-b6ae-1897cac26eba: !Template
     id: e174f56a-b0af-4937-b6ae-1897cac26eba
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\n\nDoes Sentence 2\
-      \ entail Sentence 1? Yes, No or Neutral? |||\n{% if label == 0 %} \nYes\n{%\
+    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\n\nDoes Sentence 1\
+      \ entail Sentence 2? Yes, No or Neutral? |||\n{% if label == 0 %} \nYes\n{%\
       \ elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
     name: Concatenation
     reference: Concatenation of premise and hypothesis


### PR DESCRIPTION
Currently there are two XNLI prompts that ask "does Sentence 2 entail Sentence 1". Note that for entailment, we can only prompt “does S1 entail S2” (does the premise entail the hypothesis) not the other way around. For contradiction, we could maybe either prompt "does S1 contradict S2" or “does S2 contradict S1”, but I sticked to the former to be consistent. Would be an interesting experiment to see if it generalizes to the latter though. 

I also fixed some typos and standardized line breaks to match Figure G7 (ANLI) of the GPT-3 paper. If they look good, I will write more prompts from other papers and copy and paste them to other NLI datasets.