### PR TITLE
Add a new task template field for fields corresponding to the original task.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,7 @@ combined to form different (input, output) pairs i.e. different "tasks". Don't h
 introduce some diversity by prompting a given dataset into multiple tasks and provide some
 description in the "Template Reference" text box. An example is given
 in the already prompted `movie_rationales`.
+* **Task Template Checkbox** While there are many different ways to prompt the tasks, only some of them correspond to the original intention of the dataset. For instance, for a summary dataset you can generate a summary or hallucinate an article. However, only the first was the true original task for the dataset. Use the *Task template* check box to indicate true task prompts. (We realize there are some corner cases, for instance, if there was no original task, you should leave this blank. If there are multiple original tasks you can check it for each of them. If you are confused for your dataset, consult with us in slack.) 
 * **Filtering templates.** If a template is applied to an example and produces an
 empty string, that template/example pair will be skipped. (Either the entire output
 is whitespace or the text on either side of the separator `|||` is whitespace.

--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -376,7 +376,7 @@ else:
                             help="Short description of the template and/or paper reference for the template.",
                             value=template.reference,
                         )
-
+                        state.task_template = st.checkbox("Task Template?", value=template.get_task_template(), help="Task templates correspond one-to-one with the original task.")
                         state.jinja = st.text_area("Template", height=40, value=template.jinja)
 
                         if st.form_submit_button("Save"):
@@ -392,7 +392,7 @@ else:
                                 st.error("Need to provide a template name.")
                             else:
                                 dataset_templates.update_template(
-                                    state.template_name, updated_template_name, state.jinja, state.reference
+                                    state.template_name, updated_template_name, state.jinja, state.reference, state.task_template
                                 )
                                 # Update the state as well
                                 state.template_name = updated_template_name

--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -390,7 +390,11 @@ else:
                             help="Short description of the template and/or paper reference for the template.",
                             value=template.reference,
                         )
-                        state.task_template = st.checkbox("Task Template?", value=template.get_task_template(), help="Task templates correspond one-to-one with the original task.")
+                        state.task_template = st.checkbox(
+                            "Task Template?",
+                            value=template.get_task_template(),
+                            help="Task templates correspond one-to-one with the original task.",
+                        )
                         state.jinja = st.text_area("Template", height=40, value=template.jinja)
 
                         if st.form_submit_button("Save"):
@@ -406,7 +410,11 @@ else:
                                 st.error("Need to provide a template name.")
                             else:
                                 dataset_templates.update_template(
-                                    state.template_name, updated_template_name, state.jinja, state.reference, state.task_template
+                                    state.template_name,
+                                    updated_template_name,
+                                    state.jinja,
+                                    state.reference,
+                                    state.task_template,
                                 )
                                 # Update the state as well
                                 state.template_name = updated_template_name

--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -105,6 +105,7 @@ if mode == "Helicopter view":
                 "Dataset name": dataset_name,
                 "Subset name": "" if subset_name is None else subset_name,
                 "Number of templates": len(dataset_templates),
+                "Number of task templates": sum([t.get_task_template() for t in dataset_templates.templates.values()]),
                 "Template names": [t.name for t in dataset_templates.templates.values()],
                 # TODO: template name is not very informative... refine that
             }
@@ -269,6 +270,8 @@ else:
                 st.text(template.name)
                 st.markdown("##### Reference")
                 st.text(template.reference)
+                st.markdown("##### Task Template? ")
+                st.text(template.get_task_template())
                 st.markdown("##### Jinja")
                 splitted_template = template.jinja.split("|||")
                 st.markdown("###### Prompt + X")

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -197,7 +197,7 @@ class DatasetTemplates:
             # We just update the file
             self.write_to_file()
 
-    def update_template(self, current_template_name: str, new_template_name: str, jinja: str, reference: str) -> None:
+    def update_template(self, current_template_name: str, new_template_name: str, jinja: str, reference: str, task_template: bool) -> None:
         """
         Updates a pre-existing template and writes changes
 
@@ -210,6 +210,7 @@ class DatasetTemplates:
         self.templates[template_id].name = new_template_name
         self.templates[template_id].jinja = jinja
         self.templates[template_id].reference = reference
+        self.templates[template_id].task_template = task_template
 
         self.write_to_file()
 
@@ -242,7 +243,7 @@ class Template(yaml.YAMLObject):
 
     yaml_tag = "!Template"
 
-    def __init__(self, name, jinja, reference):
+    def __init__(self, name, jinja, reference, task_template=False):
         """
         Creates a prompt template.
 
@@ -263,6 +264,7 @@ class Template(yaml.YAMLObject):
         self.name = name
         self.jinja = jinja
         self.reference = reference
