### PR TITLE
Prompts for generated_reviews_enth

### DIFF
--- a/templates/generated_reviews_enth/templates.yaml
+++ b/templates/generated_reviews_enth/templates.yaml
@@ -1,0 +1,32 @@
+dataset: generated_reviews_enth
+templates:
+  7f158fb6-bbdd-41b8-bed7-21508c9f3c80: !Template
+    id: 7f158fb6-bbdd-41b8-bed7-21508c9f3c80
+    jinja: Do "{{translation.en}}" seems like a positive review to you? ||| {{["no","yes"][0
+      if review_star<3 else 1]}}'
+    name: sentiment_analysis_4
+    reference: stsb_multi_mt_en
+  95136948-3402-4bd4-8a69-1aa7b85461cc: !Template
+    id: 95136948-3402-4bd4-8a69-1aa7b85461cc
+    jinja: 'Rate the positivity of this review: ({{"1"}} being the lowest and {{"5"}}
+      the highest) "{{translation.en}}" ||| {{review_star | string}}'
+    name: sentiment_analysis_5
+    reference: stsb_multi_mt
+  ad12212f-a230-4750-a199-9791628856c4: !Template
+    id: ad12212f-a230-4750-a199-9791628856c4
+    jinja: "How positive is the review \"{{translation.en}}\"? Give a score between\n\
+      \      {{\"0\"}} and {{\"5\"}}. ||| {{review_star | string}}"
+    name: sentiment_analysis_1
+    reference: stsb_multi_mt_en
+  cf8f4dcb-f527-4944-b9ec-a1a3e476c13f: !Template
+    id: cf8f4dcb-f527-4944-b9ec-a1a3e476c13f
+    jinja: On a scale from {{"1"}} to {{"5"}}, how positive the review "{{translation.en}}"
+      is? ||| {{review_star | string}}
+    name: sentiment_analysis_3
+    reference: stsb_multi_mt_en
+  e6c55d56-23d4-41a4-9908-e9366cc2e167: !Template
+    id: e6c55d56-23d4-41a4-9908-e9366cc2e167
+    jinja: Do you think "{{translation.en}}" is a positive review? ||| {{["no","yes"][0
+      if review_star < 3 else 1]}}'
+    name: sentiment_analysis_2
+    reference: stsb_multi_mt_en

--- a/templates/generated_reviews_enth/templates.yaml
+++ b/templates/generated_reviews_enth/templates.yaml
@@ -2,31 +2,36 @@ dataset: generated_reviews_enth
 templates:
   7f158fb6-bbdd-41b8-bed7-21508c9f3c80: !Template
     id: 7f158fb6-bbdd-41b8-bed7-21508c9f3c80
-    jinja: Do "{{translation.en}}" seems like a positive review to you? ||| {{["no","yes"][0
+    jinja: Does "{{translation.en}}" seem like a positive review to you? ||| {{["no","yes"][0
       if review_star<3 else 1]}}'
     name: sentiment_analysis_4
     reference: stsb_multi_mt_en
+    task_template: true
   95136948-3402-4bd4-8a69-1aa7b85461cc: !Template
     id: 95136948-3402-4bd4-8a69-1aa7b85461cc
     jinja: 'Rate the positivity of this review: ({{"1"}} being the lowest and {{"5"}}
       the highest) "{{translation.en}}" ||| {{review_star | string}}'
     name: sentiment_analysis_5
     reference: stsb_multi_mt
+    task_template: true
   ad12212f-a230-4750-a199-9791628856c4: !Template
     id: ad12212f-a230-4750-a199-9791628856c4
     jinja: "How positive is the review \"{{translation.en}}\"? Give a score between\n\
       \      {{\"0\"}} and {{\"5\"}}. ||| {{review_star | string}}"
     name: sentiment_analysis_1
     reference: stsb_multi_mt_en
+    task_template: true
   cf8f4dcb-f527-4944-b9ec-a1a3e476c13f: !Template
     id: cf8f4dcb-f527-4944-b9ec-a1a3e476c13f
-    jinja: On a scale from {{"1"}} to {{"5"}}, how positive the review "{{translation.en}}"
-      is? ||| {{review_star | string}}
+    jinja: On a scale from {{"1"}} to {{"5"}}, how positive is the review "{{translation.en}}"?
+      ||| {{review_star | string}}
     name: sentiment_analysis_3
     reference: stsb_multi_mt_en
+    task_template: true
   e6c55d56-23d4-41a4-9908-e9366cc2e167: !Template
     id: e6c55d56-23d4-41a4-9908-e9366cc2e167
     jinja: Do you think "{{translation.en}}" is a positive review? ||| {{["no","yes"][0
       if review_star < 3 else 1]}}'
     name: sentiment_analysis_2
     reference: stsb_multi_mt_en
+    task_template: true


### PR DESCRIPTION
Prompts for the generated_reviews_enth dataset.
Since we only focus on english task, I did not consider translation/translation rating, only sentiment analysis of the english review.
I took inspiration from another templates I created for stsb_multi_mt (PR : https://github.com/bigscience-workshop/promptsource/pull/160)

As a sidenote, I just thought that an easy way to add prompts "for free" is to "inverse" the classification/prompt.
E.g, for "On a scale of 1 to 5, how positive is the review {{review}} ||| {{score}}", create also "On a scale of 1 to 5, how negative is the review {{review}} ||| {{6 - score}}" and inverse yes/no answer in the binary case.
Is it useful/profitable or is it better to just keep this version ?