### PR TITLE
Fix: Paws and paws-x 

### DIFF
--- a/templates/paws-x/en/templates.yaml
+++ b/templates/paws-x/en/templates.yaml
@@ -1,6 +1,12 @@
 dataset: paws-x
 subset: en
 templates:
+  289448c3-63fc-4904-8387-86d232424243: !Template
+    id: 289448c3-63fc-4904-8387-86d232424243
+    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence2}} \n{% endif\
+      \ %}\n||| \n{{sentence1}} "
+    name: paraphrase-task-reverse
+    reference: Create a generative paraphrase task
   2a659ff8-286e-4177-a459-e903baec6fb9: !Template
     id: 2a659ff8-286e-4177-a459-e903baec6fb9
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\nSentence\
@@ -78,6 +84,12 @@ templates:
       Yes\n{% endif %}"
     name: Concatenation
     reference: Concatenation of sentence 1 and sentence 2
+  c873732e-c424-417f-a474-f19eff2caf35: !Template
+    id: c873732e-c424-417f-a474-f19eff2caf35
+    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence1}} \n{% endif\
+      \ %}\n||| \n{{sentence2}} "
+    name: paraphrase-task
+    reference: Create a generative paraphrase task
   d94a57f5-7344-42e8-b8a8-b1fb731d39f8: !Template
     id: d94a57f5-7344-42e8-b8a8-b1fb731d39f8
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\

--- a/templates/paws-x/en/templates.yaml
+++ b/templates/paws-x/en/templates.yaml
@@ -4,12 +4,11 @@ templates:
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
-      \ paraphrase or not?\nSentence 1 paraphrase Sentence 2? Yes or No? \n{% endif\
-      \ %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1 %}\nTrue\n{% endif\
-      \ %}"
+      \ paraphrase or not?\n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif\
+      \ label == 1 %}\nTrue\n{% endif %}"
     name: PAWS-ANLI GPT3-no-label
     reference: ANLI prompt format from Table G7 in the GPT3 paper. Additionally added
-      task information without any label..
+      task information without any label.
   32c0f3d5-a6c7-4ab2-a922-3a9d66db309f: !Template
     id: 32c0f3d5-a6c7-4ab2-a922-3a9d66db309f
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
@@ -17,7 +16,7 @@ templates:
       \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
       Yes\n{% endif %}"
     name: Rewrite
-    reference: 'Natural Question '
+    reference: 'Natural Question'
   568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
     id: 568abe6e-4014-4d20-b4a0-3b0622026e36
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\

--- a/templates/paws-x/en/templates.yaml
+++ b/templates/paws-x/en/templates.yaml
@@ -62,11 +62,10 @@ templates:
     reference: Generalized prompt format, context-question
   ae3fbffe-b99d-4080-8aa0-e9040dcb68f9: !Template
     id: ae3fbffe-b99d-4080-8aa0-e9040dcb68f9
-    jinja: "{% if label == 0 or label == 1 %} \nDetermine the relation between the\
-      \ following two sentences. The relations are Paraphrase, Not-paraphrase\n{{sentence1}}\n\
-      {{sentence2}}\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n{% elif\
-      \ label == 1 %}\nParaphrase\n{% endif %}"
-    name: task_description-label
+    jinja: "{% if label == 0 or label == 1 %} \nDetermine if the following two sentences\
+      \ paraphrase or not.\n{{sentence1}}\n{{sentence2}}\n{% endif %}\n||| \n{% if\
+      \ label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: task_description-no-label
     reference: Generalized prompt format, task_description-input.
   c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
     id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad

--- a/templates/paws-x/en/templates.yaml
+++ b/templates/paws-x/en/templates.yaml
@@ -7,14 +7,6 @@ templates:
       \ %}\n||| \n{{sentence1}} "
     name: paraphrase-task-reverse
     reference: Create a generative paraphrase task
-  2a659ff8-286e-4177-a459-e903baec6fb9: !Template
-    id: 2a659ff8-286e-4177-a459-e903baec6fb9
-    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\nSentence\
-      \ 2: {{sentence2}}\nSelect the relation between Sentence 1 and Sentence 2?\n\
-      A) Paraphrase B) Not-paraphrase\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n\
-      {% elif label == 1 %}\nParaphrase\n{% endif %}"
-    name: multiple-choice
-    reference: Generalized prompt format, multiple-choice
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\

--- a/templates/paws-x/en/templates.yaml
+++ b/templates/paws-x/en/templates.yaml
@@ -1,6 +1,14 @@
 dataset: paws-x
 subset: en
 templates:
+  2a659ff8-286e-4177-a459-e903baec6fb9: !Template
+    id: 2a659ff8-286e-4177-a459-e903baec6fb9
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\nSentence\
+      \ 2: {{sentence2}}\nSelect the relation between Sentence 1 and Sentence 2?\n\
+      A) Paraphrase B) Not-paraphrase\n{% endif %}\n||| \n{% if label == 0 %} \nB\n\
+      {% elif label == 1 %}\nA\n{% endif %}"
+    name: multiple-choice
+    reference: Generalized prompt format, multiple-choice
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
@@ -16,7 +24,7 @@ templates:
       \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
       Yes\n{% endif %}"
     name: Rewrite
-    reference: 'Natural Question'
+    reference: Natural Question
   568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
     id: 568abe6e-4014-4d20-b4a0-3b0622026e36
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
@@ -40,6 +48,14 @@ templates:
       \ == 1 %}\nTrue\n{% endif %}"
     name: PAWS-ANLI GPT3
     reference: ANLI prompt format from Table G7 in the GPT3 paper
+  ae3fbffe-b99d-4080-8aa0-e9040dcb68f9: !Template
+    id: ae3fbffe-b99d-4080-8aa0-e9040dcb68f9
+    jinja: "{% if label == 0 or label == 1 %} \nDetermine the relation between the\
+      \ following two sentences. The relations are Paraphrase, Not-paraphrase\n{{sentence1}}\n\
+      {{sentence2}}\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n{% elif\
+      \ label == 1 %}\nParaphrase\n{% endif %}"
+    name: task_description-input
+    reference: Generalized prompt format, task_description-input.
   c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
     id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\

