### PR TITLE
following colin's sugg. Removing reverse (cyclic) prompt augmetation.

### DIFF
--- a/templates/paws-x/en/templates.yaml
+++ b/templates/paws-x/en/templates.yaml
@@ -1,12 +1,6 @@
 dataset: paws-x
 subset: en
 templates:
-  289448c3-63fc-4904-8387-86d232424243: !Template
-    id: 289448c3-63fc-4904-8387-86d232424243
-    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence2}} \n{% endif\
-      \ %}\n||| \n{{sentence1}} "
-    name: paraphrase-task-reverse
-    reference: Create a generative paraphrase task
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\

--- a/templates/paws/labeled_final/templates.yaml
+++ b/templates/paws/labeled_final/templates.yaml
@@ -1,12 +1,6 @@
 dataset: paws
 subset: labeled_final
 templates:
-  289448c3-63fc-4904-8387-86d232424243: !Template
-    id: 289448c3-63fc-4904-8387-86d232424243
-    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence2}} \n{% endif\
-      \ %}\n||| \n{{sentence1}} "
-    name: paraphrase-task-reverse
-    reference: Create a generative paraphrase task
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\

--- a/templates/paws/labeled_swap/templates.yaml
+++ b/templates/paws/labeled_swap/templates.yaml
@@ -1,12 +1,6 @@
 dataset: paws
 subset: labeled_swap
 templates:
-  289448c3-63fc-4904-8387-86d232424243: !Template
-    id: 289448c3-63fc-4904-8387-86d232424243
-    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence2}} \n{% endif\
-      \ %}\n||| \n{{sentence1}} "
-    name: paraphrase-task-reverse
-    reference: Create a generative paraphrase task
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\

--- a/templates/paws/unlabeled_final/templates.yaml
+++ b/templates/paws/unlabeled_final/templates.yaml
@@ -1,12 +1,6 @@
 dataset: paws
 subset: unlabeled_final
 templates:
-  289448c3-63fc-4904-8387-86d232424243: !Template
-    id: 289448c3-63fc-4904-8387-86d232424243
-    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence2}} \n{% endif\
-      \ %}\n||| \n{{sentence1}} "
-    name: paraphrase-task-reverse
-    reference: Create a generative paraphrase task
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\


### PR DESCRIPTION
Earlier I added generation samples by, A -> B and then B -> A.
As suggested by @craffel, this might create a memorization problem. So removing, duplicate pairs.