### PR TITLE
Prompts for `climate_fever`

### DIFF
--- a/templates/climate_fever/templates.yaml
+++ b/templates/climate_fever/templates.yaml
@@ -1,0 +1,87 @@
+dataset: climate_fever
+templates:
+  82c484bd-2ed7-4ee0-aaee-2b31ac68e751: !Template
+    id: 82c484bd-2ed7-4ee0-aaee-2b31ac68e751
+    jinja: 'Considering the following claim:
+
+      {{claim}}.
+
+      Does the following statement {{"supports"}}, {{"refutes"}}, or provide {{"not
+      enough info"}} on climate change?
+
+      {{evidences[4]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[4]["evidence_label"]]
+      }}'
+    name: fifth_evidence_claim_pair
+    reference: Relation between the claim and fifth evidence pair.
+  cb78a363-fd32-4dbd-976f-b56de644ba90: !Template
+    id: cb78a363-fd32-4dbd-976f-b56de644ba90
+    jinja: 'Considering the following claim:
+
+      {{claim}}.
+
+      Does the following statement {{"supports"}}, {{"refutes"}}, or provide {{"not
+      enough info"}} on climate change?
+
+      {{evidences[1]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[1]["evidence_label"]]
+      }}'
+    name: second_evidence_claim_pair
+    reference: Relation between the claim and second evidence pair.
+  cca7b6f5-29e3-45a4-bc8b-889f5ab2fc13: !Template
+    id: cca7b6f5-29e3-45a4-bc8b-889f5ab2fc13
+    jinja: 'Considering the following claim:
+
+      {{claim}}.
+
+      Does the following statement {{"supports"}}, {{"refutes"}}, or provide {{"not
+      enough info"}} on climate change?
+
+      {{evidences[0]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[0]["evidence_label"]]
+      }}'
+    name: first_evidence_claim_pair
+    reference: Relation between the claim and first evidence pair.
+  dc3e0a0b-4f4d-4a76-9e7b-eafce4967e98: !Template
+    id: dc3e0a0b-4f4d-4a76-9e7b-eafce4967e98
+    jinja: 'Considering the following claim:
+
+      {{claim}}.
+
+      Does the following statement {{"supports"}}, {{"refutes"}}, or provide {{"not
+      enough info"}} on climate change?
+
+      {{evidences[3]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[3]["evidence_label"]]
+      }}'
+    name: fourth_evidence_claim_pair
+    reference: Relation between the claim and fourth evidence pair.
+  ff9c9c11-92f1-4cb2-a73c-d786d58b00e1: !Template
+    id: ff9c9c11-92f1-4cb2-a73c-d786d58b00e1
+    jinja: 'Considering the following claim:
+
+      {{claim}}.
+
+      Does the following statement {{"supports"}}, {{"refutes"}}, or provide {{"not
+      enough info"}} on climate change?
+
+      {{evidences[2]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[2]["evidence_label"]]
+      }}'
+    name: third_evidence_claim_pair
+    reference: Relation between the claim and third evidence pair.

--- a/templates/climate_fever/templates.yaml
+++ b/templates/climate_fever/templates.yaml
@@ -1,5 +1,61 @@
 dataset: climate_fever
 templates:
+  38632cd9-7c4c-4e1d-85b3-20e7a78d4580: !Template
+    id: 38632cd9-7c4c-4e1d-85b3-20e7a78d4580
+    jinja: 'Here''s a statement and accompanying evidence. Does the evidence {{"supports"}},
+      {{"refutes"}}, or provide {{"not enough info"}} on climate change?
+
+
+      Statement: {{claim}}
+
+
+      Evidence: {{evidences[0]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[0]["evidence_label"]]
+      }}'
+    name: first_evidence_and_claim_itemization
+    reference: First evidence and claim with simple itemization
+  3970f474-a9e3-4264-aefa-dd4cfadd279c: !Template
+    id: 3970f474-a9e3-4264-aefa-dd4cfadd279c
+    jinja: 'Here''s a claim and accompanying evidence statements . Do the statements
+      {{"support"}}, {{"refute"}},  {{"dispute"}} or provide {{"not enough info"}}
+      on climate change?
+
+
+      Claim: {{claim}}
+
+
+      Statements:
+
+      - {{ evidences | map(attribute="evidence") | map("trim", "\".")  | join(".\n-
+      ") }}.
+
+      |||
+
+      {{ ["Supports", "Refutes", "Not enough information", "Disputed"][claim_label]
+      }}'
+    name: claim_and_all_supporting_evidences
+    reference: A claim and all supproting evidences provided with the associated claim
+      label
+  5d5062c1-d28f-4b1c-a7da-9b53796ed39f: !Template
+    id: 5d5062c1-d28f-4b1c-a7da-9b53796ed39f
+    jinja: 'Here''s a statement and accompanying evidence. Does the evidence {{"supports"}},
+      {{"refutes"}}, or provide {{"not enough info"}} on climate change?
+
+
+      Statement: {{claim}}
+
+
+      Evidence: {{evidences[4]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[4]["evidence_label"]]
+      }}'
+    name: fifth_evidence_and_claim_itemization
+    reference: Fifth evidence and claim with simple itemization
   82c484bd-2ed7-4ee0-aaee-2b31ac68e751: !Template
     id: 82c484bd-2ed7-4ee0-aaee-2b31ac68e751
     jinja: 'Considering the following claim:
@@ -13,10 +69,44 @@ templates:
 
       |||
 
-      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[4]["evidence_label"]]
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[4]["evidence_label"]]
       }}'
     name: fifth_evidence_claim_pair
     reference: Relation between the claim and fifth evidence pair.
+  9ba074a2-fbcf-4f69-bf03-bd16dbdec9cd: !Template
+    id: 9ba074a2-fbcf-4f69-bf03-bd16dbdec9cd
+    jinja: 'Here''s a statement and accompanying evidence. Does the evidence {{"supports"}},
+      {{"refutes"}}, or provide {{"not enough info"}} on climate change?
+
+
+      Statement: {{claim}}
+
+
+      Evidence: {{evidences[3]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[3]["evidence_label"]]
+      }}'
+    name: fourth_evidence_and_claim_itemization
+    reference: Fourth evidence and claim with simple itemization
+  9f68b883-d6a3-4e95-af2a-b7755bc46ba9: !Template
+    id: 9f68b883-d6a3-4e95-af2a-b7755bc46ba9
+    jinja: 'Here''s a statement and accompanying evidence. Does the evidence {{"supports"}},
+      {{"refutes"}}, or provide {{"not enough info"}} on climate change?
+
+
+      Statement: {{claim}}
+
+
+      Evidence: {{evidences[2]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[2]["evidence_label"]]
+      }}'
+    name: third_evidence_and_claim_itemization
+    reference: Third evidence and claim with simple itemization
   cb78a363-fd32-4dbd-976f-b56de644ba90: !Template
     id: cb78a363-fd32-4dbd-976f-b56de644ba90
     jinja: 'Considering the following claim:
@@ -30,7 +120,7 @@ templates:
 
       |||
 
-      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[1]["evidence_label"]]
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[1]["evidence_label"]]
       }}'
     name: second_evidence_claim_pair
     reference: Relation between the claim and second evidence pair.
@@ -47,7 +137,7 @@ templates:
 
       |||
 
-      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[0]["evidence_label"]]
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[0]["evidence_label"]]
       }}'
     name: first_evidence_claim_pair
     reference: Relation between the claim and first evidence pair.
@@ -64,10 +154,27 @@ templates:
 
       |||
 
-      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[3]["evidence_label"]]
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[3]["evidence_label"]]
       }}'
     name: fourth_evidence_claim_pair
     reference: Relation between the claim and fourth evidence pair.
+  e3e01825-e256-4098-b7bb-aa07c399e8f6: !Template
+    id: e3e01825-e256-4098-b7bb-aa07c399e8f6
+    jinja: 'Here''s a statement and accompanying evidence. Does the evidence {{"supports"}},
+      {{"refutes"}}, or provide {{"not enough info"}} on climate change?
+
+
+      Statement: {{claim}}
+
+
+      Evidence: {{evidences[1]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[1]["evidence_label"]]
+      }}'
+    name: second_evidence_and_claim_itemization
+    reference: Second evidence and claim with simple itemization
   ff9c9c11-92f1-4cb2-a73c-d786d58b00e1: !Template
     id: ff9c9c11-92f1-4cb2-a73c-d786d58b00e1
     jinja: 'Considering the following claim:
@@ -81,7 +188,7 @@ templates:
 
       |||
 
-      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[2]["evidence_label"]]
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[2]["evidence_label"]]
       }}'
     name: third_evidence_claim_pair
     reference: Relation between the claim and third evidence pair.


### PR DESCRIPTION
Created five template prompt to evaluate claim/evidence pairs from the dataset.
One main note.
Looking at the schema from HuggingFace datasets (https://huggingface.co/datasets/climate_fever#data-fields), the labels should be indexed as follows:
- claim_label: a int feature, overall label assigned to claim (based on evidence majority vote). The label correspond to 0: "refutes", 1: "supports" and 2: "not enough info"
- evidence_label: a int feature, micro-verdict label. The label correspond to 0: "refutes", 1: "supports" and 2: "not enough info"
But after some inspection I realized that 0 is usually associated to `SUPPORTS` and 1 is associated to `REFUTES`.
The template I created reflects this.