--- a/templates/paws-x/en/templates.yaml
+++ b/templates/paws-x/en/templates.yaml
@@ -5,8 +5,8 @@ templates:
     id: 2a659ff8-286e-4177-a459-e903baec6fb9
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\nSentence\
       \ 2: {{sentence2}}\nSelect the relation between Sentence 1 and Sentence 2?\n\
-      A) Paraphrase B) Not-paraphrase\n{% endif %}\n||| \n{% if label == 0 %} \nB\n\
-      {% elif label == 1 %}\nA\n{% endif %}"
+      A) Paraphrase B) Not-paraphrase\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n\
+      {% elif label == 1 %}\nParaphrase\n{% endif %}"
     name: multiple-choice
     reference: Generalized prompt format, multiple-choice
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template

--- a/templates/paws-x/en/templates.yaml
+++ b/templates/paws-x/en/templates.yaml
@@ -33,6 +33,13 @@ templates:
       Yes\n{% endif %}"
     name: Meaning-no-label
     reference: Natural question without label
+  60becf78-b280-43e1-aebb-475ee64076c8: !Template
+    id: 60becf78-b280-43e1-aebb-475ee64076c8
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\n{{sentence1}}\nIs that\
+      \ a paraphrase of the following sentence?\n{{sentence2}}?\n{% endif %}\n|||\
+      \ \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: context-question-no-label
+    reference: Generalized prompt format, context-question without any label
   68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
     id: 68f76857-66f0-4aa4-ad70-3443cce0c7ae
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
@@ -48,6 +55,13 @@ templates:
       \ == 1 %}\nTrue\n{% endif %}"
     name: PAWS-ANLI GPT3
     reference: ANLI prompt format from Table G7 in the GPT3 paper
+  a922400e-f562-4501-bff7-998e78e9866f: !Template
+    id: a922400e-f562-4501-bff7-998e78e9866f
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\nIs that a paraphrase\
+      \ of the following sentence?\n{{sentence2}}?\nYes, No\n{% endif %}\n||| \n{%\
+      \ if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: context-question
+    reference: Generalized prompt format, context-question
   ae3fbffe-b99d-4080-8aa0-e9040dcb68f9: !Template
     id: ae3fbffe-b99d-4080-8aa0-e9040dcb68f9
     jinja: "{% if label == 0 or label == 1 %} \nDetermine the relation between the\

--- a/templates/paws-x/en/templates.yaml
+++ b/templates/paws-x/en/templates.yaml
@@ -1,0 +1,66 @@
+dataset: paws-x
+subset: en
+templates:
+  2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
+    id: 2ff509a8-2712-4406-97bd-ce86824cdc18
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
+      \ paraphrase or not?\nSentence 1 paraphrase Sentence 2? Yes or No? \n{% endif\
+      \ %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1 %}\nTrue\n{% endif\
+      \ %}"
+    name: PAWS-ANLI GPT3-no-label
+    reference: ANLI prompt format from Table G7 in the GPT3 paper. Additionally added
+      task information without any label..
+  32c0f3d5-a6c7-4ab2-a922-3a9d66db309f: !Template
+    id: 32c0f3d5-a6c7-4ab2-a922-3a9d66db309f
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? Yes\
+      \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Rewrite
+    reference: 'Natural Question '
+  568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
+    id: 568abe6e-4014-4d20-b4a0-3b0622026e36
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning\
+      \ or not\n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Meaning-no-label
+    reference: Natural question without label
+  68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
+    id: 68f76857-66f0-4aa4-ad70-3443cce0c7ae
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? \n{%\
+      \ endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}"
+    name: Rewrite-no-label
+    reference: Natural Question without label
+  82dbfba2-24f2-401a-9f81-618ca86f464f: !Template
+    id: 82dbfba2-24f2-401a-9f81-618ca86f464f
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
+      \ True or False? \n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label\
+      \ == 1 %}\nTrue\n{% endif %}"
+    name: PAWS-ANLI GPT3
+    reference: ANLI prompt format from Table G7 in the GPT3 paper
+  c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
+    id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? Yes or\
+      \ No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Concatenation
+    reference: Concatenation of sentence 1 and sentence 2
+  d94a57f5-7344-42e8-b8a8-b1fb731d39f8: !Template
+    id: d94a57f5-7344-42e8-b8a8-b1fb731d39f8
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning?\
+      \ Yes or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label ==\
+      \ 1 %}\nYes\n{% endif %}"
+    name: Meaning
+    reference: Natural question
+  e94388e1-bf2f-4be1-8693-23c6ce8277e6: !Template
+    id: e94388e1-bf2f-4be1-8693-23c6ce8277e6
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? \n{% endif\
+      \ %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: Concatenation-no-label
+    reference: Concatenation of sentence 1 and sentence 2 without any label

--- a/templates/paws-x/en/templates.yaml
+++ b/templates/paws-x/en/templates.yaml
@@ -35,9 +35,9 @@ templates:
     reference: Natural question without label
   60becf78-b280-43e1-aebb-475ee64076c8: !Template
     id: 60becf78-b280-43e1-aebb-475ee64076c8
-    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\n{{sentence1}}\nIs that\
-      \ a paraphrase of the following sentence?\n{{sentence2}}?\n{% endif %}\n|||\
-      \ \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\nIs that a paraphrase\
+      \ of the following sentence?\n{{sentence2}}?\n{% endif %}\n||| \n{% if label\
+      \ == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
     name: context-question-no-label
     reference: Generalized prompt format, context-question without any label
   68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
@@ -68,7 +68,7 @@ templates:
       \ following two sentences. The relations are Paraphrase, Not-paraphrase\n{{sentence1}}\n\
       {{sentence2}}\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n{% elif\
       \ label == 1 %}\nParaphrase\n{% endif %}"
-    name: task_description-input
+    name: task_description-label
     reference: Generalized prompt format, task_description-input.
   c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
     id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad

--- a/templates/paws/labeled_final/templates.yaml
+++ b/templates/paws/labeled_final/templates.yaml
@@ -68,7 +68,7 @@ templates:
       \ following two sentences. The relations are Paraphrase, Not-paraphrase\n{{sentence1}}\n\
       {{sentence2}}\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n{% elif\
       \ label == 1 %}\nParaphrase\n{% endif %}"
-    name: task_description-input
+    name: task_description-label
     reference: Generalized prompt format, task_description-input.
   c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
     id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad

--- a/templates/paws/labeled_final/templates.yaml
+++ b/templates/paws/labeled_final/templates.yaml
@@ -4,12 +4,11 @@ templates:
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
-      \ paraphrase or not?\nSentence 1 paraphrase Sentence 2? Yes or No? \n{% endif\
-      \ %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1 %}\nTrue\n{% endif\
-      \ %}"
+      \ paraphrase or not?\n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif\
+      \ label == 1 %}\nTrue\n{% endif %}"
     name: PAWS-ANLI GPT3-no-label
     reference: ANLI prompt format from Table G7 in the GPT3 paper. Additionally added
-      task information without any label..
+      task information without any label.
   32c0f3d5-a6c7-4ab2-a922-3a9d66db309f: !Template
     id: 32c0f3d5-a6c7-4ab2-a922-3a9d66db309f
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
@@ -17,7 +16,7 @@ templates:
       \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
       Yes\n{% endif %}"
     name: Rewrite
-    reference: 'Natural Question '
+    reference: 'Natural Question'
   568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
     id: 568abe6e-4014-4d20-b4a0-3b0622026e36
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\

--- a/templates/paws/labeled_final/templates.yaml
+++ b/templates/paws/labeled_final/templates.yaml
@@ -62,11 +62,10 @@ templates:
     reference: Generalized prompt format, context-question
   ae3fbffe-b99d-4080-8aa0-e9040dcb68f9: !Template
     id: ae3fbffe-b99d-4080-8aa0-e9040dcb68f9
-    jinja: "{% if label == 0 or label == 1 %} \nDetermine the relation between the\
-      \ following two sentences. The relations are Paraphrase, Not-paraphrase\n{{sentence1}}\n\
-      {{sentence2}}\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n{% elif\
-      \ label == 1 %}\nParaphrase\n{% endif %}"
-    name: task_description-label
+    jinja: "{% if label == 0 or label == 1 %} \nDetermine if the following two sentences\
+      \ paraphrase or not.\n{{sentence1}}\n{{sentence2}}\n{% endif %}\n||| \n{% if\
+      \ label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: task_description-no-label
     reference: Generalized prompt format, task_description-input.
   c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
     id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad

--- a/templates/paws/labeled_final/templates.yaml
+++ b/templates/paws/labeled_final/templates.yaml
@@ -7,14 +7,6 @@ templates:
       \ %}\n||| \n{{sentence1}} "
     name: paraphrase-task-reverse
     reference: Create a generative paraphrase task