+        self.task_template = task_template
 
     def get_id(self):
         """
@@ -288,6 +290,12 @@ class Template(yaml.YAMLObject):
         """
         return self.reference
 
+    def get_task_template(self):
+        if hasattr(self, "task_template"):
+            return self.task_template
+        else:
+            return False
+    
     def apply(self, example, highlight_variables=False):
         """
         Creates a prompt by applying this template to an example

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -197,7 +197,9 @@ class DatasetTemplates:
             # We just update the file
             self.write_to_file()
 
-    def update_template(self, current_template_name: str, new_template_name: str, jinja: str, reference: str, task_template: bool) -> None:
+    def update_template(
+        self, current_template_name: str, new_template_name: str, jinja: str, reference: str, task_template: bool
+    ) -> None:
         """
         Updates a pre-existing template and writes changes
 
@@ -259,6 +261,8 @@ class Template(yaml.YAMLObject):
         :param jinja: template expressed in Jinja
         :param reference: string metadata describing author or paper reference
                           for template
+        :param task_template: bool whether this template corresponds 1-1 with the dataset task
+
         """
         self.id = str(uuid.uuid4())
         self.name = name
@@ -291,11 +295,17 @@ class Template(yaml.YAMLObject):
         return self.reference
 
     def get_task_template(self):
+        """
+        Returns whether this template corresponds 1-1 with the dataset task
+
+        :return: bool
+        """
+
         if hasattr(self, "task_template"):
             return self.task_template
         else:
             return False
-    
+
     def apply(self, example, highlight_variables=False):
         """
         Creates a prompt by applying this template to an example

--- a/templates/cnn_dailymail/3.0.0/templates.yaml
+++ b/templates/cnn_dailymail/3.0.0/templates.yaml
@@ -11,6 +11,7 @@ templates:
       {{highlights}}'
     name: news_summary
     reference: ''
+    task_template: true
   9b7c6abf-5110-4b31-8345-be6b2eeea580: !Template
     id: 9b7c6abf-5110-4b31-8345-be6b2eeea580
     jinja: 'Condense the article down to the essentials to present it in the form
@@ -22,6 +23,7 @@ templates:
       {{highlights}}'
     name: news_card_view
     reference: ''
+    task_template: true
   b4ff2f63-8539-4d9c-9858-42fa5f95ba56: !Template
     id: b4ff2f63-8539-4d9c-9858-42fa5f95ba56
     jinja: 'Generate a story from key plot points:
@@ -43,6 +45,7 @@ templates:
       {{highlights}}'
     name: news_stock
     reference: ''
+    task_template: true
   efa42de6-7a20-4e35-92fc-919a5eb0b77e: !Template
     id: efa42de6-7a20-4e35-92fc-919a5eb0b77e
     jinja: 'What details would you include in a storyline to make it more engaging

--- a/test/show_templates.py
+++ b/test/show_templates.py
@@ -27,6 +27,17 @@ template_list = dataset_templates.all_template_names
 
 width = 80
 print("DATASET ", args.dataset_path)
+
+# First show all the templates.
+for template_name in template_list:
+    template = dataset_templates[template_name]
+    print("TEMPLATE")
+    print("NAME:", template_name)
+    print("Is Task Template: ", template.get_task_template())
+    print(template.jinja)
+    print()
+
+# Show examples of the templates.
 for template_name in template_list:
     template = dataset_templates[template_name]
     print()

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -35,9 +35,10 @@ def test_dataset(dataset):
 
     # Iterates over each template for current data (sub)set
     dataset_templates = template_collection.get_dataset(dataset_name, subset_name)
+    any_task = False
     for template_name in dataset_templates.all_template_names:
         template = dataset_templates[template_name]
-
+        any_task = any_task or template.get_task_template()
         # Check 1: Jinja and all features valid?
         try:
             parse = env.parse(template.jinja)
@@ -67,3 +68,5 @@ def test_dataset(dataset):
 
         template_name_set.add(template.get_name())
         template_jinja_set.add(template.jinja)
+
+    assert any_task, "There must be at least one task template for each dataset"

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -69,4 +69,5 @@ def test_dataset(dataset):
         template_name_set.add(template.get_name())
         template_jinja_set.add(template.jinja)
 
-    assert any_task, "There must be at least one task template for each dataset"
+    # Turned off for now until we fix.
+    #assert any_task, "There must be at least one task template for each dataset"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/35882/121405235-cbcdbe80-c92a-11eb-9534-4e11a8454ab0.png)

There are a bunch of templates that are clever, but do not correspond to the original proposed task. This makes users mark them explicitly. 