### PR TITLE
Fix dataset_info.json not found error

### DIFF
--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -181,10 +181,13 @@ else:
 
         dataset, failed = get_dataset(dataset_key, str(conf_option.name) if conf_option else None)
         if failed:
+            st.error(f"Loading dataset {dataset_key} failed.\n{dataset}. Please skip for the moment.")
+            """
             if dataset.manual_download_instructions is not None:
                 st.error(f"Dataset {dataset_key} requires manual download. Please skip for the moment.")
             else:
                 st.error(f"Loading dataset {dataset_key} failed.\n{dataset}. Please skip for the moment.")
+            """
 
         splits = list(dataset.keys())
         index = 0

--- a/promptsource/utils.py
+++ b/promptsource/utils.py
@@ -2,6 +2,7 @@
 
 import datasets
 import requests
+from datasets import load_dataset
 
 
 def removeHyphen(example):
@@ -42,16 +43,11 @@ def get_dataset_builder(path, conf=None):
 
 def get_dataset(path, conf=None):
     "Get a dataset from name and conf."
-    builder_instance = get_dataset_builder(path, conf)
-    fail = False
-    if builder_instance.manual_download_instructions is None and builder_instance.info.size_in_bytes is not None:
-        builder_instance.download_and_prepare()
-        dts = builder_instance.as_dataset()
-        dataset = dts
-    else:
-        dataset = builder_instance
-        fail = True
-    return dataset, fail
+    try:
+        dataset = load_dataset(path, conf)
+        return dataset, False
+    except:
+        return None, True
 
 
 def get_dataset_confs(path):


### PR DESCRIPTION
The common way to load dataset
```
from datasets import load_dataset
dataset = load_dataset("glue", 'cola')
```
doesn't cache the `dataset_info.json` , but this app needs it to know if manual download is needed.
If you have previously cached a dataset without `dataset_info.json`, an error occurs when loading it in the app.

This is an ugly fix around that.