-  2a659ff8-286e-4177-a459-e903baec6fb9: !Template
-    id: 2a659ff8-286e-4177-a459-e903baec6fb9
-    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\nSentence\
-      \ 2: {{sentence2}}\nSelect the relation between Sentence 1 and Sentence 2?\n\
-      A) Paraphrase B) Not-paraphrase\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n\
-      {% elif label == 1 %}\nParaphrase\n{% endif %}"
-    name: multiple-choice
-    reference: Generalized prompt format, multiple-choice
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\

--- a/templates/paws/labeled_final/templates.yaml
+++ b/templates/paws/labeled_final/templates.yaml
@@ -33,6 +33,13 @@ templates:
       Yes\n{% endif %}"
     name: Meaning-no-label
     reference: Natural question without label
+  60becf78-b280-43e1-aebb-475ee64076c8: !Template
+    id: 60becf78-b280-43e1-aebb-475ee64076c8
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\nIs that a paraphrase\
+      \ of the following sentence?\n{{sentence2}}?\n{% endif %}\n||| \n{% if label\
+      \ == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: context-question-no-label
+    reference: Generalized prompt format, context-question without any label
   68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
     id: 68f76857-66f0-4aa4-ad70-3443cce0c7ae
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
@@ -48,6 +55,13 @@ templates:
       \ == 1 %}\nTrue\n{% endif %}"
     name: PAWS-ANLI GPT3
     reference: ANLI prompt format from Table G7 in the GPT3 paper
+  a922400e-f562-4501-bff7-998e78e9866f: !Template
+    id: a922400e-f562-4501-bff7-998e78e9866f
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\nIs that a paraphrase\
+      \ of the following sentence?\n{{sentence2}}?\nYes, No\n{% endif %}\n||| \n{%\
+      \ if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: context-question
+    reference: Generalized prompt format, context-question
   ae3fbffe-b99d-4080-8aa0-e9040dcb68f9: !Template
     id: ae3fbffe-b99d-4080-8aa0-e9040dcb68f9
     jinja: "{% if label == 0 or label == 1 %} \nDetermine the relation between the\

--- a/templates/paws/labeled_final/templates.yaml
+++ b/templates/paws/labeled_final/templates.yaml
@@ -1,6 +1,14 @@
 dataset: paws
 subset: labeled_final
 templates:
+  2a659ff8-286e-4177-a459-e903baec6fb9: !Template
+    id: 2a659ff8-286e-4177-a459-e903baec6fb9
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\nSentence\
+      \ 2: {{sentence2}}\nSelect the relation between Sentence 1 and Sentence 2?\n\
+      A) Paraphrase B) Not-paraphrase\n{% endif %}\n||| \n{% if label == 0 %} \nB\n\
+      {% elif label == 1 %}\nA\n{% endif %}"
+    name: multiple-choice
+    reference: Generalized prompt format, multiple-choice
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
@@ -16,7 +24,7 @@ templates:
       \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
       Yes\n{% endif %}"
     name: Rewrite
