### PR TITLE
Prompts for S/M/X/ANLI, RTE, CB, SciTail, HANS

### DIFF
--- a/templates/anli/templates.yaml
+++ b/templates/anli/templates.yaml
@@ -6,12 +6,12 @@ templates:
       \ 1 contradict Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \n\
       No\n{% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
     name: does S1 contradict S2?
-    reference: Copied from Victor's prompt for XNLI.
+    reference: Copied from Victor's prompts for XNLI.
   5459237b-97de-4340-bf7b-2939c3f7ca19: !Template
     id: 5459237b-97de-4340-bf7b-2939c3f7ca19
     jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes, no, or maybe?
       ||| {{ ["Yes", "Maybe", "No"][label] }}
-    name: "given\u2026 does it follows that\u2026 "
+    name: "given\u2026 does it follow that\u2026 "
     reference: "\"Does it follow that\" could be replaced with \"can we infer that\u2026\
       \ \", \"is it guaranteed that\u2026\", etc. Ideally there should be a question\
       \ mark after \"does it follow that {hypothesis}?\", but the hypothesis string\
@@ -37,12 +37,14 @@ templates:
       \ 1 entail Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \nYes\n\
       {% elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
     name: does S1 entail S2?
-    reference: Copied from Victor's prompt for XNLI.
+    reference: Copied from Victor's prompts for XNLI.
   e0e8b914-c32c-4c85-8b8f-0f61ae79e2b3: !Template
     id: e0e8b914-c32c-4c85-8b8f-0f61ae79e2b3
     jinja: Given that {{premise}}, it {{"must be true, might be true, or must be false"}}
       that {{hypothesis}}? ||| It {{ ["must be true", "might be true", "must be false"][label]
       }}.
-    name: "given\u2026 must be true that\u2026"
-    reference: Anecdotally this is the most natural way of how I say an NLI sentence
-      pair out loud to humans.
+    name: "given\u2026 it must be true that\u2026"
+    reference: 'Maybe a little verbose for a generative model, but anecdotally this
+      is the most natural way of how I say an NLI sentence pair out loud to humans.
+      Caveat: NLI annotations are not meant to be strictly truth-conditional entailment,
+      so "must" is not ideal.'

--- a/templates/anli/templates.yaml
+++ b/templates/anli/templates.yaml
@@ -1,0 +1,48 @@
+dataset: anli
+templates:
+  391acb43-732a-4c09-8c10-e02d226d8854: !Template
+    id: 391acb43-732a-4c09-8c10-e02d226d8854
+    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
+      \ 1 contradict Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \n\
+      No\n{% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
+    name: does S1 contradict S2?
+    reference: Copied from Victor's prompt for XNLI.
+  5459237b-97de-4340-bf7b-2939c3f7ca19: !Template
+    id: 5459237b-97de-4340-bf7b-2939c3f7ca19
+    jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes, no, or maybe?
+      ||| {{ ["Yes", "Maybe", "No"][label] }}
+    name: "given\u2026 does it follows that\u2026 "
+    reference: "\"Does it follow that\" could be replaced with \"can we infer that\u2026\
+      \ \", \"is it guaranteed that\u2026\", etc. Ideally there should be a question\
+      \ mark after \"does it follow that {hypothesis}?\", but the hypothesis string\
+      \ often comes with ending punctuations of its own."
+  620aa3fc-d5eb-46f5-a1ee-4c754527aa97: !Template
+    id: 620aa3fc-d5eb-46f5-a1ee-4c754527aa97
+    jinja: '{{premise}}
+
+      Question: {{hypothesis}} True, False, or Neither? ||| {{ ["True", "Neither",
+      "False"][label] }}'
+    name: GPT-3 style
+    reference: 'Same as reported in Figure G7 of the GPT-3 paper, except that there
+      is no task identifying tokens like "anli R1: ".'
+  9b613182-c6ab-4427-9221-3d68f6d62765: !Template
+    id: 9b613182-c6ab-4427-9221-3d68f6d62765
+    jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
+      Yes, no, or maybe? ||| {{ ["Yes", "Maybe", "No"][label] }}'
+    name: based on the previous passage
+    reference: "Adopted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+  cf55f09b-bc68-439d-a9b2-781263509f99: !Template
+    id: cf55f09b-bc68-439d-a9b2-781263509f99
+    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
+      \ 1 entail Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \nYes\n\
+      {% elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
+    name: does S1 entail S2?
+    reference: Copied from Victor's prompt for XNLI.
+  e0e8b914-c32c-4c85-8b8f-0f61ae79e2b3: !Template
+    id: e0e8b914-c32c-4c85-8b8f-0f61ae79e2b3
+    jinja: Given that {{premise}}, it {{"must be true, might be true, or must be false"}}
+      that {{hypothesis}}? ||| It {{ ["must be true", "might be true", "must be false"][label]
+      }}.
+    name: "given\u2026 must be true that\u2026"
+    reference: Anecdotally this is the most natural way of how I say an NLI sentence
+      pair out loud to humans.

--- a/templates/hans/templates.yaml
+++ b/templates/hans/templates.yaml
@@ -1,0 +1,42 @@
+dataset: hans
+templates:
+  1b2386f7-4b2b-436b-a0cc-7092a90964f7: !Template
+    id: 1b2386f7-4b2b-436b-a0cc-7092a90964f7
+    jinja: '{{premise}} Does the previous passage support the claim that {{hypothesis}}?
+      ||| {{ ["Yes", "No"][label] }}'
+    name: "\u2026does the previous passage support the claim that"
+    reference: ''
+  213f6f71-0987-4cba-8e16-85ed08b6d237: !Template
+    id: 213f6f71-0987-4cba-8e16-85ed08b6d237
+    jinja: Suppose {{premise}} Can we infer that {{hypothesis}}? ||| {{ ["Yes", "No"][label]
+      }}
+    name: "Suppose\u2026 Can we infer that\u2026"
+    reference: ''
+  930dbf9e-be95-458c-bf63-0358e36b8f8f: !Template
+    id: 930dbf9e-be95-458c-bf63-0358e36b8f8f
+    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
+      \ 1 entail Sentence 2? Yes or no? |||\n{% if label == 0 %} \nYes\n{% else %}\n\
+      No\n{% endif %}"
+    name: does S1 entail S2?
+    reference: Adopted from Victor's prompts for XNLI.
+  9666d06a-63eb-4992-a1f5-3e582ffe39a6: !Template
+    id: 9666d06a-63eb-4992-a1f5-3e582ffe39a6
+    jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes or no? |||
+      {{ ["Yes", "No"][label] }}
+    name: "given\u2026 does it follow that\u2026 "
+    reference: ''
+  9be63780-a784-4a8e-9440-4453c14f8a0e: !Template
+    id: 9be63780-a784-4a8e-9440-4453c14f8a0e
+    jinja: '{{premise}}
+
+      Question: {{hypothesis}} True or False? ||| {{ ["True", "False"][label] }}'
+    name: GPT-3 style
+    reference: Same as reported in Figure G31 of the GPT-3 paper, although I'm not
+      sure about phrasing the not_entailment label (could be either neutral and contradiction)
+      simply as "False".
+  b7676330-5e75-4f3d-96bd-2ab7aa10fbcd: !Template
+    id: b7676330-5e75-4f3d-96bd-2ab7aa10fbcd
+    jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}?
+      ||| {{ ["Yes", "No"][label] }}'
+    name: based on the previous passage
+    reference: "Adopted from the BoolQ prompts in Schick & Sch\xFCtze 2021."

--- a/templates/multi_nli/templates.yaml
+++ b/templates/multi_nli/templates.yaml
@@ -1,0 +1,50 @@
+dataset: multi_nli
+templates:
+  4100d721-b9c1-41ef-9392-3eeb64e8a4cd: !Template
+    id: 4100d721-b9c1-41ef-9392-3eeb64e8a4cd
+    jinja: Given that {{premise}}, it {{"must be true, might be true, or must be false"}}
+      that {{hypothesis}}? ||| It {{ ["must be true", "might be true", "must be false"][label]
+      }}.
+    name: "given\u2026 it must be true that\u2026"
+    reference: 'Maybe a little verbose for a generative model, but anecdotally this
+      is the most natural way of how I say an NLI sentence pair out loud to humans.
+      Caveat: NLI annotations are not meant to be strictly truth-conditional entailment,
+      so "must" is not ideal.'
+  6c6d824a-89c8-48cc-a4b5-cab04d649117: !Template
+    id: 6c6d824a-89c8-48cc-a4b5-cab04d649117
+    jinja: '{{premise}}
+
+      Question: {{hypothesis}} True, False, or Neither? ||| {{ ["True", "Neither",
+      "False"][label] }}'
+    name: GPT-3 style
+    reference: 'Same as reported in Figure G7 of the GPT-3 paper, except that there
+      is no task identifying tokens like "anli R1: ".'
+  b2dcedb3-265e-4dfa-bbd2-9d9d992bd389: !Template
+    id: b2dcedb3-265e-4dfa-bbd2-9d9d992bd389
+    jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes, no, or maybe?
+      ||| {{ ["Yes", "Maybe", "No"][label] }}
+    name: "given\u2026 does it follow that\u2026 "
+    reference: "\"Does it follow that\" could be replaced with \"can we infer that\u2026\
+      \ \", \"is it guaranteed that\u2026\", etc. Ideally there should be a question\
+      \ mark after \"does it follow that {hypothesis}?\", but the hypothesis string\
+      \ often comes with ending punctuations of its own."
+  ca5a9209-47ed-4ca9-9b03-7ea909f61d96: !Template
+    id: ca5a9209-47ed-4ca9-9b03-7ea909f61d96
+    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
+      \ 1 contradict Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \n\
+      No\n{% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
+    name: does S1 contradict S2?
+    reference: Copied from Victor's prompts for XNLI.
+  d067f960-75d9-4fed-bf54-6ddaff123a57: !Template
+    id: d067f960-75d9-4fed-bf54-6ddaff123a57
+    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
+      \ 1 entail Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \nYes\n\
+      {% elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
+    name: does S1 entail S2?
+    reference: Copied from Victor's prompts for XNLI.
+  f1a17d8b-78fb-4300-bc13-8c4572a091fa: !Template
+    id: f1a17d8b-78fb-4300-bc13-8c4572a091fa
+    jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
+      Yes, no, or maybe? ||| {{ ["Yes", "Maybe", "No"][label] }}'
+    name: based on the previous passage
+    reference: "Adopted from the BoolQ prompts in Schick & Sch\xFCtze 2021."

--- a/templates/scitail/tsv_format/templates.yaml
+++ b/templates/scitail/tsv_format/templates.yaml
@@ -1,0 +1,38 @@
+dataset: scitail
+subset: tsv_format
+templates:
+  189ed384-c077-49ad-b606-ed08b66f8376: !Template
+    id: 189ed384-c077-49ad-b606-ed08b66f8376
+    jinja: '{{premise}} Therefore, we are licensed to say that {{hypothesis}} True
+      or false? ||| {{ {''entails'': ''Yes'', ''neutral'': ''No''}[label] }}'
+    name: "\u2026 Therefore, we're licensed to say that\u2026"
+    reference: ''
+  1ff92b02-fefc-49e0-b676-9391fab8f193: !Template
+    id: 1ff92b02-fefc-49e0-b676-9391fab8f193
+    jinja: 'Suppose {{premise}} Can we infer that {{hypothesis}}? ||| {{ {''entails'':
+      ''Yes'', ''neutral'': ''No''}[label] }}'
+    name: "Suppose\u2026 Can we infer that\u2026"
+    reference: ''
+  5aa53544-73a6-4486-b8c8-623345353fa7: !Template
+    id: 5aa53544-73a6-4486-b8c8-623345353fa7
+    jinja: '{{premise}} Does the previous passage support the claim that {{hypothesis}}?
+      ||| {{ {''entails'': ''Yes'', ''neutral'': ''No''}[label] }}'
+    name: "\u2026does the previous passage support the claim that"
+    reference: ''
+  705fa099-0650-4de5-b72f-881aea0fa208: !Template
+    id: 705fa099-0650-4de5-b72f-881aea0fa208
+    jinja: 'Given that {{premise}} Does it follow that {{hypothesis}} Yes or no? |||
+      {{ {''entails'': ''Yes'', ''neutral'': ''No''}[label] }}'
+    name: "given\u2026 does it follow that\u2026 "
+    reference: ''
+  9aa89dee-6cef-43bc-bdf4-e38cdf0796a6: !Template
+    id: 9aa89dee-6cef-43bc-bdf4-e38cdf0796a6
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 entail Sentence 2? Yes or no? |||
+
+      {{ {''entails'': ''Yes'', ''neutral'': ''No''}[label] }}'
+    name: does S1 entail S2?
+    reference: Adopted from Victor's prompts for XNLI.

--- a/templates/snli/templates.yaml
+++ b/templates/snli/templates.yaml
@@ -1,0 +1,50 @@
+dataset: snli
+templates:
+  4b15006d-48de-49e9-970c-6c4206fd4216: !Template
+    id: 4b15006d-48de-49e9-970c-6c4206fd4216
+    jinja: '{{premise}}
+
+      Question: {{hypothesis}} True, False, or Neither? ||| {{ ["True", "Neither",
+      "False"][label] }}'
+    name: GPT-3 style
+    reference: 'Same as reported in Figure G7 of the GPT-3 paper, except that there
+      is no task identifying tokens like "anli R1: ".'
+  5f0ef86f-2b8f-4a0c-8bca-a8b8d9ac015e: !Template
+    id: 5f0ef86f-2b8f-4a0c-8bca-a8b8d9ac015e
+    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
+      \ 1 entail Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \nYes\n\
+      {% elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
+    name: does S1 entail S2?
+    reference: Copied from Victor's prompts for XNLI.
+  68afa6d2-547d-4c2f-bcac-71507b1fe778: !Template
+    id: 68afa6d2-547d-4c2f-bcac-71507b1fe778
+    jinja: Given that {{premise}}, it {{"must be true, might be true, or must be false"}}
+      that {{hypothesis}}? ||| It {{ ["must be true", "might be true", "must be false"][label]
+      }}.
+    name: "given\u2026 it must be true that\u2026"
+    reference: 'Maybe a little verbose for a generative model, but anecdotally this
+      is the most natural way of how I say an NLI sentence pair out loud to humans.
+      Caveat: NLI annotations are not meant to be strictly truth-conditional entailment,
+      so "must" is not ideal.'
+  94c87dc3-865e-4321-a696-bbc5a54d7096: !Template
+    id: 94c87dc3-865e-4321-a696-bbc5a54d7096
+    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
+      \ 1 contradict Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \n\
+      No\n{% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
+    name: does S1 contradict S2?
+    reference: Copied from Victor's prompts for XNLI.
+  b6abcb2e-a0b0-4046-810c-d27f316b1bd5: !Template
+    id: b6abcb2e-a0b0-4046-810c-d27f316b1bd5
+    jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes, no, or maybe?
+      ||| {{ ["Yes", "Maybe", "No"][label] }}
+    name: "given\u2026 does it follow that\u2026 "
+    reference: "\"Does it follow that\" could be replaced with \"can we infer that\u2026\
+      \ \", \"is it guaranteed that\u2026\", etc. Ideally there should be a question\
+      \ mark after \"does it follow that {hypothesis}?\", but the hypothesis string\
+      \ often comes with ending punctuations of its own."
+  f227d882-7838-4c7a-93fc-c2b68d2464fb: !Template
+    id: f227d882-7838-4c7a-93fc-c2b68d2464fb
+    jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
+      Yes, no, or maybe? ||| {{ ["Yes", "Maybe", "No"][label] }}'
+    name: based on the previous passage
+    reference: "Adopted from the BoolQ prompts in Schick & Sch\xFCtze 2021."

--- a/templates/super_glue/cb/templates.yaml
+++ b/templates/super_glue/cb/templates.yaml
@@ -1,0 +1,48 @@
+dataset: super_glue
+subset: cb
+templates:
+  0acadc5c-8cd0-4e33-b117-379321bc0df1: !Template
+    id: 0acadc5c-8cd0-4e33-b117-379321bc0df1
+    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
+      \ 1 contradict Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \n\
+      No\n{% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
+    name: does S1 contradict S2?
+    reference: Copied from Victor's prompts for XNLI.
+  5bca1a90-340b-42b4-9c0d-e5eb1c25605e: !Template
+    id: 5bca1a90-340b-42b4-9c0d-e5eb1c25605e
+    jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes, no, or maybe?
+      ||| {{ ["Yes", "Maybe", "No"][label] }}
+    name: "given\u2026 does it follow that\u2026 "
+    reference: ''
+  684f44af-f09a-4231-a318-94473a9624b7: !Template
+    id: 684f44af-f09a-4231-a318-94473a9624b7
+    jinja: Given that {{premise}}, it {{"must be true, might be true, or must be false"}}
+      that {{hypothesis}}? ||| It {{ ["must be true", "might be true", "must be false"][label]
+      }}.
+    name: "given\u2026 it must be true that\u2026"
+    reference: 'Maybe a little verbose for a generative model, but anecdotally this
+      is the most natural way of how I say an NLI sentence pair out loud to humans.
+      Caveat: NLI annotations are not meant to be strictly truth-conditional entailment,
+      so "must" is not ideal.'
+  774c170e-9fff-4b0b-871a-30967b0186f6: !Template
+    id: 774c170e-9fff-4b0b-871a-30967b0186f6
+    jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
+      Yes, no, or maybe? ||| {{ ["Yes", "Maybe", "No"][label] }}'
+    name: based on the previous passage
+    reference: "Adopted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+  86120953-771a-4dca-a681-d628117ba6d2: !Template
+    id: 86120953-771a-4dca-a681-d628117ba6d2
+    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
+      \ 1 entail Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \nYes\n\
+      {% elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
+    name: does S1 entail S2?
+    reference: Copied from Victor's prompts for XNLI.
+  bab42d43-d1e6-4a42-8112-75a398fd582c: !Template
+    id: bab42d43-d1e6-4a42-8112-75a398fd582c
+    jinja: '{{premise}}
+
+      Question: {{hypothesis}} True, False, or Neither? ||| {{ ["True", "Neither",
+      "False"][label] }}'
+    name: GPT-3 style
+    reference: 'Same as reported in Figure G7 of the GPT-3 paper, except that there
+      is no task identifying tokens like "anli R1: ".'

--- a/templates/super_glue/rte/templates.yaml
+++ b/templates/super_glue/rte/templates.yaml
@@ -1,0 +1,51 @@
+dataset: super_glue
+subset: rte
+templates:
+  0583671e-b717-4353-a0d4-ea1e4ac56429: !Template
+    id: 0583671e-b717-4353-a0d4-ea1e4ac56429
+    jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes or no? |||
+      {{ ["Yes", "No"][label] }}
+    name: "given\u2026 does it follow that\u2026 "
+    reference: Ideally there should be a question mark after "does it follow that
+      {hypothesis}?", but the hypothesis string often comes with ending punctuations
+      of its own.
+  1abaa658-e7f0-4e54-b7ad-312ba009d544: !Template
+    id: 1abaa658-e7f0-4e54-b7ad-312ba009d544
+    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
+      \ 1 entail Sentence 2? Yes or no? |||\n{% if label == 0 %} \nYes\n{% else %}\n\
+      No\n{% endif %}"
+    name: does S1 entail S2?
+    reference: Adopted from Victor's prompts for XNLI.
+  1bf2eee4-448b-48df-98e0-dee86edf7b96: !Template
+    id: 1bf2eee4-448b-48df-98e0-dee86edf7b96
+    jinja: '{{premise}} Therefore, we are licensed to say that {{hypothesis}} True
+      or false? ||| {{ ["True", "False"][label] }}'
+    name: "\u2026 Therefore, we're licensed to say that\u2026"
+    reference: ''
+  2721e378-68b2-40e6-be7e-fc2783b16042: !Template
+    id: 2721e378-68b2-40e6-be7e-fc2783b16042
+    jinja: '{{premise}}
+
+      Question: {{hypothesis}} True or False? ||| {{ ["True", "False"][label] }}'
+    name: GPT-3 style
+    reference: Same as reported in Figure G31 of the GPT-3 paper, although I'm not
+      sure about phrasing the not_entailment label (could be either neutral and contradiction)
+      simply as "False".
+  325dbe5c-167d-4b17-95db-1d93d8806782: !Template
+    id: 325dbe5c-167d-4b17-95db-1d93d8806782
+    jinja: Suppose {{premise}} Can we infer that {{hypothesis}}? ||| {{ ["Yes", "No"][label]
+      }}
+    name: "Suppose\u2026 Can we infer that\u2026"
+    reference: ''
+  4aac6388-3e90-4d06-be90-68fc31a89fa4: !Template
+    id: 4aac6388-3e90-4d06-be90-68fc31a89fa4
+    jinja: '{{premise}} Does the previous passage support the claim that {{hypothesis}}?
+      ||| {{ ["Yes", "No"][label] }}'
+    name: "\u2026does the previous passage support the claim that"
+    reference: ''
+  ad3361d7-505f-4b5d-93dd-e426394a3943: !Template
+    id: ad3361d7-505f-4b5d-93dd-e426394a3943
+    jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}?
+      ||| {{ ["Yes", "No"][label] }}'
+    name: based on the previous passage
+    reference: "Adopted from the BoolQ prompts in Schick & Sch\xFCtze 2021."

--- a/templates/xnli/en/templates.yaml
+++ b/templates/xnli/en/templates.yaml
@@ -14,8 +14,10 @@ templates:
       that {{hypothesis}}? ||| It {{ ["must be true", "might be true", "must be false"][label]
       }}.
     name: "given\u2026 must be true that\u2026"
-    reference: Anecdotally this is the most natural way of how I say an NLI sentence
-      pair out loud to humans.
+    reference: 'Maybe a little verbose for a generative model, but anecdotally this
+      is the most natural way of how I say an NLI sentence pair out loud to humans.
+      Caveat: NLI annotations are not meant to be strictly truth-conditional entailment,
+      so "must" is not ideal.'
   c62a3048-018e-4d93-bc46-645f3f763ee6: !Template
     id: c62a3048-018e-4d93-bc46-645f3f763ee6
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
@@ -28,7 +30,7 @@ templates:
     id: d027ab50-a86b-45ba-99fa-018c0e4cac4a
     jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes, no, or maybe?
       ||| {{ ["Yes", "Maybe", "No"][label] }}
-    name: "given\u2026 does it follows that\u2026 "
+    name: "given\u2026 does it follow that\u2026 "
     reference: "\"Does it follow that\" could be replaced with \"can we infer that\u2026\
       \ \", \"is it guaranteed that\u2026\", etc. Ideally there should be a question\
       \ mark after \"does it follow that {hypothesis}?\", but the hypothesis string\

--- a/templates/xnli/en/templates.yaml
+++ b/templates/xnli/en/templates.yaml
@@ -8,6 +8,14 @@ templates:
       \ 0 %} \nNo\n{% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
     name: Concatenation contraposition
     reference: Concatenation contraposition
+  a1506390-8d7a-4b8f-922c-6135e23094d7: !Template
+    id: a1506390-8d7a-4b8f-922c-6135e23094d7
+    jinja: Given that {{premise}}, it {{"must be true, might be true, or must be false"}}
+      that {{hypothesis}}? ||| It {{ ["must be true", "might be true", "must be false"][label]
+      }}.
+    name: "given\u2026 must be true that\u2026"
+    reference: Anecdotally this is the most natural way of how I say an NLI sentence
+      pair out loud to humans.
   c62a3048-018e-4d93-bc46-645f3f763ee6: !Template
     id: c62a3048-018e-4d93-bc46-645f3f763ee6
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
@@ -16,6 +24,15 @@ templates:
     name: Label binarization contraposition
     reference: Inspired from https://arxiv.org/pdf/1902.01007.pdf Section 4 - Implementation
       and evaluation
+  d027ab50-a86b-45ba-99fa-018c0e4cac4a: !Template
+    id: d027ab50-a86b-45ba-99fa-018c0e4cac4a
+    jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes, no, or maybe?
+      ||| {{ ["Yes", "Maybe", "No"][label] }}
+    name: "given\u2026 does it follows that\u2026 "
+    reference: "\"Does it follow that\" could be replaced with \"can we infer that\u2026\
+      \ \", \"is it guaranteed that\u2026\", etc. Ideally there should be a question\
+      \ mark after \"does it follow that {hypothesis}?\", but the hypothesis string\
+      \ often comes with ending punctuations of its own."
   d9e13133-267e-46c4-afad-c2379dcc5272: !Template
     id: d9e13133-267e-46c4-afad-c2379dcc5272
     jinja: "{{premise}}\nQuestion: {{hypothesis}} True, False, or Neither? ||| \n\
@@ -31,6 +48,12 @@ templates:
     name: Label binarization
     reference: Grouping "neutral" and "contradiction" as a single label following
       https://arxiv.org/pdf/1902.01007.pdf Section 4 - Implementation and evaluation
+  ddfd2eb1-96a4-42db-ad5e-91d7cb011b4e: !Template
+    id: ddfd2eb1-96a4-42db-ad5e-91d7cb011b4e
+    jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
+      Yes, no, or maybe? ||| {{ ["Yes", "Maybe", "No"][label] }}'
+    name: based on the previous passage
+    reference: "Adopted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
   e174f56a-b0af-4937-b6ae-1897cac26eba: !Template
     id: e174f56a-b0af-4937-b6ae-1897cac26eba
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\


### PR DESCRIPTION
Now there are at least 5 templates for each NLI task. Roughly, the three-way NLI tasks (S/M/X/ANLI and SuperGLUE CB) share the same prompt templates, while the binary NLI tasks (RTE, SciTail, and HANS) share the same templates. But there are multiple exceptions. For example, SciTail only has neutral labels without any contradiction labels, and it sounds weird to say, e.g., based on the premise the hypothesis is False. 

I manually checked each task and read out loud each prompt with some examples to make sure that they all sound reasonably natural. I erred on the slightly more conservative side because I find some prompts in the literature, e.g., [here](https://arxiv.org/pdf/2105.11447.pdf) on p. 20 "Premise… Hypothesis… Therefore the answer is yes", reads quite unnatural. (Maybe it's fine that they somehow work in evaluation, but we might want higher-standard prompts for training.) 

@VictorSanh wrote some prompts for XNLI that ask the model to predict the contraposition. I didn't adopt those for the binary NLI tasks because it sounded weird to ask "does P contradict H", when the label is only "non-entailment". (We could in theory ask "does P not entail H", but I have zero faith in neural nets today understanding any negation.)

Anyway. NLI annotations are not meant to be strictly logical/truth-conditional entailment, and (for humans at least) the exact phrasing of prompts really have meaningful pragmatic effects. I'm sure the ones I wrote today include some mistakes, so scrutiny is obviously welcome. 