### PR TITLE
Adapted Perez et al. 2021’s prompts for SuperGLUE

### DIFF
--- a/templates/anli/templates.yaml
+++ b/templates/anli/templates.yaml
@@ -30,7 +30,7 @@ templates:
     jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
       Yes, no, or maybe? ||| {{ ["Yes", "Maybe", "No"][label] }}'
     name: based on the previous passage
-    reference: "Adopted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+    reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
   cf55f09b-bc68-439d-a9b2-781263509f99: !Template
     id: cf55f09b-bc68-439d-a9b2-781263509f99
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\

--- a/templates/hans/templates.yaml
+++ b/templates/hans/templates.yaml
@@ -18,7 +18,7 @@ templates:
       \ 1 entail Sentence 2? Yes or no? |||\n{% if label == 0 %} \nYes\n{% else %}\n\
       No\n{% endif %}"
     name: does S1 entail S2?
-    reference: Adopted from Victor's prompts for XNLI.
+    reference: Adapted from Victor's prompts for XNLI.
   9666d06a-63eb-4992-a1f5-3e582ffe39a6: !Template
     id: 9666d06a-63eb-4992-a1f5-3e582ffe39a6
     jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes or no? |||
@@ -39,4 +39,4 @@ templates:
     jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}?
       ||| {{ ["Yes", "No"][label] }}'
     name: based on the previous passage
-    reference: "Adopted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+    reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."

--- a/templates/multi_nli/templates.yaml
+++ b/templates/multi_nli/templates.yaml
@@ -47,4 +47,4 @@ templates:
     jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
       Yes, no, or maybe? ||| {{ ["Yes", "Maybe", "No"][label] }}'
     name: based on the previous passage
-    reference: "Adopted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+    reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."

--- a/templates/scitail/snli_format/templates.yaml
+++ b/templates/scitail/snli_format/templates.yaml
@@ -1,9 +1,0 @@
-dataset: scitail
-subset: snli_format
-templates:
-  707f9870-64dc-4f24-b4e3-3f26297ec28c: !Template
-    id: 707f9870-64dc-4f24-b4e3-3f26297ec28c
-    jinja: "{{sentence1}} \n{{sentence2}}\nAre these sentences {{\"neutral or entailment\"\
-      }} to one another?|||\n{{gold_label}}"
-    name: Test1
-    reference: ''

--- a/templates/scitail/snli_format/templates.yaml
+++ b/templates/scitail/snli_format/templates.yaml
@@ -1,0 +1,9 @@
+dataset: scitail
+subset: snli_format
+templates:
+  707f9870-64dc-4f24-b4e3-3f26297ec28c: !Template
+    id: 707f9870-64dc-4f24-b4e3-3f26297ec28c
+    jinja: "{{sentence1}} \n{{sentence2}}\nAre these sentences {{\"neutral or entailment\"\
+      }} to one another?|||\n{{gold_label}}"
+    name: Test1
+    reference: ''

--- a/templates/scitail/tsv_format/templates.yaml
+++ b/templates/scitail/tsv_format/templates.yaml
@@ -35,4 +35,4 @@ templates:
 
       {{ {''entails'': ''Yes'', ''neutral'': ''No''}[label] }}'
     name: does S1 entail S2?
-    reference: Adopted from Victor's prompts for XNLI.
+    reference: Adapted from Victor's prompts for XNLI.

--- a/templates/snli/templates.yaml
+++ b/templates/snli/templates.yaml
@@ -47,4 +47,4 @@ templates:
     jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
       Yes, no, or maybe? ||| {{ ["Yes", "Maybe", "No"][label] }}'
     name: based on the previous passage
-    reference: "Adopted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+    reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."

