### PR TITLE
Add Poem Sentiment Dataset

### DIFF
--- a/templates/poem_sentiment/templates.yaml
+++ b/templates/poem_sentiment/templates.yaml
@@ -48,13 +48,13 @@ templates:
     reference: ''
   e53d2fe8-b83b-484e-81f9-efca32bd7012: !Template
     id: e53d2fe8-b83b-484e-81f9-efca32bd7012
-    jinja: '{{verse_text}} The poem expresses {{ ["negative", "positive","no_impact","mixed"]
+    jinja: '{{verse_text}} The poem expresses ||| {{ ["negative", "positive","no_impact","mixed"]
       [label] }} sentiment.'
     name: poem_sentiment_7
     reference: ''
   fdbebd3d-6517-4be1-8771-489e2de658ef: !Template
     id: fdbebd3d-6517-4be1-8771-489e2de658ef
-    jinja: '{{verse_text}} The poet wants the readers to feel {{ ["negative", "positive","no_impact","mixed"]
-      [label] }} sentiment.'
+    jinja: '{{verse_text}} The poet wants the readers to feel ||| {{ ["negative",
+      "positive","no_impact","mixed"] [label] }} sentiment.'
     name: poem_sentiment_8
     reference: ''

--- a/templates/poem_sentiment/templates.yaml
+++ b/templates/poem_sentiment/templates.yaml
@@ -1,0 +1,60 @@
+dataset: poem_sentiment
+templates:
+  211c0765-1f51-4574-b354-040273ea7c38: !Template
+    id: 211c0765-1f51-4574-b354-040273ea7c38
+    jinja: '{{verse_text}} How does the reader feel about this poem? |||  {{ ["negative",
+      "positive","no_impact","mixed"] [label] }}'
+    name: poem_sentiment_5
+    reference: ''
+  2714baf0-5d19-4781-a60f-f44cd95935f7: !Template
+    id: 2714baf0-5d19-4781-a60f-f44cd95935f7
+    jinja: '{{verse_text}} What sentiment does the poet express for the poem? |||  {{
+      ["negative", "positive","no_impact","mixed"] [label] }}'
+    name: poem_sentiment_6
+    reference: ''
+  574ab816-b0bc-4049-a5a5-dcf8f4280dc5: !Template
+    id: 574ab816-b0bc-4049-a5a5-dcf8f4280dc5
+    jinja: The following poem expresses what sentiment? {{verse_text}} ||| {{ ["negative",
+      "positive","no_impact","mixed"] [label] }}
+    name: poem_sentiment_3
+    reference: ''
+  7801d04c-4f42-4411-a552-9614c8c3fd53: !Template
+    id: 7801d04c-4f42-4411-a552-9614c8c3fd53
+    jinja: '{{verse_text}} The sentiment expressed in the poem is |||  {{ ["negative",
+      "positive","no_impact","mixed"] [label] }}'
+    name: poem_sentiment_2
+    reference: ''
+  99982263-04c0-4bac-915d-7265521f8a37: !Template
+    id: 99982263-04c0-4bac-915d-7265521f8a37
+    jinja: '{{verse_text}} What is the sentiment expressed in this poem? |||  {{ ["negative",
+      "positive","neutral","mixed"] [label] }}
+
+      '
+    name: poem_sentiment_9
+    reference: ''
+  9fa8eeb4-314b-4850-a28b-0f53bca006d8: !Template
+    id: 9fa8eeb4-314b-4850-a28b-0f53bca006d8
+    jinja: '{{verse_text}} What is the sentiment expressed in this poem? |||  {{ ["negative",
+      "positive","no_impact","mixed"] [label] }}
+
+      '
+    name: poem_sentiment_1
+    reference: ''
+  aecb3d13-ff68-4e60-a382-87191940bd5b: !Template
+    id: aecb3d13-ff68-4e60-a382-87191940bd5b
+    jinja: '{{verse_text}} What is the sentiment expressed by the poet? |||  {{ ["negative",
+      "positive","no_impact","mixed"] [label] }}'
+    name: poem_sentiment_4
+    reference: ''
+  e53d2fe8-b83b-484e-81f9-efca32bd7012: !Template
+    id: e53d2fe8-b83b-484e-81f9-efca32bd7012
+    jinja: '{{verse_text}} The poem expresses {{ ["negative", "positive","no_impact","mixed"]
+      [label] }} sentiment.'
+    name: poem_sentiment_7
+    reference: ''
+  fdbebd3d-6517-4be1-8771-489e2de658ef: !Template
+    id: fdbebd3d-6517-4be1-8771-489e2de658ef
+    jinja: '{{verse_text}} The poet wants the readers to feel {{ ["negative", "positive","no_impact","mixed"]
+      [label] }} sentiment.'
+    name: poem_sentiment_8
+    reference: ''