-    reference: 'Natural Question'
+    reference: Natural Question
   568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
     id: 568abe6e-4014-4d20-b4a0-3b0622026e36
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
@@ -40,6 +48,14 @@ templates:
       \ == 1 %}\nTrue\n{% endif %}"
     name: PAWS-ANLI GPT3
     reference: ANLI prompt format from Table G7 in the GPT3 paper
+  ae3fbffe-b99d-4080-8aa0-e9040dcb68f9: !Template
+    id: ae3fbffe-b99d-4080-8aa0-e9040dcb68f9
+    jinja: "{% if label == 0 or label == 1 %} \nDetermine the relation between the\
+      \ following two sentences. The relations are Paraphrase, Not-paraphrase\n{{sentence1}}\n\
+      {{sentence2}}\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n{% elif\
+      \ label == 1 %}\nParaphrase\n{% endif %}"
+    name: task_description-input
+    reference: Generalized prompt format, task_description-input.
   c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
     id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\

--- a/templates/paws/labeled_final/templates.yaml
+++ b/templates/paws/labeled_final/templates.yaml
@@ -1,6 +1,12 @@
 dataset: paws
 subset: labeled_final
 templates:
+  289448c3-63fc-4904-8387-86d232424243: !Template
+    id: 289448c3-63fc-4904-8387-86d232424243
+    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence2}} \n{% endif\
+      \ %}\n||| \n{{sentence1}} "
+    name: paraphrase-task-reverse
+    reference: Create a generative paraphrase task
   2a659ff8-286e-4177-a459-e903baec6fb9: !Template
     id: 2a659ff8-286e-4177-a459-e903baec6fb9
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\nSentence\
@@ -78,6 +84,12 @@ templates:
       Yes\n{% endif %}"
     name: Concatenation
     reference: Concatenation of sentence 1 and sentence 2
+  c873732e-c424-417f-a474-f19eff2caf35: !Template
+    id: c873732e-c424-417f-a474-f19eff2caf35
+    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence1}} \n{% endif\
+      \ %}\n||| \n{{sentence2}} "
+    name: paraphrase-task
+    reference: Create a generative paraphrase task
   d94a57f5-7344-42e8-b8a8-b1fb731d39f8: !Template
     id: d94a57f5-7344-42e8-b8a8-b1fb731d39f8
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\

--- a/templates/paws/labeled_final/templates.yaml
+++ b/templates/paws/labeled_final/templates.yaml
@@ -1,0 +1,66 @@
+dataset: paws
+subset: labeled_final
+templates:
+  2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
+    id: 2ff509a8-2712-4406-97bd-ce86824cdc18
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
+      \ paraphrase or not?\nSentence 1 paraphrase Sentence 2? Yes or No? \n{% endif\
+      \ %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1 %}\nTrue\n{% endif\
+      \ %}"
+    name: PAWS-ANLI GPT3-no-label
+    reference: ANLI prompt format from Table G7 in the GPT3 paper. Additionally added
+      task information without any label..
+  32c0f3d5-a6c7-4ab2-a922-3a9d66db309f: !Template
+    id: 32c0f3d5-a6c7-4ab2-a922-3a9d66db309f
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? Yes\
+      \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Rewrite
+    reference: 'Natural Question '
+  568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
+    id: 568abe6e-4014-4d20-b4a0-3b0622026e36
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning\
+      \ or not\n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Meaning-no-label
+    reference: Natural question without label
+  68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
+    id: 68f76857-66f0-4aa4-ad70-3443cce0c7ae
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? \n{%\
+      \ endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}"
+    name: Rewrite-no-label
+    reference: Natural Question without label
+  82dbfba2-24f2-401a-9f81-618ca86f464f: !Template
+    id: 82dbfba2-24f2-401a-9f81-618ca86f464f
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
+      \ True or False? \n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label\
+      \ == 1 %}\nTrue\n{% endif %}"
+    name: PAWS-ANLI GPT3
+    reference: ANLI prompt format from Table G7 in the GPT3 paper
+  c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
+    id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? Yes or\
+      \ No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Concatenation
+    reference: Concatenation of sentence 1 and sentence 2
+  d94a57f5-7344-42e8-b8a8-b1fb731d39f8: !Template
+    id: d94a57f5-7344-42e8-b8a8-b1fb731d39f8
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning?\
+      \ Yes or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label ==\
+      \ 1 %}\nYes\n{% endif %}"
+    name: Meaning
+    reference: Natural question
+  e94388e1-bf2f-4be1-8693-23c6ce8277e6: !Template
+    id: e94388e1-bf2f-4be1-8693-23c6ce8277e6
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? \n{% endif\
+      \ %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: Concatenation-no-label
+    reference: Concatenation of sentence 1 and sentence 2 without any label

--- a/templates/paws/labeled_final/templates.yaml
+++ b/templates/paws/labeled_final/templates.yaml
@@ -5,8 +5,8 @@ templates:
     id: 2a659ff8-286e-4177-a459-e903baec6fb9
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\nSentence\
       \ 2: {{sentence2}}\nSelect the relation between Sentence 1 and Sentence 2?\n\
-      A) Paraphrase B) Not-paraphrase\n{% endif %}\n||| \n{% if label == 0 %} \nB\n\
-      {% elif label == 1 %}\nA\n{% endif %}"
+      A) Paraphrase B) Not-paraphrase\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n\
+      {% elif label == 1 %}\nParaphrase\n{% endif %}"
     name: multiple-choice
     reference: Generalized prompt format, multiple-choice
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template

--- a/templates/paws/labeled_swap/templates.yaml
+++ b/templates/paws/labeled_swap/templates.yaml
@@ -4,12 +4,11 @@ templates:
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
-      \ paraphrase or not?\nSentence 1 paraphrase Sentence 2? Yes or No? \n{% endif\
-      \ %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1 %}\nTrue\n{% endif\
-      \ %}"
+      \ paraphrase or not?\n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif\
+      \ label == 1 %}\nTrue\n{% endif %}"
     name: PAWS-ANLI GPT3-no-label
     reference: ANLI prompt format from Table G7 in the GPT3 paper. Additionally added
