### PR TITLE
Add go emotions templates

### DIFF
--- a/templates/go_emotions/raw/templates.yaml
+++ b/templates/go_emotions/raw/templates.yaml
@@ -26,6 +26,7 @@ templates:
       {% endif %}"
     name: get_all_sentiments_from_text
     reference: Given the text, provide all the sentiments.
+    task_template: false
   c0a0af62-9282-4bb4-9aed-883d2a0e9a8d: !Template
     id: c0a0af62-9282-4bb4-9aed-883d2a0e9a8d
     jinja:
@@ -48,6 +49,7 @@ templates:
     reference:
       Given the text and asked about a random sentiment, answer whether the
       text has that sentiment or not.
+    task_template: true
   fa307ac0-67ba-49f5-ab87-795491d2b9d1: !Template
     id: fa307ac0-67ba-49f5-ab87-795491d2b9d1
     jinja: "{% set sentiment_dict\
@@ -74,3 +76,4 @@ templates:
       \ %}"
     name: get_single_sentiment_from_text
     reference: Given the text, describe the sentiment in a single word.
+    task_template: false

--- a/templates/go_emotions/raw/templates.yaml
+++ b/templates/go_emotions/raw/templates.yaml
@@ -3,9 +3,7 @@ subset: raw
 templates:
   8a80ad98-6785-46d8-a68b-c27d1c173fcd: !Template
     id: 8a80ad98-6785-46d8-a68b-c27d1c173fcd