--- a/templates/super_glue/boolq/templates.yaml
+++ b/templates/super_glue/boolq/templates.yaml
@@ -1,0 +1,22 @@
+dataset: super_glue
+subset: boolq
+templates:
+  492f0f88-4370-46cd-839b-1de37a55aeda: !Template
+    id: 492f0f88-4370-46cd-839b-1de37a55aeda
+    jinja: "{{ passage }} \nquestion: {{ question }}\nanswer: ||| {{ [\"False\", \"\
+      True\"][label] }} "
+    name: GPT-3 Style
+    reference: Same as Figure G29, p. 58 of the GPT-3 paper
+  9a1bf459-8047-437c-9def-f21e960429cc: !Template
+    id: 9a1bf459-8047-437c-9def-f21e960429cc
+    jinja: "Based on the following passage, {{ passage }} \n{{ question }}? ||| {{\
+      \ [\"No\", \"Yes\"][label] }} "
+    name: based on the following passage
+    reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+  b2b3cb60-d6e3-491c-a09a-8201e13e417e: !Template
+    id: b2b3cb60-d6e3-491c-a09a-8201e13e417e
+    jinja: '{{ passage }}
+
+      Based on the previous passage, {{ question }}? ||| {{ ["No", "Yes"][label] }} '
+    name: based on the previous passage
+    reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."

--- a/templates/super_glue/cb/templates.yaml
+++ b/templates/super_glue/cb/templates.yaml
@@ -29,7 +29,7 @@ templates:
     jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
       Yes, no, or maybe? ||| {{ ["Yes", "Maybe", "No"][label] }}'
     name: based on the previous passage
-    reference: "Adopted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+    reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
   86120953-771a-4dca-a681-d628117ba6d2: !Template
     id: 86120953-771a-4dca-a681-d628117ba6d2
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\

--- a/templates/super_glue/copa/templates.yaml
+++ b/templates/super_glue/copa/templates.yaml
@@ -1,0 +1,9 @@
+dataset: super_glue
+subset: copa
+templates:
+  744047dc-1298-45a2-8d68-d67e3f834ded: !Template
+    id: 744047dc-1298-45a2-8d68-d67e3f834ded
+    jinja: '"{{ choice1 }}" or "{{ choice2 }}"? {{ premise }} {% if question == "cause"
+      %} because {% else %} so {% endif %} ||| {{ [choice1, choice2][label] }}'
+    name: "C1 or C2? premise, so/because\u2026"
+    reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."

--- a/templates/super_glue/multirc/templates.yaml
+++ b/templates/super_glue/multirc/templates.yaml
@@ -1,0 +1,21 @@
+dataset: super_glue
+subset: multirc
+templates:
+  42d47df9-09de-4691-8e49-7cfadd636cdd: !Template
+    id: 42d47df9-09de-4691-8e49-7cfadd636cdd
+    jinja: "{{ paragraph }}\nBased on the previous passage, {{ question }} \nIs \"\
+      {{ answer }}\" a correct answer? ||| {{ [\"No\", \"Yes\"][label] }}"
+    name: "is\u2026 a correct answer?"
+    reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+  59a2d847-27f3-4002-a125-cf9a291b3098: !Template
+    id: 59a2d847-27f3-4002-a125-cf9a291b3098
+    jinja: "{{ paragraph }}\nQuestion: {{ question }} \nIs it {{ answer }}? ||| {{\
+      \ [\"No\", \"Yes\"][label] }}"
+    name: "paragraph\u2026 question\u2026 is it\u2026 ?"
+    reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+  7d878b89-2774-429a-82fb-ac801379e3ae: !Template
+    id: 7d878b89-2774-429a-82fb-ac801379e3ae
+    jinja: "{{ paragraph }}\nQuestion: {{ question }} \nIs the correct answer {{ answer\
+      \ }}? ||| {{ [\"No\", \"Yes\"][label] }}"
+    name: "is the correct answer\u2026"
+    reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."