-      task information without any label..
+      task information without any label.
   32c0f3d5-a6c7-4ab2-a922-3a9d66db309f: !Template
     id: 32c0f3d5-a6c7-4ab2-a922-3a9d66db309f
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
@@ -17,7 +16,7 @@ templates:
       \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
       Yes\n{% endif %}"
     name: Rewrite
-    reference: 'Natural Question '
+    reference: 'Natural Question'
   568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
     id: 568abe6e-4014-4d20-b4a0-3b0622026e36
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\

--- a/templates/paws/labeled_swap/templates.yaml
+++ b/templates/paws/labeled_swap/templates.yaml
@@ -62,11 +62,10 @@ templates:
     reference: Generalized prompt format, context-question
   ae3fbffe-b99d-4080-8aa0-e9040dcb68f9: !Template
     id: ae3fbffe-b99d-4080-8aa0-e9040dcb68f9
-    jinja: "{% if label == 0 or label == 1 %} \nDetermine the relation between the\
-      \ following two sentences. The relations are Paraphrase, Not-paraphrase\n{{sentence1}}\n\
-      {{sentence2}}\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n{% elif\
-      \ label == 1 %}\nParaphrase\n{% endif %}"
-    name: task_description-label
+    jinja: "{% if label == 0 or label == 1 %} \nDetermine if the following two sentences\
+      \ paraphrase or not.\n{{sentence1}}\n{{sentence2}}\n{% endif %}\n||| \n{% if\
+      \ label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: task_description-no-label
     reference: Generalized prompt format, task_description-input.
   c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
     id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad

--- a/templates/paws/labeled_swap/templates.yaml
+++ b/templates/paws/labeled_swap/templates.yaml
@@ -1,0 +1,66 @@
+dataset: paws
+subset: labeled_swap
+templates:
+  2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
+    id: 2ff509a8-2712-4406-97bd-ce86824cdc18
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
+      \ paraphrase or not?\nSentence 1 paraphrase Sentence 2? Yes or No? \n{% endif\
+      \ %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1 %}\nTrue\n{% endif\
+      \ %}"
+    name: PAWS-ANLI GPT3-no-label
+    reference: ANLI prompt format from Table G7 in the GPT3 paper. Additionally added
+      task information without any label..
+  32c0f3d5-a6c7-4ab2-a922-3a9d66db309f: !Template
+    id: 32c0f3d5-a6c7-4ab2-a922-3a9d66db309f
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? Yes\
+      \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Rewrite
+    reference: 'Natural Question '
+  568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
+    id: 568abe6e-4014-4d20-b4a0-3b0622026e36
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning\
+      \ or not\n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Meaning-no-label
+    reference: Natural question without label
+  68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
+    id: 68f76857-66f0-4aa4-ad70-3443cce0c7ae
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? \n{%\
+      \ endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}"
+    name: Rewrite-no-label
+    reference: Natural Question without label
+  82dbfba2-24f2-401a-9f81-618ca86f464f: !Template
+    id: 82dbfba2-24f2-401a-9f81-618ca86f464f
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
+      \ True or False? \n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label\
+      \ == 1 %}\nTrue\n{% endif %}"
+    name: PAWS-ANLI GPT3
+    reference: ANLI prompt format from Table G7 in the GPT3 paper
+  c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
+    id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? Yes or\
+      \ No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Concatenation
+    reference: Concatenation of sentence 1 and sentence 2
+  d94a57f5-7344-42e8-b8a8-b1fb731d39f8: !Template
+    id: d94a57f5-7344-42e8-b8a8-b1fb731d39f8
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning?\
+      \ Yes or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label ==\
+      \ 1 %}\nYes\n{% endif %}"
+    name: Meaning
+    reference: Natural question
+  e94388e1-bf2f-4be1-8693-23c6ce8277e6: !Template
+    id: e94388e1-bf2f-4be1-8693-23c6ce8277e6
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? \n{% endif\
+      \ %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: Concatenation-no-label
+    reference: Concatenation of sentence 1 and sentence 2 without any label

--- a/templates/paws/labeled_swap/templates.yaml
+++ b/templates/paws/labeled_swap/templates.yaml
@@ -7,14 +7,6 @@ templates:
       \ %}\n||| \n{{sentence1}} "
     name: paraphrase-task-reverse
     reference: Create a generative paraphrase task
-  2a659ff8-286e-4177-a459-e903baec6fb9: !Template
-    id: 2a659ff8-286e-4177-a459-e903baec6fb9
-    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\nSentence\
-      \ 2: {{sentence2}}\nSelect the relation between Sentence 1 and Sentence 2?\n\
-      A) Paraphrase B) Not-paraphrase\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n\
-      {% elif label == 1 %}\nParaphrase\n{% endif %}"
-    name: multiple-choice
-    reference: Generalized prompt format, multiple-choice
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\

--- a/templates/paws/labeled_swap/templates.yaml
+++ b/templates/paws/labeled_swap/templates.yaml
@@ -1,6 +1,12 @@
 dataset: paws
 subset: labeled_swap
 templates:
+  289448c3-63fc-4904-8387-86d232424243: !Template
+    id: 289448c3-63fc-4904-8387-86d232424243
+    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence2}} \n{% endif\
+      \ %}\n||| \n{{sentence1}} "
+    name: paraphrase-task-reverse
+    reference: Create a generative paraphrase task
   2a659ff8-286e-4177-a459-e903baec6fb9: !Template
     id: 2a659ff8-286e-4177-a459-e903baec6fb9
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\nSentence\
@@ -78,6 +84,12 @@ templates:
       Yes\n{% endif %}"
     name: Concatenation
     reference: Concatenation of sentence 1 and sentence 2
+  c873732e-c424-417f-a474-f19eff2caf35: !Template
+    id: c873732e-c424-417f-a474-f19eff2caf35
+    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence1}} \n{% endif\
+      \ %}\n||| \n{{sentence2}} "
+    name: paraphrase-task
+    reference: Create a generative paraphrase task
   d94a57f5-7344-42e8-b8a8-b1fb731d39f8: !Template
     id: d94a57f5-7344-42e8-b8a8-b1fb731d39f8
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\