--- a/templates/poem_sentiment/templates.yaml
+++ b/templates/poem_sentiment/templates.yaml
@@ -3,25 +3,25 @@ templates:
   211c0765-1f51-4574-b354-040273ea7c38: !Template
     id: 211c0765-1f51-4574-b354-040273ea7c38
     jinja: '{{verse_text}} How does the reader feel about this poem? |||  {{ ["negative",
-      "positive","no_impact","mixed"] [label] }}'
+      "positive","no impact","mixed"] [label] }}'
     name: poem_sentiment_5
     reference: ''
   2714baf0-5d19-4781-a60f-f44cd95935f7: !Template
     id: 2714baf0-5d19-4781-a60f-f44cd95935f7
     jinja: '{{verse_text}} What sentiment does the poet express for the poem? |||  {{
-      ["negative", "positive","no_impact","mixed"] [label] }}'
+      ["negative", "positive","no impact","mixed"] [label] }}'
     name: poem_sentiment_6
     reference: ''
   574ab816-b0bc-4049-a5a5-dcf8f4280dc5: !Template
     id: 574ab816-b0bc-4049-a5a5-dcf8f4280dc5
     jinja: The following poem expresses what sentiment? {{verse_text}} ||| {{ ["negative",
-      "positive","no_impact","mixed"] [label] }}
+      "positive","no impact","mixed"] [label] }}
     name: poem_sentiment_3
     reference: ''
   7801d04c-4f42-4411-a552-9614c8c3fd53: !Template
     id: 7801d04c-4f42-4411-a552-9614c8c3fd53
     jinja: '{{verse_text}} The sentiment expressed in the poem is |||  {{ ["negative",
-      "positive","no_impact","mixed"] [label] }}'
+      "positive","no impact","mixed"] [label] }}'
     name: poem_sentiment_2
     reference: ''
   99982263-04c0-4bac-915d-7265521f8a37: !Template
@@ -35,7 +35,7 @@ templates:
   9fa8eeb4-314b-4850-a28b-0f53bca006d8: !Template
     id: 9fa8eeb4-314b-4850-a28b-0f53bca006d8
     jinja: '{{verse_text}} What is the sentiment expressed in this poem? |||  {{ ["negative",
-      "positive","no_impact","mixed"] [label] }}
+      "positive","no impact","mixed"] [label] }}
 
       '
     name: poem_sentiment_1
@@ -43,18 +43,18 @@ templates:
   aecb3d13-ff68-4e60-a382-87191940bd5b: !Template
     id: aecb3d13-ff68-4e60-a382-87191940bd5b
     jinja: '{{verse_text}} What is the sentiment expressed by the poet? |||  {{ ["negative",
-      "positive","no_impact","mixed"] [label] }}'
+      "positive","no impact","mixed"] [label] }}'
     name: poem_sentiment_4
     reference: ''
   e53d2fe8-b83b-484e-81f9-efca32bd7012: !Template
     id: e53d2fe8-b83b-484e-81f9-efca32bd7012