-    jinja:
-      "What do you think the person was feeling when he wrote this:  {{ text\
-      \ }}?\n|||\n{% if example_very_unclear %}\nunclear\n{% else %}\n{% set sentiment_dict\
+    jinja: "{% set sentiment_dict\
       \ = ({\n    \"admiration\": admiration,\n    \"amusement\": amusement,\n   \
       \ \"anger\": anger,\n    \"annoyance\": annoyance,\n    \"approval\": approval,\n\
       \    \"author\": author,\n    \"caring\": caring,\n    \"confusion\": confusion,\n\
@@ -16,8 +14,12 @@ templates:
       \   \"joy\": joy,\n    \"love\": love,\n    \"nervousness\": nervousness,\n\
       \    \"neutral\": neutral,\n    \"optimism\": optimism,\n    \"pride\": pride,\n\
       \    \"realization\": realization,\n    \"relief\": relief,\n    \"remorse\"\
-      : remorse,\n    \"sadness\": sadness,\n    \"surprise\": surprise,\n}) %}\n\
-      {% set current_sentiment_list = [] %}\n{% for item,value in sentiment_dict.items()\
+      : remorse,\n    \"sadness\": sadness,\n    \"surprise\": surprise,\n}) %}
+
+      {% set current_sentiment_list = [] %}
+
+      What do you think the person was feeling when he wrote this:  {{ text\
+      \ }}?\n|||\n{% if example_very_unclear %}\nunclear\n{% else %}\n{% for item,value in sentiment_dict.items()\
       \ %}\n{% if value==1 %}\n{% set current_sentiment_list = current_sentiment_list.append(item)\
       \ %}\n{% endif %}\n{% endfor %}\n{% if current_sentiment_list|length == 0 %}\n\
       unclear\n{% else %}\n{{ current_sentiment_list|join(', ') }}\n{% endif %}\n\
@@ -48,8 +50,7 @@ templates:
       text has that sentiment or not.
   fa307ac0-67ba-49f5-ab87-795491d2b9d1: !Template
     id: fa307ac0-67ba-49f5-ab87-795491d2b9d1
-    jinja: "Describe the sentiment of this text in one word:  {{ text\
-      \ }}?\n|||\n{% if example_very_unclear %}\nunclear\n{% else %}\n{% set sentiment_dict\
+    jinja: "{% set sentiment_dict\
       \ = ({\n    \"admiration\": admiration,\n    \"amusement\": amusement,\n   \
       \ \"anger\": anger,\n    \"annoyance\": annoyance,\n    \"approval\": approval,\n\
       \    \"author\": author,\n    \"caring\": caring,\n    \"confusion\": confusion,\n\
@@ -60,8 +61,13 @@ templates:
       \   \"joy\": joy,\n    \"love\": love,\n    \"nervousness\": nervousness,\n\
       \    \"neutral\": neutral,\n    \"optimism\": optimism,\n    \"pride\": pride,\n\
       \    \"realization\": realization,\n    \"relief\": relief,\n    \"remorse\"\
-      : remorse,\n    \"sadness\": sadness,\n    \"surprise\": surprise,\n}) %}\n\
-      {% set current_sentiment_list = [] %}\n{% for item,value in sentiment_dict.items()\
+      : remorse,\n    \"sadness\": sadness,\n    \"surprise\": surprise,\n}) %}
+
+      {% set current_sentiment_list = [] %}
+
+      Describe the sentiment of this text in one word:  {{ text\
+      \ }}?\n|||\n{% if example_very_unclear %}\nunclear\n{% else %}\n\
+      \n{% for item,value in sentiment_dict.items()\
       \ %}\n{% if value==1 %}\n{% set current_sentiment_list = current_sentiment_list.append(item)\
       \ %}\n{% endif %}\n{% endfor %}\n{% if current_sentiment_list|length == 0 %}\n\
       unclear\n{% else %}\n{{ current_sentiment_list|random }}\n{% endif %}\n{% endif\

--- a/templates/go_emotions/raw/templates.yaml
+++ b/templates/go_emotions/raw/templates.yaml
@@ -1,0 +1,70 @@
+dataset: go_emotions
+subset: raw
+templates:
+  8a80ad98-6785-46d8-a68b-c27d1c173fcd: !Template
+    id: 8a80ad98-6785-46d8-a68b-c27d1c173fcd
+    jinja:
+      "What do you think the person was feeling when he wrote this:  {{ text\
+      \ }}?\n|||\n{% if example_very_unclear %}\nunclear\n{% else %}\n{% set sentiment_dict\
+      \ = ({\n    \"admiration\": admiration,\n    \"amusement\": amusement,\n   \
+      \ \"anger\": anger,\n    \"annoyance\": annoyance,\n    \"approval\": approval,\n\
+      \    \"author\": author,\n    \"caring\": caring,\n    \"confusion\": confusion,\n\
+      \    \"curiosity\": curiosity,\n    \"desire\": desire,\n    \"disappointment\"\
+      : disappointment,\n    \"disapproval\": disapproval,\n    \"disgust\": disgust,\n\
+      \    \"embarrassment\": embarrassment,\n    \"excitement\": excitement,\n  \
+      \  \"fear\": fear,\n    \"gratitude\": gratitude,\n    \"grief\": grief,\n \
+      \   \"joy\": joy,\n    \"love\": love,\n    \"nervousness\": nervousness,\n\
+      \    \"neutral\": neutral,\n    \"optimism\": optimism,\n    \"pride\": pride,\n\
+      \    \"realization\": realization,\n    \"relief\": relief,\n    \"remorse\"\
+      : remorse,\n    \"sadness\": sadness,\n    \"surprise\": surprise,\n}) %}\n\
+      {% set current_sentiment_list = [] %}\n{% for item,value in sentiment_dict.items()\
+      \ %}\n{% if value==1 %}\n{% set current_sentiment_list = current_sentiment_list.append(item)\
+      \ %}\n{% endif %}\n{% endfor %}\n{% if current_sentiment_list|length == 0 %}\n\
+      unclear\n{% else %}\n{{ current_sentiment_list|join(', ') }}\n{% endif %}\n\
+      {% endif %}"
+    name: get_all_sentiments_from_text
+    reference: Given the text, provide all the sentiments.
+  c0a0af62-9282-4bb4-9aed-883d2a0e9a8d: !Template
+    id: c0a0af62-9282-4bb4-9aed-883d2a0e9a8d
+    jinja:
+      "{% set sentiment_dict = ({\n    \"admiration\": admiration,\n    \"amusement\"\
+      : amusement,\n    \"anger\": anger,\n    \"annoyance\": annoyance,\n    \"approval\"\
+      : approval,\n    \"author\": author,\n    \"caring\": caring,\n    \"confusion\"\
+      : confusion,\n    \"curiosity\": curiosity,\n    \"desire\": desire,\n    \"\
+      disappointment\": disappointment,\n    \"disapproval\": disapproval,\n    \"\
+      disgust\": disgust,\n    \"embarrassment\": embarrassment,\n    \"excitement\"\
+      : excitement,\n    \"fear\": fear,\n    \"gratitude\": gratitude,\n    \"grief\"\
+      : grief,\n    \"joy\": joy,\n    \"love\": love,\n    \"nervousness\": nervousness,\n\
+      \    \"neutral\": neutral,\n    \"optimism\": optimism,\n    \"pride\": pride,\n\
+      \    \"realization\": realization,\n    \"relief\": relief,\n    \"remorse\"\
+      : remorse,\n    \"sadness\": sadness,\n    \"surprise\": surprise,\n}) %}\n\
+      {% set random_sentiment = sentiment_dict.keys()|list|random %}\nDo you think\
+      \ the following text has the \"{{random_sentiment}}\" sentiment:  {{ text }}?\n\
+      |||\n{% if example_very_unclear %}\nunclear\n{% else %}\n{% if sentiment_dict[random_sentiment]==1\
+      \ %}\nyes\n{% else %}\nno\n{% endif %}\n{% endif %}"
+    name: true_or_false_sentiment
+    reference:
+      Given the text and asked about a random sentiment, answer whether the
+      text has that sentiment or not.
+  fa307ac0-67ba-49f5-ab87-795491d2b9d1: !Template
+    id: fa307ac0-67ba-49f5-ab87-795491d2b9d1
+    jinja: "Describe the sentiment of this text in one word:  {{ text\
+      \ }}?\n|||\n{% if example_very_unclear %}\nunclear\n{% else %}\n{% set sentiment_dict\
+      \ = ({\n    \"admiration\": admiration,\n    \"amusement\": amusement,\n   \
+      \ \"anger\": anger,\n    \"annoyance\": annoyance,\n    \"approval\": approval,\n\
+      \    \"author\": author,\n    \"caring\": caring,\n    \"confusion\": confusion,\n\
+      \    \"curiosity\": curiosity,\n    \"desire\": desire,\n    \"disappointment\"\
+      : disappointment,\n    \"disapproval\": disapproval,\n    \"disgust\": disgust,\n\
+      \    \"embarrassment\": embarrassment,\n    \"excitement\": excitement,\n  \
+      \  \"fear\": fear,\n    \"gratitude\": gratitude,\n    \"grief\": grief,\n \
+      \   \"joy\": joy,\n    \"love\": love,\n    \"nervousness\": nervousness,\n\
+      \    \"neutral\": neutral,\n    \"optimism\": optimism,\n    \"pride\": pride,\n\
+      \    \"realization\": realization,\n    \"relief\": relief,\n    \"remorse\"\
+      : remorse,\n    \"sadness\": sadness,\n    \"surprise\": surprise,\n}) %}\n\
+      {% set current_sentiment_list = [] %}\n{% for item,value in sentiment_dict.items()\
+      \ %}\n{% if value==1 %}\n{% set current_sentiment_list = current_sentiment_list.append(item)\
+      \ %}\n{% endif %}\n{% endfor %}\n{% if current_sentiment_list|length == 0 %}\n\
+      unclear\n{% else %}\n{{ current_sentiment_list|random }}\n{% endif %}\n{% endif\
+      \ %}"
+    name: get_single_sentiment_from_text
+    reference: Given the text, describe the sentiment in a single word.

--- a/templates/go_emotions/simplified/templates.yaml
+++ b/templates/go_emotions/simplified/templates.yaml
@@ -1,0 +1,51 @@
+dataset: go_emotions
+subset: simplified
+templates:
+  8a80ad98-6785-46d8-a68b-c27d1c173fcd: !Template
+    id: 8a80ad98-6785-46d8-a68b-c27d1c173fcd
+    jinja: "What do you think the person was feeling when he wrote this:  {{ text\
+      \ }}?\n|||\n{% if labels|length==0 %}\nunclear\n{% else %}\n{% set labels_list=\
+      \ ([\n  \"admiration\",\n  \"amusement\",\n  \"anger\",\n  \"annoyance\",\n\
+      \  \"approval\",\n  \"caring\",\n  \"confusion\",\n  \"curiosity\",\n  \"desire\"\
+      ,\n  \"disappointment\",\n  \"disapproval\",\n  \"disgust\",\n  \"embarrassment\"\
+      ,\n  \"excitement\",\n  \"fear\",\n  \"gratitude\",\n  \"grief\",\n  \"joy\"\
+      ,\n  \"love\",\n  \"nervousness\",\n  \"optimism\",\n  \"pride\",\n  \"realization\"\
+      ,\n  \"relief\",\n  \"remorse\",\n  \"sadness\",\n  \"surprise\",\n  \"neutral\"\
+      \n]) %}\n{% set current_sentiment_list = [] %}\n{% for label_index in labels\
+      \ %}\n{% set current_sentiment_list = current_sentiment_list.append(labels_list[label_index])\
+      \ %}\n{% endfor %}\n{% if current_sentiment_list|length == 0 %}\nunclear\n{%\
+      \ else %}\n{{ current_sentiment_list|join(', ') }}\n{% endif %}\n{% endif %}"
+    name: get_all_sentiments_from_text
+    reference: Given the text, provide all the sentiments.
+  c0a0af62-9282-4bb4-9aed-883d2a0e9a8d: !Template
+    id: c0a0af62-9282-4bb4-9aed-883d2a0e9a8d
+    jinja: "{% set labels_list= ([\n  \"admiration\",\n  \"amusement\",\n  \"anger\"\
+      ,\n  \"annoyance\",\n  \"approval\",\n  \"caring\",\n  \"confusion\",\n  \"\
+      curiosity\",\n  \"desire\",\n  \"disappointment\",\n  \"disapproval\",\n  \"\
+      disgust\",\n  \"embarrassment\",\n  \"excitement\",\n  \"fear\",\n  \"gratitude\"\
+      ,\n  \"grief\",\n  \"joy\",\n  \"love\",\n  \"nervousness\",\n  \"optimism\"\
+      ,\n  \"pride\",\n  \"realization\",\n  \"relief\",\n  \"remorse\",\n  \"sadness\"\
+      ,\n  \"surprise\",\n  \"neutral\"\n]) %}\n{% set random_label= range(28)|list|random\
+      \ %}\nDo you think the following text has the \"{{labels_list[random_label]}}\"\
+      \ sentiment:  {{ text }}?\n|||\n{% if example_very_unclear %}\nunclear\n{% else\
+      \ %}\n{% if random_label in labels %}\nyes\n{% else %}\nno\n{% endif %}\n{%\
+      \ endif %}"
+    name: true_or_false_sentiment
+    reference: Given the text and asked about a random sentiment, answer whether the
+      text has that sentiment or not.
+  fa307ac0-67ba-49f5-ab87-795491d2b9d1: !Template
+    id: fa307ac0-67ba-49f5-ab87-795491d2b9d1
+    jinja: "Describe the sentiment of this text in one word:  {{ text }}?\n|||\n{%\
+      \ if labels|length==0 %}\nunclear\n{% else %}\n{% set labels_list= ([\n  \"\
+      admiration\",\n  \"amusement\",\n  \"anger\",\n  \"annoyance\",\n  \"approval\"\
+      ,\n  \"caring\",\n  \"confusion\",\n  \"curiosity\",\n  \"desire\",\n  \"disappointment\"\
+      ,\n  \"disapproval\",\n  \"disgust\",\n  \"embarrassment\",\n  \"excitement\"\
+      ,\n  \"fear\",\n  \"gratitude\",\n  \"grief\",\n  \"joy\",\n  \"love\",\n  \"\
+      nervousness\",\n  \"optimism\",\n  \"pride\",\n  \"realization\",\n  \"relief\"\
+      ,\n  \"remorse\",\n  \"sadness\",\n  \"surprise\",\n  \"neutral\"\n]) %}\n{%\
+      \ set current_sentiment_list = [] %}\n{% for label_index in labels %}\n{% set\
+      \ current_sentiment_list = current_sentiment_list.append(labels_list[label_index])\
+      \ %}\n{% endfor %}\n{% if current_sentiment_list|length == 0 %}\nunclear\n{%\
+      \ else %}\n{{ current_sentiment_list|random}}\n{% endif %}\n{% endif %}"
+    name: get_single_sentiment_from_text
+    reference: Given the text, describe the sentiment in a single word.

--- a/templates/go_emotions/simplified/templates.yaml
+++ b/templates/go_emotions/simplified/templates.yaml
@@ -3,23 +3,26 @@ subset: simplified
 templates:
   8a80ad98-6785-46d8-a68b-c27d1c173fcd: !Template
     id: 8a80ad98-6785-46d8-a68b-c27d1c173fcd
-    jinja: "What do you think the person was feeling when he wrote this:  {{ text\
-      \ }}?\n|||\n{% if labels|length==0 %}\nunclear\n{% else %}\n{% set labels_list=\
+    jinja: "{% set labels_list=\
       \ ([\n  \"admiration\",\n  \"amusement\",\n  \"anger\",\n  \"annoyance\",\n\
       \  \"approval\",\n  \"caring\",\n  \"confusion\",\n  \"curiosity\",\n  \"desire\"\
       ,\n  \"disappointment\",\n  \"disapproval\",\n  \"disgust\",\n  \"embarrassment\"\
       ,\n  \"excitement\",\n  \"fear\",\n  \"gratitude\",\n  \"grief\",\n  \"joy\"\
       ,\n  \"love\",\n  \"nervousness\",\n  \"optimism\",\n  \"pride\",\n  \"realization\"\
       ,\n  \"relief\",\n  \"remorse\",\n  \"sadness\",\n  \"surprise\",\n  \"neutral\"\
-      \n]) %}\n{% set current_sentiment_list = [] %}\n{% for label_index in labels\
+      \n]) %}\n{% set current_sentiment_list = [] %}
+      What do you think the person was feeling when he wrote this:  {{ text\
+      \ }}?\n|||\n{% if labels|length==0 %}\nunclear\n{% else %}\n{% for label_index in labels\
       \ %}\n{% set current_sentiment_list = current_sentiment_list.append(labels_list[label_index])\
       \ %}\n{% endfor %}\n{% if current_sentiment_list|length == 0 %}\nunclear\n{%\
       \ else %}\n{{ current_sentiment_list|join(', ') }}\n{% endif %}\n{% endif %}"
     name: get_all_sentiments_from_text
     reference: Given the text, provide all the sentiments.
+    task_template: false
   c0a0af62-9282-4bb4-9aed-883d2a0e9a8d: !Template
     id: c0a0af62-9282-4bb4-9aed-883d2a0e9a8d
-    jinja: "{% set labels_list= ([\n  \"admiration\",\n  \"amusement\",\n  \"anger\"\
+    jinja:
+      "{% set labels_list= ([\n  \"admiration\",\n  \"amusement\",\n  \"anger\"\
       ,\n  \"annoyance\",\n  \"approval\",\n  \"caring\",\n  \"confusion\",\n  \"\
       curiosity\",\n  \"desire\",\n  \"disappointment\",\n  \"disapproval\",\n  \"\
       disgust\",\n  \"embarrassment\",\n  \"excitement\",\n  \"fear\",\n  \"gratitude\"\
@@ -30,21 +33,25 @@ templates:
       \ sentiment:  {{ text }}?\n|||\n{% if random_label in labels %}\nyes\n{% else\
       \ %}\nno\n{% endif %}"
     name: true_or_false_sentiment
-    reference: Given the text and asked about a random sentiment, answer whether the
+    reference:
+      Given the text and asked about a random sentiment, answer whether the
       text has that sentiment or not.
+    task_template: true
   fa307ac0-67ba-49f5-ab87-795491d2b9d1: !Template
     id: fa307ac0-67ba-49f5-ab87-795491d2b9d1
-    jinja: "Describe the sentiment of this text in one word:  {{ text }}?\n|||\n{%\
-      \ if labels|length==0 %}\nunclear\n{% else %}\n{% set labels_list= ([\n  \"\
+    jinja: "{% set labels_list= ([\n  \"\
       admiration\",\n  \"amusement\",\n  \"anger\",\n  \"annoyance\",\n  \"approval\"\
       ,\n  \"caring\",\n  \"confusion\",\n  \"curiosity\",\n  \"desire\",\n  \"disappointment\"\
       ,\n  \"disapproval\",\n  \"disgust\",\n  \"embarrassment\",\n  \"excitement\"\
       ,\n  \"fear\",\n  \"gratitude\",\n  \"grief\",\n  \"joy\",\n  \"love\",\n  \"\
       nervousness\",\n  \"optimism\",\n  \"pride\",\n  \"realization\",\n  \"relief\"\
       ,\n  \"remorse\",\n  \"sadness\",\n  \"surprise\",\n  \"neutral\"\n]) %}\n{%\
-      \ set current_sentiment_list = [] %}\n{% for label_index in labels %}\n{% set\
+      \ set current_sentiment_list = [] %}
+      Describe the sentiment of this text in one word:  {{ text }}?\n|||\n{%\
+      \ if labels|length==0 %}\nunclear\n{% else %}\n{% for label_index in labels %}\n{% set\
       \ current_sentiment_list = current_sentiment_list.append(labels_list[label_index])\
       \ %}\n{% endfor %}\n{% if current_sentiment_list|length == 0 %}\nunclear\n{%\
       \ else %}\n{{ current_sentiment_list|random}}\n{% endif %}\n{% endif %}"
     name: get_single_sentiment_from_text
     reference: Given the text, describe the sentiment in a single word.
+    task_template: false

--- a/templates/go_emotions/simplified/templates.yaml
+++ b/templates/go_emotions/simplified/templates.yaml
@@ -27,9 +27,8 @@ templates:
       ,\n  \"pride\",\n  \"realization\",\n  \"relief\",\n  \"remorse\",\n  \"sadness\"\
       ,\n  \"surprise\",\n  \"neutral\"\n]) %}\n{% set random_label= range(28)|list|random\
       \ %}\nDo you think the following text has the \"{{labels_list[random_label]}}\"\
-      \ sentiment:  {{ text }}?\n|||\n{% if example_very_unclear %}\nunclear\n{% else\
-      \ %}\n{% if random_label in labels %}\nyes\n{% else %}\nno\n{% endif %}\n{%\
-      \ endif %}"
+      \ sentiment:  {{ text }}?\n|||\n{% if random_label in labels %}\nyes\n{% else\
+      \ %}\nno\n{% endif %}"
     name: true_or_false_sentiment
     reference: Given the text and asked about a random sentiment, answer whether the
       text has that sentiment or not.


### PR DESCRIPTION
 **Notes**:
- The `raw` subset is relatively complex and filled with lots of `neutral` data (based on a glance at the examples). The `simplified` version is relatively better but has fewer examples.
- The dataset is collected from Reddit, but since it is sentiment classification it could be allowed? From the paper:```We identify harmful comments using pre-defined
lists containing offensive/adult, vulgar (mildly offensive profanity), identity, and religion terms (included as supplementary material). These are used
for data filtering and masking, as described below.
Lists were internally compiled and we believe they
are comprehensive and widely useful for dataset
curation, however, they may not be complete```

Need help with fixing the failing test. `namescope` is not working on the app.