--- a/templates/paws/labeled_swap/templates.yaml
+++ b/templates/paws/labeled_swap/templates.yaml
@@ -1,6 +1,14 @@
 dataset: paws
 subset: labeled_swap
 templates:
+  2a659ff8-286e-4177-a459-e903baec6fb9: !Template
+    id: 2a659ff8-286e-4177-a459-e903baec6fb9
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\nSentence\
+      \ 2: {{sentence2}}\nSelect the relation between Sentence 1 and Sentence 2?\n\
+      A) Paraphrase B) Not-paraphrase\n{% endif %}\n||| \n{% if label == 0 %} \nB\n\
+      {% elif label == 1 %}\nA\n{% endif %}"
+    name: multiple-choice
+    reference: Generalized prompt format, multiple-choice
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
@@ -16,7 +24,7 @@ templates:
       \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
       Yes\n{% endif %}"
     name: Rewrite
-    reference: 'Natural Question'
+    reference: Natural Question
   568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
     id: 568abe6e-4014-4d20-b4a0-3b0622026e36
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
@@ -40,6 +48,14 @@ templates:
       \ == 1 %}\nTrue\n{% endif %}"
     name: PAWS-ANLI GPT3
     reference: ANLI prompt format from Table G7 in the GPT3 paper
+  ae3fbffe-b99d-4080-8aa0-e9040dcb68f9: !Template
+    id: ae3fbffe-b99d-4080-8aa0-e9040dcb68f9
+    jinja: "{% if label == 0 or label == 1 %} \nDetermine the relation between the\
+      \ following two sentences. The relations are Paraphrase, Not-paraphrase\n{{sentence1}}\n\
+      {{sentence2}}\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n{% elif\
+      \ label == 1 %}\nParaphrase\n{% endif %}"
+    name: task_description-input
+    reference: Generalized prompt format, task_description-input.
   c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
     id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\

--- a/templates/paws/labeled_swap/templates.yaml
+++ b/templates/paws/labeled_swap/templates.yaml
@@ -5,8 +5,8 @@ templates:
     id: 2a659ff8-286e-4177-a459-e903baec6fb9
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\nSentence\
       \ 2: {{sentence2}}\nSelect the relation between Sentence 1 and Sentence 2?\n\
-      A) Paraphrase B) Not-paraphrase\n{% endif %}\n||| \n{% if label == 0 %} \nB\n\
-      {% elif label == 1 %}\nA\n{% endif %}"
+      A) Paraphrase B) Not-paraphrase\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n\
+      {% elif label == 1 %}\nParaphrase\n{% endif %}"
     name: multiple-choice
     reference: Generalized prompt format, multiple-choice
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template

--- a/templates/paws/labeled_swap/templates.yaml
+++ b/templates/paws/labeled_swap/templates.yaml
@@ -33,6 +33,13 @@ templates:
       Yes\n{% endif %}"
     name: Meaning-no-label
     reference: Natural question without label
+  60becf78-b280-43e1-aebb-475ee64076c8: !Template
+    id: 60becf78-b280-43e1-aebb-475ee64076c8
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\n{{sentence1}}\nIs that\
+      \ a paraphrase of the following sentence?\n{{sentence2}}?\n{% endif %}\n|||\
+      \ \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: context-question-no-label
+    reference: Generalized prompt format, context-question without any label
   68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
     id: 68f76857-66f0-4aa4-ad70-3443cce0c7ae
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
@@ -48,6 +55,13 @@ templates:
       \ == 1 %}\nTrue\n{% endif %}"
     name: PAWS-ANLI GPT3
     reference: ANLI prompt format from Table G7 in the GPT3 paper
+  a922400e-f562-4501-bff7-998e78e9866f: !Template
+    id: a922400e-f562-4501-bff7-998e78e9866f
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\nIs that a paraphrase\
+      \ of the following sentence?\n{{sentence2}}?\nYes, No\n{% endif %}\n||| \n{%\
+      \ if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: context-question
+    reference: Generalized prompt format, context-question
   ae3fbffe-b99d-4080-8aa0-e9040dcb68f9: !Template
     id: ae3fbffe-b99d-4080-8aa0-e9040dcb68f9
     jinja: "{% if label == 0 or label == 1 %} \nDetermine the relation between the\

--- a/templates/paws/labeled_swap/templates.yaml
+++ b/templates/paws/labeled_swap/templates.yaml
@@ -35,9 +35,9 @@ templates:
     reference: Natural question without label
   60becf78-b280-43e1-aebb-475ee64076c8: !Template
     id: 60becf78-b280-43e1-aebb-475ee64076c8
-    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\n{{sentence1}}\nIs that\
-      \ a paraphrase of the following sentence?\n{{sentence2}}?\n{% endif %}\n|||\
-      \ \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\nIs that a paraphrase\
+      \ of the following sentence?\n{{sentence2}}?\n{% endif %}\n||| \n{% if label\
+      \ == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
     name: context-question-no-label
     reference: Generalized prompt format, context-question without any label
   68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
@@ -68,7 +68,7 @@ templates:
       \ following two sentences. The relations are Paraphrase, Not-paraphrase\n{{sentence1}}\n\
       {{sentence2}}\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n{% elif\
       \ label == 1 %}\nParaphrase\n{% endif %}"
-    name: task_description-input
+    name: task_description-label
     reference: Generalized prompt format, task_description-input.
   c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
     id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad

--- a/templates/paws/unlabeled_final/templates.yaml
+++ b/templates/paws/unlabeled_final/templates.yaml
@@ -4,12 +4,11 @@ templates:
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
-      \ paraphrase or not?\nSentence 1 paraphrase Sentence 2? Yes or No? \n{% endif\
-      \ %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1 %}\nTrue\n{% endif\
-      \ %}"
+      \ paraphrase or not?\n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif\
+      \ label == 1 %}\nTrue\n{% endif %}"
     name: PAWS-ANLI GPT3-no-label
     reference: ANLI prompt format from Table G7 in the GPT3 paper. Additionally added
-      task information without any label..
+      task information without any label.
   32c0f3d5-a6c7-4ab2-a922-3a9d66db309f: !Template
     id: 32c0f3d5-a6c7-4ab2-a922-3a9d66db309f
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
@@ -17,7 +16,7 @@ templates:
       \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
       Yes\n{% endif %}"
     name: Rewrite
-    reference: 'Natural Question '
+    reference: 'Natural Question'
   568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
     id: 568abe6e-4014-4d20-b4a0-3b0622026e36
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\

--- a/templates/paws/unlabeled_final/templates.yaml
+++ b/templates/paws/unlabeled_final/templates.yaml
@@ -62,11 +62,10 @@ templates:
     reference: Generalized prompt format, context-question
   ae3fbffe-b99d-4080-8aa0-e9040dcb68f9: !Template
     id: ae3fbffe-b99d-4080-8aa0-e9040dcb68f9
-    jinja: "{% if label == 0 or label == 1 %} \nDetermine the relation between the\
-      \ following two sentences. The relations are Paraphrase, Not-paraphrase\n{{sentence1}}\n\
-      {{sentence2}}\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n{% elif\
-      \ label == 1 %}\nParaphrase\n{% endif %}"
-    name: task_description-label
+    jinja: "{% if label == 0 or label == 1 %} \nDetermine if the following two sentences\
+      \ paraphrase or not.\n{{sentence1}}\n{{sentence2}}\n{% endif %}\n||| \n{% if\
+      \ label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: task_description-no-label
     reference: Generalized prompt format, task_description-input.
   c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
     id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad

--- a/templates/paws/unlabeled_final/templates.yaml
+++ b/templates/paws/unlabeled_final/templates.yaml
@@ -7,14 +7,6 @@ templates:
       \ %}\n||| \n{{sentence1}} "
     name: paraphrase-task-reverse
     reference: Create a generative paraphrase task