-    jinja: '{{verse_text}} The poem expresses ||| {{ ["negative", "positive","no_impact","mixed"]
+    jinja: '{{verse_text}} The poem expresses ||| {{ ["negative", "positive","no impact","mixed"]
       [label] }} sentiment.'
     name: poem_sentiment_7
     reference: ''
   fdbebd3d-6517-4be1-8771-489e2de658ef: !Template
     id: fdbebd3d-6517-4be1-8771-489e2de658ef
     jinja: '{{verse_text}} The poet wants the readers to feel ||| {{ ["negative",
-      "positive","no_impact","mixed"] [label] }} sentiment.'
+      "positive","no impact","mixed"] [label] }} sentiment.'
     name: poem_sentiment_8
     reference: ''

--- a/templates/poem_sentiment/templates.yaml
+++ b/templates/poem_sentiment/templates.yaml
@@ -51,7 +51,7 @@ templates:
     id: e53d2fe8-b83b-484e-81f9-efca32bd7012
     jinja: '{{verse_text}} Out of {{"negative"}}, {{"positive"}}, {{"neutral"}} and
       {{"mixed"}} sentiments, the poem expresses ||| {{ ["negative", "positive","neutral","mixed"]
-      [label] }} sentiment.'
+      [label] }} sentiments.'
     name: poem_sentiment_7
     reference: ''
   f87a7ba0-11f7-41f9-bee6-94d0ad6e597a: !Template
@@ -64,6 +64,6 @@ templates:
   fdbebd3d-6517-4be1-8771-489e2de658ef: !Template
     id: fdbebd3d-6517-4be1-8771-489e2de658ef
     jinja: '{{verse_text}} The poet wants the readers to feel ||| {{ ["negative",
-      "positive","neutral","mixed"] [label] }} sentiment.'
+      "positive","neutral","mixed"] [label] }} sentiments.'
     name: poem_sentiment_8
     reference: ''

--- a/templates/poem_sentiment/templates.yaml
+++ b/templates/poem_sentiment/templates.yaml
@@ -3,58 +3,67 @@ templates:
   211c0765-1f51-4574-b354-040273ea7c38: !Template
     id: 211c0765-1f51-4574-b354-040273ea7c38
     jinja: '{{verse_text}} How does the reader feel about this poem? |||  {{ ["negative",
-      "positive","no impact","mixed"] [label] }}'
+      "positive","neutral","mixed"] [label] }}'
     name: poem_sentiment_5
     reference: ''
   2714baf0-5d19-4781-a60f-f44cd95935f7: !Template
     id: 2714baf0-5d19-4781-a60f-f44cd95935f7
-    jinja: '{{verse_text}} What sentiment does the poet express for the poem? |||  {{
-      ["negative", "positive","no impact","mixed"] [label] }}'
+    jinja: '{{verse_text}} Is the sentiment the poet express for the poem {{"negative"}},
+      {{"positive"}}, {{"neutral"}} or {{"mixed"}}? |||  {{ ["negative", "positive","neutral","mixed"]
+      [label] }}'
     name: poem_sentiment_6
     reference: ''
   574ab816-b0bc-4049-a5a5-dcf8f4280dc5: !Template
     id: 574ab816-b0bc-4049-a5a5-dcf8f4280dc5
     jinja: The following poem expresses what sentiment? {{verse_text}} ||| {{ ["negative",
-      "positive","no impact","mixed"] [label] }}
+      "positive","neutral","mixed"] [label] }}
     name: poem_sentiment_3
     reference: ''
   7801d04c-4f42-4411-a552-9614c8c3fd53: !Template
     id: 7801d04c-4f42-4411-a552-9614c8c3fd53
     jinja: '{{verse_text}} The sentiment expressed in the poem is |||  {{ ["negative",
-      "positive","no impact","mixed"] [label] }}'
+      "positive","neutral","mixed"] [label] }}'
     name: poem_sentiment_2
