### PR TITLE
paws and paws-x template added

### DIFF
--- a/templates/paws-x/en/templates.yaml
+++ b/templates/paws-x/en/templates.yaml
@@ -1,4 +1,4 @@
-dataset: paws
+dataset: paws-x
 subset: en
 templates:
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template

--- a/templates/paws-x/en/templates.yaml
+++ b/templates/paws-x/en/templates.yaml
@@ -1,0 +1,66 @@
+dataset: paws
+subset: labeled_final
+templates:
+  2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
+    id: 2ff509a8-2712-4406-97bd-ce86824cdc18
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
+      \ paraphrase or not?\nSentence 1 paraphrase Sentence 2? Yes or No? \n{% endif\
+      \ %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1 %}\nTrue\n{% endif\
+      \ %}"
+    name: PAWS-ANLI GPT3-no-label
+    reference: ANLI prompt format from Table G7 in the GPT3 paper. Additionally added
+      task information without any label..
+  32c0f3d5-a6c7-4ab2-a922-3a9d66db309f: !Template
+    id: 32c0f3d5-a6c7-4ab2-a922-3a9d66db309f
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? Yes\
+      \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Rewrite
+    reference: 'Natural Question '
+  568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
+    id: 568abe6e-4014-4d20-b4a0-3b0622026e36
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning\
+      \ or not\n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Meaning-no-label
+    reference: Natural question without label
+  68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
+    id: 68f76857-66f0-4aa4-ad70-3443cce0c7ae
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? \n{%\
+      \ endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}"
+    name: Rewrite-no-label
+    reference: Natural Question without label
+  82dbfba2-24f2-401a-9f81-618ca86f464f: !Template
+    id: 82dbfba2-24f2-401a-9f81-618ca86f464f
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
+      \ True or False? \n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label\
+      \ == 1 %}\nTrue\n{% endif %}"
+    name: PAWS-ANLI GPT3
+    reference: ANLI prompt format from Table G7 in the GPT3 paper
+  c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
+    id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? Yes or\
+      \ No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Concatenation
+    reference: Concatenation of sentence 1 and sentence 2
+  d94a57f5-7344-42e8-b8a8-b1fb731d39f8: !Template
+    id: d94a57f5-7344-42e8-b8a8-b1fb731d39f8
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning?\
+      \ Yes or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label ==\
+      \ 1 %}\nYes\n{% endif %}"
+    name: Meaning
+    reference: Natural question
+  e94388e1-bf2f-4be1-8693-23c6ce8277e6: !Template
+    id: e94388e1-bf2f-4be1-8693-23c6ce8277e6
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? \n{% endif\
+      \ %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: Concatenation-no-label
+    reference: Concatenation of sentence 1 and sentence 2 without any label

--- a/templates/paws-x/en/templates.yaml
+++ b/templates/paws-x/en/templates.yaml
@@ -1,5 +1,5 @@
 dataset: paws
-subset: labeled_final
+subset: en
 templates:
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18

--- a/templates/paws/labeled_final/templates.yaml
+++ b/templates/paws/labeled_final/templates.yaml
@@ -1,0 +1,66 @@
+dataset: paws
+subset: labeled_final
+templates:
+  2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
+    id: 2ff509a8-2712-4406-97bd-ce86824cdc18
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
+      \ paraphrase or not?\nSentence 1 paraphrase Sentence 2? Yes or No? \n{% endif\
+      \ %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1 %}\nTrue\n{% endif\
+      \ %}"
+    name: PAWS-ANLI GPT3-no-label
+    reference: ANLI prompt format from Table G7 in the GPT3 paper. Additionally added
+      task information without any label..
+  32c0f3d5-a6c7-4ab2-a922-3a9d66db309f: !Template
+    id: 32c0f3d5-a6c7-4ab2-a922-3a9d66db309f
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? Yes\
+      \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Rewrite
+    reference: 'Natural Question '
+  568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
+    id: 568abe6e-4014-4d20-b4a0-3b0622026e36
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning\
+      \ or not\n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Meaning-no-label
+    reference: Natural question without label
+  68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
+    id: 68f76857-66f0-4aa4-ad70-3443cce0c7ae
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? \n{%\
+      \ endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}"
+    name: Rewrite-no-label
+    reference: Natural Question without label
+  82dbfba2-24f2-401a-9f81-618ca86f464f: !Template
+    id: 82dbfba2-24f2-401a-9f81-618ca86f464f
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
+      \ True or False? \n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label\
+      \ == 1 %}\nTrue\n{% endif %}"
+    name: PAWS-ANLI GPT3
+    reference: ANLI prompt format from Table G7 in the GPT3 paper
+  c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
+    id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? Yes or\
+      \ No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Concatenation
+    reference: Concatenation of sentence 1 and sentence 2
+  d94a57f5-7344-42e8-b8a8-b1fb731d39f8: !Template
+    id: d94a57f5-7344-42e8-b8a8-b1fb731d39f8
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning?\
+      \ Yes or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label ==\
+      \ 1 %}\nYes\n{% endif %}"
+    name: Meaning
+    reference: Natural question
+  e94388e1-bf2f-4be1-8693-23c6ce8277e6: !Template
+    id: e94388e1-bf2f-4be1-8693-23c6ce8277e6
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? \n{% endif\
+      \ %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: Concatenation-no-label
+    reference: Concatenation of sentence 1 and sentence 2 without any label

--- a/templates/paws/labeled_swap/templates.yaml
+++ b/templates/paws/labeled_swap/templates.yaml
@@ -1,5 +1,5 @@
 dataset: paws
-subset: labeled_final
+subset: labeled_swap
 templates:
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18

--- a/templates/paws/labeled_swap/templates.yaml
+++ b/templates/paws/labeled_swap/templates.yaml
@@ -1,0 +1,66 @@
+dataset: paws
+subset: labeled_final
+templates:
+  2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
+    id: 2ff509a8-2712-4406-97bd-ce86824cdc18
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
+      \ paraphrase or not?\nSentence 1 paraphrase Sentence 2? Yes or No? \n{% endif\
+      \ %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1 %}\nTrue\n{% endif\
+      \ %}"
+    name: PAWS-ANLI GPT3-no-label
+    reference: ANLI prompt format from Table G7 in the GPT3 paper. Additionally added
+      task information without any label..
+  32c0f3d5-a6c7-4ab2-a922-3a9d66db309f: !Template
+    id: 32c0f3d5-a6c7-4ab2-a922-3a9d66db309f
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? Yes\
+      \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Rewrite
+    reference: 'Natural Question '
+  568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
+    id: 568abe6e-4014-4d20-b4a0-3b0622026e36
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning\
+      \ or not\n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Meaning-no-label
+    reference: Natural question without label
+  68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
+    id: 68f76857-66f0-4aa4-ad70-3443cce0c7ae
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? \n{%\
+      \ endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}"
+    name: Rewrite-no-label
+    reference: Natural Question without label
+  82dbfba2-24f2-401a-9f81-618ca86f464f: !Template
+    id: 82dbfba2-24f2-401a-9f81-618ca86f464f
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
+      \ True or False? \n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label\
+      \ == 1 %}\nTrue\n{% endif %}"
+    name: PAWS-ANLI GPT3
+    reference: ANLI prompt format from Table G7 in the GPT3 paper
+  c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
+    id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? Yes or\
+      \ No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Concatenation
+    reference: Concatenation of sentence 1 and sentence 2
+  d94a57f5-7344-42e8-b8a8-b1fb731d39f8: !Template
+    id: d94a57f5-7344-42e8-b8a8-b1fb731d39f8
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning?\
+      \ Yes or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label ==\
+      \ 1 %}\nYes\n{% endif %}"
+    name: Meaning
+    reference: Natural question
+  e94388e1-bf2f-4be1-8693-23c6ce8277e6: !Template
+    id: e94388e1-bf2f-4be1-8693-23c6ce8277e6
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? \n{% endif\
+      \ %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: Concatenation-no-label
+    reference: Concatenation of sentence 1 and sentence 2 without any label

--- a/templates/paws/unlabeled_final/templates.yaml
+++ b/templates/paws/unlabeled_final/templates.yaml
@@ -1,0 +1,66 @@
+dataset: paws
+subset: labeled_final
+templates:
+  2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
+    id: 2ff509a8-2712-4406-97bd-ce86824cdc18
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
+      \ paraphrase or not?\nSentence 1 paraphrase Sentence 2? Yes or No? \n{% endif\
+      \ %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1 %}\nTrue\n{% endif\
+      \ %}"
+    name: PAWS-ANLI GPT3-no-label
+    reference: ANLI prompt format from Table G7 in the GPT3 paper. Additionally added
+      task information without any label..
+  32c0f3d5-a6c7-4ab2-a922-3a9d66db309f: !Template
+    id: 32c0f3d5-a6c7-4ab2-a922-3a9d66db309f
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? Yes\
+      \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Rewrite
+    reference: 'Natural Question '
+  568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
+    id: 568abe6e-4014-4d20-b4a0-3b0622026e36
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning\
+      \ or not\n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Meaning-no-label
+    reference: Natural question without label
+  68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
+    id: 68f76857-66f0-4aa4-ad70-3443cce0c7ae
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? \n{%\
+      \ endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}"
+    name: Rewrite-no-label
+    reference: Natural Question without label
+  82dbfba2-24f2-401a-9f81-618ca86f464f: !Template
+    id: 82dbfba2-24f2-401a-9f81-618ca86f464f
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
+      \ True or False? \n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label\
+      \ == 1 %}\nTrue\n{% endif %}"
+    name: PAWS-ANLI GPT3
+    reference: ANLI prompt format from Table G7 in the GPT3 paper
+  c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
+    id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? Yes or\
+      \ No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Concatenation
+    reference: Concatenation of sentence 1 and sentence 2
+  d94a57f5-7344-42e8-b8a8-b1fb731d39f8: !Template
+    id: d94a57f5-7344-42e8-b8a8-b1fb731d39f8
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning?\
+      \ Yes or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label ==\
+      \ 1 %}\nYes\n{% endif %}"
+    name: Meaning
+    reference: Natural question
+  e94388e1-bf2f-4be1-8693-23c6ce8277e6: !Template
+    id: e94388e1-bf2f-4be1-8693-23c6ce8277e6
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? \n{% endif\
+      \ %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: Concatenation-no-label
+    reference: Concatenation of sentence 1 and sentence 2 without any label

--- a/templates/paws/unlabeled_final/templates.yaml
+++ b/templates/paws/unlabeled_final/templates.yaml
@@ -1,5 +1,5 @@
 dataset: paws
-subset: labeled_final
+subset: unlabeled_final
 templates:
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18


### PR DESCRIPTION
Special Notes:
1. There are some labels that are -1. According to the documentation, they are "missing" or "wrong". So I have ignored them while writing the prompt.
2. The prompts for subset `labeled_final`, `labeled_swap` and `unlabeled_final` are same. Initially I have created prompts for `labeled_final` then copy-pasted the `templates/paws/labeled_final/templates.yaml` to `templates/paws/labeled_swap/templates.yaml` and `templates/paws/unlabeled_final/templates.yaml`. [I also changed the `subset` field in each of the `templates.yaml` file](https://github.com/bigscience-workshop/promptsource/pull/56/commits/e5129b82a87c3983fd1a72ed6bc34a42a87132a2). Similar way I created prompt for `paws-x` `en` subset prompts.  But I see that each time I create a new prompt, a hash is generated by the app in the  `templates.yaml`. I wonder if there will be an issue because for copy-pasting the hash remains the same. 