-  2a659ff8-286e-4177-a459-e903baec6fb9: !Template
-    id: 2a659ff8-286e-4177-a459-e903baec6fb9
-    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\nSentence\
-      \ 2: {{sentence2}}\nSelect the relation between Sentence 1 and Sentence 2?\n\
-      A) Paraphrase B) Not-paraphrase\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n\
-      {% elif label == 1 %}\nParaphrase\n{% endif %}"
-    name: multiple-choice
-    reference: Generalized prompt format, multiple-choice
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\

--- a/templates/paws/unlabeled_final/templates.yaml
+++ b/templates/paws/unlabeled_final/templates.yaml
@@ -1,0 +1,66 @@
+dataset: paws
+subset: unlabeled_final
+templates:
+  2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
+    id: 2ff509a8-2712-4406-97bd-ce86824cdc18
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
+      \ paraphrase or not?\nSentence 1 paraphrase Sentence 2? Yes or No? \n{% endif\
+      \ %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1 %}\nTrue\n{% endif\
+      \ %}"
+    name: PAWS-ANLI GPT3-no-label
+    reference: ANLI prompt format from Table G7 in the GPT3 paper. Additionally added
+      task information without any label..
+  32c0f3d5-a6c7-4ab2-a922-3a9d66db309f: !Template
+    id: 32c0f3d5-a6c7-4ab2-a922-3a9d66db309f
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? Yes\
+      \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Rewrite
+    reference: 'Natural Question '
+  568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
+    id: 568abe6e-4014-4d20-b4a0-3b0622026e36
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning\
+      \ or not\n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Meaning-no-label
+    reference: Natural question without label
+  68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
+    id: 68f76857-66f0-4aa4-ad70-3443cce0c7ae
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? \n{%\
+      \ endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}"
+    name: Rewrite-no-label
+    reference: Natural Question without label
+  82dbfba2-24f2-401a-9f81-618ca86f464f: !Template
+    id: 82dbfba2-24f2-401a-9f81-618ca86f464f
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
+      \ True or False? \n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label\
+      \ == 1 %}\nTrue\n{% endif %}"
+    name: PAWS-ANLI GPT3
+    reference: ANLI prompt format from Table G7 in the GPT3 paper
+  c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
+    id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? Yes or\
+      \ No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
+      Yes\n{% endif %}"
+    name: Concatenation
+    reference: Concatenation of sentence 1 and sentence 2
+  d94a57f5-7344-42e8-b8a8-b1fb731d39f8: !Template
+    id: d94a57f5-7344-42e8-b8a8-b1fb731d39f8
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning?\
+      \ Yes or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label ==\
+      \ 1 %}\nYes\n{% endif %}"
+    name: Meaning
+    reference: Natural question
+  e94388e1-bf2f-4be1-8693-23c6ce8277e6: !Template
+    id: e94388e1-bf2f-4be1-8693-23c6ce8277e6
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? \n{% endif\
+      \ %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: Concatenation-no-label
+    reference: Concatenation of sentence 1 and sentence 2 without any label

--- a/templates/paws/unlabeled_final/templates.yaml
+++ b/templates/paws/unlabeled_final/templates.yaml
@@ -1,6 +1,12 @@
 dataset: paws
 subset: unlabeled_final
 templates:
+  289448c3-63fc-4904-8387-86d232424243: !Template
+    id: 289448c3-63fc-4904-8387-86d232424243
+    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence2}} \n{% endif\
+      \ %}\n||| \n{{sentence1}} "
+    name: paraphrase-task-reverse
+    reference: Create a generative paraphrase task
   2a659ff8-286e-4177-a459-e903baec6fb9: !Template
     id: 2a659ff8-286e-4177-a459-e903baec6fb9
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\nSentence\
@@ -78,6 +84,12 @@ templates:
       Yes\n{% endif %}"
     name: Concatenation
     reference: Concatenation of sentence 1 and sentence 2
+  c873732e-c424-417f-a474-f19eff2caf35: !Template
+    id: c873732e-c424-417f-a474-f19eff2caf35
+    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence1}} \n{% endif\
+      \ %}\n||| \n{{sentence2}} "
+    name: paraphrase-task
+    reference: Create a generative paraphrase task
   d94a57f5-7344-42e8-b8a8-b1fb731d39f8: !Template
     id: d94a57f5-7344-42e8-b8a8-b1fb731d39f8
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\