--- a/templates/super_glue/record/templates.yaml
+++ b/templates/super_glue/record/templates.yaml
@@ -1,0 +1,15 @@
+dataset: super_glue
+subset: record
+templates:
+  a5ed27ed-162b-4ac1-9c7a-85059d5214be: !Template
+    id: a5ed27ed-162b-4ac1-9c7a-85059d5214be
+    jinja: "{{ passage }} \n{{ query }} \nThe{% if answers | length < 2 %} placeholder\
+      \ refers {% else %} placeholders refer {% endif %}to ||| {{ answers | join(\"\
+      , \") }}"
+    name: "the placeholders refer to\u2026"
+    reference: ''
+  ff9aee36-c6da-48ca-816d-b4222526f8cd: !Template
+    id: ff9aee36-c6da-48ca-816d-b4222526f8cd
+    jinja: "{{ passage }} \n{{ query }} ||| {{ answers | join(\", \") }}"
+    name: naive LM
+    reference: "Adapted from Schick & Sch\xFCtz 2021."

--- a/templates/super_glue/rte/templates.yaml
+++ b/templates/super_glue/rte/templates.yaml
@@ -15,7 +15,7 @@ templates:
       \ 1 entail Sentence 2? Yes or no? |||\n{% if label == 0 %} \nYes\n{% else %}\n\
       No\n{% endif %}"
     name: does S1 entail S2?
-    reference: Adopted from Victor's prompts for XNLI.
+    reference: Adapted from Victor's prompts for XNLI.
   1bf2eee4-448b-48df-98e0-dee86edf7b96: !Template
     id: 1bf2eee4-448b-48df-98e0-dee86edf7b96
     jinja: '{{premise}} Therefore, we are licensed to say that {{hypothesis}} True
@@ -48,4 +48,4 @@ templates:
     jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}?
       ||| {{ ["Yes", "No"][label] }}'
     name: based on the previous passage
-    reference: "Adopted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+    reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."

--- a/templates/super_glue/wsc.fixed/templates.yaml
+++ b/templates/super_glue/wsc.fixed/templates.yaml
@@ -1,0 +1,21 @@
+dataset: super_glue
+subset: wsc.fixed
+templates:
+  212fb8b1-8436-4f64-8f37-a9094fe029f4: !Template
+    id: 212fb8b1-8436-4f64-8f37-a9094fe029f4
+    jinja: "{{ text }} \nIn the passage above, what does the  pronoun \"{{ span2_text\
+      \ }}\" refer to? ||| {{ span1_text }}"
+    name: in the passage above, what does the pronoun refer to?
+    reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+  7d377293-d043-4b6c-8ec1-d61eaf14ec67: !Template
+    id: 7d377293-d043-4b6c-8ec1-d61eaf14ec67
+    jinja: "Passage: {{ text }} \nQuestion: In the passage above, what does the pronoun\
+      \ \"{{ span2_text }}\" refer to? \nAnswer: ||| {{ span1_text }}"
+    name: "passage\u2026 what does the pronoun refer to?"
+    reference: Adapted from Figure G33, p. 59, Brown et al. 2020
+  aae24b54-c3a7-4f69-8b77-f6dc115988f8: !Template
+    id: aae24b54-c3a7-4f69-8b77-f6dc115988f8
+    jinja: "{{ text }} \nIn the passage above, the pronoun \"{{ span2_text }}\" refers\
+      \ to ||| {{ span1_text }}"
+    name: "in the passage above, the pronoun X refers to\u2026"
+    reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."

--- a/templates/xnli/en/templates.yaml
+++ b/templates/xnli/en/templates.yaml
@@ -55,7 +55,7 @@ templates:
     jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
       Yes, no, or maybe? ||| {{ ["Yes", "Maybe", "No"][label] }}'
     name: based on the previous passage
-    reference: "Adopted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+    reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
   e174f56a-b0af-4937-b6ae-1897cac26eba: !Template
     id: e174f56a-b0af-4937-b6ae-1897cac26eba
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\


### PR DESCRIPTION
Per @VictorSanh’s request, I added Ethan Perez’s prompts for SuperGLUE (from his repo [here](https://github.com/ethanjperez/true_few_shot/tree/main/templates.super_glue)). 

Many of them are near duplicates of each other, differing only in whether the model is supposed to answer "Yes" or "No" vs. "True" or "False". This is probably something we can address/augment programmatically for all binary classification tasks, so for now I wrote all templates with "Yes/No".