-    reference: ''
-  99982263-04c0-4bac-915d-7265521f8a37: !Template
-    id: 99982263-04c0-4bac-915d-7265521f8a37
-    jinja: '{{verse_text}} What is the sentiment expressed in this poem? |||  {{ ["negative",
-      "positive","neutral","mixed"] [label] }}
-
-      '
-    name: poem_sentiment_9
     reference: ''
   9fa8eeb4-314b-4850-a28b-0f53bca006d8: !Template
     id: 9fa8eeb4-314b-4850-a28b-0f53bca006d8
     jinja: '{{verse_text}} What is the sentiment expressed in this poem? |||  {{ ["negative",
-      "positive","no impact","mixed"] [label] }}
+      "positive","neutral","mixed"] [label] }}
 
       '
     name: poem_sentiment_1
     reference: ''
   aecb3d13-ff68-4e60-a382-87191940bd5b: !Template
     id: aecb3d13-ff68-4e60-a382-87191940bd5b
-    jinja: '{{verse_text}} What is the sentiment expressed by the poet? |||  {{ ["negative",
-      "positive","no impact","mixed"] [label] }}'
+    jinja: '{{verse_text}} The most appropriate word out of {{"negative"}}, {{"positive"}},
+      {{"neutral"}} and {{"mixed"}}, which express the poet''s sentiment is: |||  {{
+      ["negative", "positive","neutral","mixed"] [label] }}'
     name: poem_sentiment_4
+    reference: ''
+  ca15cecb-4ee6-4445-a0f4-6ef5cd519923: !Template
+    id: ca15cecb-4ee6-4445-a0f4-6ef5cd519923
+    jinja: "{{verse_text}} What sentiement does this poem express? \nOptions: {{\"\
+      negative\"}}, {{\"positive\"}}, {{\"neutral\"}},{{\"mixed\"}}.\nAnswer:  |||\
+      \ {{ [\"negative\",\"positive\",\"neutral\",\"mixed\"] [label] }}"
+    name: poem_sentiment_10
     reference: ''
   e53d2fe8-b83b-484e-81f9-efca32bd7012: !Template
     id: e53d2fe8-b83b-484e-81f9-efca32bd7012
-    jinja: '{{verse_text}} The poem expresses ||| {{ ["negative", "positive","no impact","mixed"]
+    jinja: '{{verse_text}} Out of {{"negative"}}, {{"positive"}}, {{"neutral"}} and
+      {{"mixed"}} sentiments, the poem expresses ||| {{ ["negative", "positive","neutral","mixed"]
       [label] }} sentiment.'
     name: poem_sentiment_7
+    reference: ''
+  f87a7ba0-11f7-41f9-bee6-94d0ad6e597a: !Template
+    id: f87a7ba0-11f7-41f9-bee6-94d0ad6e597a
+    jinja: Does this poem express a {{"negative"}}, {{"positive"}}, {{"neutral"}}
+      or {{"mixed"}} sentiment? {{verse_text}} ||| {{ ["negative", "positive","neutral","mixed"]
+      [label] }}
+    name: poem_sentiment_9
     reference: ''
   fdbebd3d-6517-4be1-8771-489e2de658ef: !Template
     id: fdbebd3d-6517-4be1-8771-489e2de658ef
     jinja: '{{verse_text}} The poet wants the readers to feel ||| {{ ["negative",
-      "positive","no impact","mixed"] [label] }} sentiment.'
+      "positive","neutral","mixed"] [label] }} sentiment.'
     name: poem_sentiment_8
     reference: ''


### PR DESCRIPTION
An overview of this PR:

1. Templates 1-6 are similar to the ones from IMDb's template.
2. Templates 7 and 8 constitute of variation in localization of the label
3. In template 9 I have replaced the label "no_impact" with "neutral". 

I have two questions:
1. Should we replace all "no_impact" labels with "neutral". The original example provided on the streamlit app has the former.
2. Should I add a template that includes negation. For example, after the poem the prompt will be : The sentiment the poem does not express is <any label except for the correct label>. With reference to the "Language Models are Few-Shot Learners" paper, GPT-3 does not perform well on "negation" tasks like these. Does it make sense to include it in the template here for this dataset? 