--- a/templates/paws/unlabeled_final/templates.yaml
+++ b/templates/paws/unlabeled_final/templates.yaml
@@ -1,6 +1,14 @@
 dataset: paws
 subset: unlabeled_final
 templates:
+  2a659ff8-286e-4177-a459-e903baec6fb9: !Template
+    id: 2a659ff8-286e-4177-a459-e903baec6fb9
+    jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\nSentence\
+      \ 2: {{sentence2}}\nSelect the relation between Sentence 1 and Sentence 2?\n\
+      A) Paraphrase B) Not-paraphrase\n{% endif %}\n||| \n{% if label == 0 %} \nB\n\
+      {% elif label == 1 %}\nA\n{% endif %}"
+    name: multiple-choice
+    reference: Generalized prompt format, multiple-choice
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
@@ -16,7 +24,7 @@ templates:
       \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
       Yes\n{% endif %}"
     name: Rewrite
-    reference: 'Natural Question'
+    reference: Natural Question
   568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
     id: 568abe6e-4014-4d20-b4a0-3b0622026e36
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
@@ -40,6 +48,14 @@ templates:
       \ == 1 %}\nTrue\n{% endif %}"
     name: PAWS-ANLI GPT3
     reference: ANLI prompt format from Table G7 in the GPT3 paper
+  ae3fbffe-b99d-4080-8aa0-e9040dcb68f9: !Template
+    id: ae3fbffe-b99d-4080-8aa0-e9040dcb68f9
+    jinja: "{% if label == 0 or label == 1 %} \nDetermine the relation between the\
+      \ following two sentences. The relations are Paraphrase, Not-paraphrase\n{{sentence1}}\n\
+      {{sentence2}}\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n{% elif\
+      \ label == 1 %}\nParaphrase\n{% endif %}"
+    name: task_description-input
+    reference: Generalized prompt format, task_description-input.
   c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
     id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\

--- a/templates/paws/unlabeled_final/templates.yaml
+++ b/templates/paws/unlabeled_final/templates.yaml
@@ -5,8 +5,8 @@ templates:
     id: 2a659ff8-286e-4177-a459-e903baec6fb9
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\nSentence\
       \ 2: {{sentence2}}\nSelect the relation between Sentence 1 and Sentence 2?\n\
-      A) Paraphrase B) Not-paraphrase\n{% endif %}\n||| \n{% if label == 0 %} \nB\n\
-      {% elif label == 1 %}\nA\n{% endif %}"
+      A) Paraphrase B) Not-paraphrase\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n\
+      {% elif label == 1 %}\nParaphrase\n{% endif %}"
     name: multiple-choice
     reference: Generalized prompt format, multiple-choice
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template

--- a/templates/paws/unlabeled_final/templates.yaml
+++ b/templates/paws/unlabeled_final/templates.yaml
@@ -33,6 +33,13 @@ templates:
       Yes\n{% endif %}"
     name: Meaning-no-label
     reference: Natural question without label
+  60becf78-b280-43e1-aebb-475ee64076c8: !Template
+    id: 60becf78-b280-43e1-aebb-475ee64076c8
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\n{{sentence1}}\nIs that\
+      \ a paraphrase of the following sentence?\n{{sentence2}}?\n{% endif %}\n|||\
+      \ \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: context-question-no-label
+    reference: Generalized prompt format, context-question without any label
   68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
     id: 68f76857-66f0-4aa4-ad70-3443cce0c7ae
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
@@ -48,6 +55,13 @@ templates:
       \ == 1 %}\nTrue\n{% endif %}"
     name: PAWS-ANLI GPT3
     reference: ANLI prompt format from Table G7 in the GPT3 paper
+  a922400e-f562-4501-bff7-998e78e9866f: !Template
+    id: a922400e-f562-4501-bff7-998e78e9866f
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\nIs that a paraphrase\
+      \ of the following sentence?\n{{sentence2}}?\nYes, No\n{% endif %}\n||| \n{%\
+      \ if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    name: context-question
+    reference: Generalized prompt format, context-question
   ae3fbffe-b99d-4080-8aa0-e9040dcb68f9: !Template
     id: ae3fbffe-b99d-4080-8aa0-e9040dcb68f9
     jinja: "{% if label == 0 or label == 1 %} \nDetermine the relation between the\

--- a/templates/paws/unlabeled_final/templates.yaml
+++ b/templates/paws/unlabeled_final/templates.yaml
@@ -35,9 +35,9 @@ templates:
     reference: Natural question without label
   60becf78-b280-43e1-aebb-475ee64076c8: !Template
     id: 60becf78-b280-43e1-aebb-475ee64076c8
-    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\n{{sentence1}}\nIs that\
-      \ a paraphrase of the following sentence?\n{{sentence2}}?\n{% endif %}\n|||\
-      \ \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\nIs that a paraphrase\
+      \ of the following sentence?\n{{sentence2}}?\n{% endif %}\n||| \n{% if label\
+      \ == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
     name: context-question-no-label
     reference: Generalized prompt format, context-question without any label
   68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
@@ -68,7 +68,7 @@ templates:
       \ following two sentences. The relations are Paraphrase, Not-paraphrase\n{{sentence1}}\n\
       {{sentence2}}\n{% endif %}\n||| \n{% if label == 0 %} \nNot-paraphrase\n{% elif\
       \ label == 1 %}\nParaphrase\n{% endif %}"
-    name: task_description-input
+    name: task_description-label
     reference: Generalized prompt format, task_description-input.
   c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
     id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad


### PR DESCRIPTION
This pull 
- fixes a previous bug in prompt.
- fixes a typo on ' ' and '.'
- adds four additional prompts suggested by "Iz Beltagy"
- adds two additional prompts. The idea is to create a generative task from the dataset. The dataset asks the question, given two-sentence, if they are paraphrase or not. What I did is, 
```
{% if label == 1 %} 
Paraphrase the sentence: {{sentence1}} 
{% endif %}
||| 
{{sentence2}} 

```
I added prompt for both directions.