### PR TITLE
Prompts for `gutenberg_time`

### DIFF
--- a/templates/climate_fever/templates.yaml
+++ b/templates/climate_fever/templates.yaml
@@ -1,0 +1,87 @@
+dataset: climate_fever
+templates:
+  82c484bd-2ed7-4ee0-aaee-2b31ac68e751: !Template
+    id: 82c484bd-2ed7-4ee0-aaee-2b31ac68e751
+    jinja: 'Considering the following claim:
+
+      {{claim}}.
+
+      Does the following statement {{"supports"}}, {{"refutes"}}, or provide {{"not
+      enough info"}} on climate change?
+
+      {{evidences[4]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[4]["evidence_label"]]
+      }}'
+    name: fifth_evidence_claim_pair
+    reference: Relation between the claim and fifth evidence pair.
+  cb78a363-fd32-4dbd-976f-b56de644ba90: !Template
+    id: cb78a363-fd32-4dbd-976f-b56de644ba90
+    jinja: 'Considering the following claim:
+
+      {{claim}}.
+
+      Does the following statement {{"supports"}}, {{"refutes"}}, or provide {{"not
+      enough info"}} on climate change?
+
+      {{evidences[1]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[1]["evidence_label"]]
+      }}'
+    name: second_evidence_claim_pair
+    reference: Relation between the claim and second evidence pair.
+  cca7b6f5-29e3-45a4-bc8b-889f5ab2fc13: !Template
+    id: cca7b6f5-29e3-45a4-bc8b-889f5ab2fc13
+    jinja: 'Considering the following claim:
+
+      {{claim}}.
+
+      Does the following statement {{"supports"}}, {{"refutes"}}, or provide {{"not
+      enough info"}} on climate change?
+
+      {{evidences[0]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[0]["evidence_label"]]
+      }}'
+    name: first_evidence_claim_pair
+    reference: Relation between the claim and first evidence pair.
+  dc3e0a0b-4f4d-4a76-9e7b-eafce4967e98: !Template
+    id: dc3e0a0b-4f4d-4a76-9e7b-eafce4967e98
+    jinja: 'Considering the following claim:
+
+      {{claim}}.
+
+      Does the following statement {{"supports"}}, {{"refutes"}}, or provide {{"not
+      enough info"}} on climate change?
+
+      {{evidences[3]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[3]["evidence_label"]]
+      }}'
+    name: fourth_evidence_claim_pair
+    reference: Relation between the claim and fourth evidence pair.
+  ff9c9c11-92f1-4cb2-a73c-d786d58b00e1: !Template
+    id: ff9c9c11-92f1-4cb2-a73c-d786d58b00e1
+    jinja: 'Considering the following claim:
+
+      {{claim}}.
+
+      Does the following statement {{"supports"}}, {{"refutes"}}, or provide {{"not
+      enough info"}} on climate change?
+
+      {{evidences[2]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[2]["evidence_label"]]
+      }}'
+    name: third_evidence_claim_pair
+    reference: Relation between the claim and third evidence pair.

--- a/templates/climate_fever/templates.yaml
+++ b/templates/climate_fever/templates.yaml
@@ -1,5 +1,61 @@
 dataset: climate_fever
 templates:
+  38632cd9-7c4c-4e1d-85b3-20e7a78d4580: !Template
+    id: 38632cd9-7c4c-4e1d-85b3-20e7a78d4580
+    jinja: 'Here''s a statement and accompanying evidence. Does the evidence {{"supports"}},
+      {{"refutes"}}, or provide {{"not enough info"}} on climate change?
+
+
+      Statement: {{claim}}
+
+
+      Evidence: {{evidences[0]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[0]["evidence_label"]]
+      }}'
+    name: first_evidence_and_claim_itemization
+    reference: First evidence and claim with simple itemization
+  3970f474-a9e3-4264-aefa-dd4cfadd279c: !Template
+    id: 3970f474-a9e3-4264-aefa-dd4cfadd279c
+    jinja: 'Here''s a claim and accompanying evidence statements . Do the statements
+      {{"support"}}, {{"refute"}},  {{"dispute"}} or provide {{"not enough info"}}
+      on climate change?
+
+
+      Claim: {{claim}}
+
+
+      Statements:
+
+      - {{ evidences | map(attribute="evidence") | map("trim", "\".")  | join(".\n-
+      ") }}.
+
+      |||
+
+      {{ ["Supports", "Refutes", "Not enough information", "Disputed"][claim_label]
+      }}'
+    name: claim_and_all_supporting_evidences
+    reference: A claim and all supproting evidences provided with the associated claim
+      label
+  5d5062c1-d28f-4b1c-a7da-9b53796ed39f: !Template
+    id: 5d5062c1-d28f-4b1c-a7da-9b53796ed39f
+    jinja: 'Here''s a statement and accompanying evidence. Does the evidence {{"supports"}},
+      {{"refutes"}}, or provide {{"not enough info"}} on climate change?
+
+
+      Statement: {{claim}}
+
+
+      Evidence: {{evidences[4]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[4]["evidence_label"]]
+      }}'
+    name: fifth_evidence_and_claim_itemization
+    reference: Fifth evidence and claim with simple itemization
   82c484bd-2ed7-4ee0-aaee-2b31ac68e751: !Template
     id: 82c484bd-2ed7-4ee0-aaee-2b31ac68e751
     jinja: 'Considering the following claim:
@@ -13,10 +69,44 @@ templates:
 
       |||
 
-      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[4]["evidence_label"]]
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[4]["evidence_label"]]
       }}'
     name: fifth_evidence_claim_pair
     reference: Relation between the claim and fifth evidence pair.
+  9ba074a2-fbcf-4f69-bf03-bd16dbdec9cd: !Template
+    id: 9ba074a2-fbcf-4f69-bf03-bd16dbdec9cd
+    jinja: 'Here''s a statement and accompanying evidence. Does the evidence {{"supports"}},
+      {{"refutes"}}, or provide {{"not enough info"}} on climate change?
+
+
+      Statement: {{claim}}
+
+
+      Evidence: {{evidences[3]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[3]["evidence_label"]]
+      }}'
+    name: fourth_evidence_and_claim_itemization
+    reference: Fourth evidence and claim with simple itemization
+  9f68b883-d6a3-4e95-af2a-b7755bc46ba9: !Template
+    id: 9f68b883-d6a3-4e95-af2a-b7755bc46ba9
+    jinja: 'Here''s a statement and accompanying evidence. Does the evidence {{"supports"}},
+      {{"refutes"}}, or provide {{"not enough info"}} on climate change?
+
+
+      Statement: {{claim}}
+
+
+      Evidence: {{evidences[2]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[2]["evidence_label"]]
+      }}'
+    name: third_evidence_and_claim_itemization
+    reference: Third evidence and claim with simple itemization
   cb78a363-fd32-4dbd-976f-b56de644ba90: !Template
     id: cb78a363-fd32-4dbd-976f-b56de644ba90
     jinja: 'Considering the following claim:
@@ -30,7 +120,7 @@ templates:
 
       |||
 
-      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[1]["evidence_label"]]
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[1]["evidence_label"]]
       }}'
     name: second_evidence_claim_pair
     reference: Relation between the claim and second evidence pair.
@@ -47,7 +137,7 @@ templates:
 
       |||
 
-      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[0]["evidence_label"]]
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[0]["evidence_label"]]
       }}'
     name: first_evidence_claim_pair
     reference: Relation between the claim and first evidence pair.
@@ -64,10 +154,27 @@ templates:
 
       |||
 
-      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[3]["evidence_label"]]
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[3]["evidence_label"]]
       }}'
     name: fourth_evidence_claim_pair
     reference: Relation between the claim and fourth evidence pair.
+  e3e01825-e256-4098-b7bb-aa07c399e8f6: !Template
+    id: e3e01825-e256-4098-b7bb-aa07c399e8f6
+    jinja: 'Here''s a statement and accompanying evidence. Does the evidence {{"supports"}},
+      {{"refutes"}}, or provide {{"not enough info"}} on climate change?
+
+
+      Statement: {{claim}}
+
+
+      Evidence: {{evidences[1]["evidence"].strip(".").strip(''"'')}}.
+
+      |||
+
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[1]["evidence_label"]]
+      }}'
+    name: second_evidence_and_claim_itemization
+    reference: Second evidence and claim with simple itemization
   ff9c9c11-92f1-4cb2-a73c-d786d58b00e1: !Template
     id: ff9c9c11-92f1-4cb2-a73c-d786d58b00e1
     jinja: 'Considering the following claim:
@@ -81,7 +188,7 @@ templates:
 
       |||
 
-      {{ ["SUPPORTS", "REFUTES", "NOT_ENOUGH_INFO"][evidences[2]["evidence_label"]]
+      {{ ["Supports", "Refutes", "Not enough information"][evidences[2]["evidence_label"]]
       }}'
     name: third_evidence_claim_pair
     reference: Relation between the claim and third evidence pair.

--- a/templates/gutenberg_time/templates.yaml
+++ b/templates/gutenberg_time/templates.yaml
@@ -1,68 +1,68 @@
-dataset: gutenberg_time
-templates:
-  06dce7dd-ae32-4acb-a1c8-6a01303b577b: !Template
-    id: 06dce7dd-ae32-4acb-a1c8-6a01303b577b
-    jinja: "Given the following text. What time reference is reported in the text?\n\
-      \n{{tok_context}}\n\nThe time reference reported is \n|||\n{{time_phrase}}"
-    name: asking_the_time_reference_before
-    reference: Asking the time reference before the text
-    task_template: false
-  1e880fc4-6df7-4cab-8658-82cae44135cf: !Template
-    id: 1e880fc4-6df7-4cab-8658-82cae44135cf
-    jinja: "{{tok_context}}\n\nGiven the previous text. What time reference is reported\
-      \ in the text?\n\nThe time reference reported is \n|||\n{{time_phrase}}"
-    name: asking_the_time_refence_after
-    reference: ''
-    task_template: false
-  27e6ef41-5f29-485a-9fa8-7b71feb956c8: !Template
-    id: 27e6ef41-5f29-485a-9fa8-7b71feb956c8
-    jinja: '{{tok_context}}
+  dataset: gutenberg_time
+  templates:
+    06dce7dd-ae32-4acb-a1c8-6a01303b577b: !Template
+      id: 06dce7dd-ae32-4acb-a1c8-6a01303b577b
+      jinja: "Given the following text. What time reference is reported in the text?\n\
+        \n{{tok_context}}\n\nThe time reference reported is \n|||\n{{time_phrase}}"
+      name: asking_the_time_reference_before
+      reference: Asking the time reference before the text
+      task_template: false
+    1e880fc4-6df7-4cab-8658-82cae44135cf: !Template
+      id: 1e880fc4-6df7-4cab-8658-82cae44135cf
+      jinja: "{{tok_context}}\n\nGiven the previous text. What time reference is reported\
+        \ in the text?\n\nThe time reference reported is \n|||\n{{time_phrase}}"
+      name: asking_the_time_refence_after
+      reference: ''
+      task_template: false
+    27e6ef41-5f29-485a-9fa8-7b71feb956c8: !Template
+      id: 27e6ef41-5f29-485a-9fa8-7b71feb956c8
+      jinja: '{{tok_context}}
 
 
-      Given the previous text. What time reference is reported in the text? What time
-      does it indicate?
+        Given the previous text. What time reference is reported in the text? What time
+        does it indicate?
 
 
-      |||
+        |||
 
 
-      The time reference reported is "{{time_phrase}}".
+        The time reference reported is "{{time_phrase}}".
 
-      It indicates {{hour_reference}}.'
-    name: asking_the_time_reference_and_actual_time_after
-    reference: Asking time reference and actual time after the text
-    task_template: false
-  4efa58a3-a38b-4bcd-8597-687a7b7f56f8: !Template
-    id: 4efa58a3-a38b-4bcd-8597-687a7b7f56f8
-    jinja: "Given the following text. What time does the phrase \"{{time_phrase}}\"\
-      \ indicate?\n\n{{tok_context}}\n\nIt indicates \n|||\n{{hour_reference}}"
-    name: asking_the_time_phrase_explicit_before
-    reference: Ask for the time reported in the text, explicitly mentioning the phrase,
-      asking the question before the text
-    task_template: true
-  75cbe764-02f9-4183-9be4-b7bba3d3b1f6: !Template
-    id: 75cbe764-02f9-4183-9be4-b7bba3d3b1f6
-    jinja: "{{tok_context}}\n\nGiven the previous text. What time does the phrase\
-      \ \"{{time_phrase}}\" indicate?\n\nIt indicates \n|||\n{{hour_reference}}"
-    name: asking_the_time_phrase_explicit_after
-    reference: Ask for the time reported in the text, explicitly mentioning the phrase,
-      asking the question after the text
-    task_template: true
-  9004b87b-2731-4951-976a-9269e28be7be: !Template
-    id: 9004b87b-2731-4951-976a-9269e28be7be
-    jinja: 'Given the following text. What time reference is reported in the text?
-      What time does it indicate?
-
-
-      {{tok_context}}
+        It indicates {{hour_reference}}.'
+      name: asking_the_time_reference_and_actual_time_after
+      reference: Asking time reference and actual time after the text
+      task_template: false
+    4efa58a3-a38b-4bcd-8597-687a7b7f56f8: !Template
+      id: 4efa58a3-a38b-4bcd-8597-687a7b7f56f8
+      jinja: "Given the following text. What hour (between 0 and 23) does the phrase\
+        \ \"{{time_phrase}}\" indicate?\n\n{{tok_context}}\n\nIt indicates \n|||\n{{hour_reference}}"
+      name: asking_the_time_phrase_explicit_before
+      reference: Ask for the time reported in the text, explicitly mentioning the phrase,
+        asking the question before the text
+      task_template: true
+    75cbe764-02f9-4183-9be4-b7bba3d3b1f6: !Template
+      id: 75cbe764-02f9-4183-9be4-b7bba3d3b1f6
+      jinja: "{{tok_context}}\n\nGiven the previous text. What hour (between 0 and 23)\
+        \ does the phrase \"{{time_phrase}}\" indicate?\n\nIt indicates \n|||\n{{hour_reference}}"
+      name: asking_the_time_phrase_explicit_after
+      reference: Ask for the time reported in the text, explicitly mentioning the phrase,
+        asking the question after the text
+      task_template: true
+    9004b87b-2731-4951-976a-9269e28be7be: !Template
+      id: 9004b87b-2731-4951-976a-9269e28be7be
+      jinja: 'Given the following text. What time reference is reported in the text?
+        What time does it indicate?
 
 
-      |||
+        {{tok_context}}
 
 
-      The time reference reported is "{{time_phrase}}".
+        |||
 
-      It indicates {{hour_reference}}.'
-    name: asking_the_time_reference_and_actual_time_before
-    reference: ' Asking time reference and actual time before the text'
-    task_template: false
+
+        The time reference reported is "{{time_phrase}}".
+
+        It indicates {{hour_reference}}.'
+      name: asking_the_time_reference_and_actual_time_before
+      reference: ' Asking time reference and actual time before the text'
+      task_template: false

--- a/templates/gutenberg_time/templates.yaml
+++ b/templates/gutenberg_time/templates.yaml
@@ -1,68 +1,68 @@
-  dataset: gutenberg_time
-  templates:
-    06dce7dd-ae32-4acb-a1c8-6a01303b577b: !Template
-      id: 06dce7dd-ae32-4acb-a1c8-6a01303b577b
-      jinja: "Given the following text. What time reference is reported in the text?\n\
-        \n{{tok_context}}\n\nThe time reference reported is \n|||\n{{time_phrase}}"
-      name: asking_the_time_reference_before
-      reference: Asking the time reference before the text
-      task_template: false
-    1e880fc4-6df7-4cab-8658-82cae44135cf: !Template
-      id: 1e880fc4-6df7-4cab-8658-82cae44135cf
-      jinja: "{{tok_context}}\n\nGiven the previous text. What time reference is reported\
-        \ in the text?\n\nThe time reference reported is \n|||\n{{time_phrase}}"
-      name: asking_the_time_refence_after
-      reference: ''
-      task_template: false
-    27e6ef41-5f29-485a-9fa8-7b71feb956c8: !Template
-      id: 27e6ef41-5f29-485a-9fa8-7b71feb956c8
-      jinja: '{{tok_context}}
+dataset: gutenberg_time
+templates:
+  06dce7dd-ae32-4acb-a1c8-6a01303b577b: !Template
+    id: 06dce7dd-ae32-4acb-a1c8-6a01303b577b
+    jinja: "Given the following text. What time reference is reported in the text?\n\
+      \n{{tok_context}}\n\nThe time reference reported is \n|||\n{{time_phrase}}"
+    name: asking_the_time_reference_before
+    reference: Asking the time reference before the text
+    task_template: false
+  1e880fc4-6df7-4cab-8658-82cae44135cf: !Template
+    id: 1e880fc4-6df7-4cab-8658-82cae44135cf
+    jinja: "{{tok_context}}\n\nGiven the previous text. What time reference is reported\
+      \ in the text?\n\nThe time reference reported is \n|||\n{{time_phrase}}"
+    name: asking_the_time_refence_after
+    reference: ''
+    task_template: false
+  27e6ef41-5f29-485a-9fa8-7b71feb956c8: !Template
+    id: 27e6ef41-5f29-485a-9fa8-7b71feb956c8
+    jinja: '{{tok_context}}
 
 
-        Given the previous text. What time reference is reported in the text? What time
-        does it indicate?
+      Given the previous text. What time reference is reported in the text? What time
+      does it indicate?
 
 
-        |||
+      |||
 
 
-        The time reference reported is "{{time_phrase}}".
+      The time reference reported is "{{time_phrase}}".
 
-        It indicates {{hour_reference}}.'
-      name: asking_the_time_reference_and_actual_time_after
-      reference: Asking time reference and actual time after the text
-      task_template: false
-    4efa58a3-a38b-4bcd-8597-687a7b7f56f8: !Template
-      id: 4efa58a3-a38b-4bcd-8597-687a7b7f56f8
-      jinja: "Given the following text. What hour (between 0 and 23) does the phrase\
-        \ \"{{time_phrase}}\" indicate?\n\n{{tok_context}}\n\nIt indicates \n|||\n{{hour_reference}}"
-      name: asking_the_time_phrase_explicit_before
-      reference: Ask for the time reported in the text, explicitly mentioning the phrase,
-        asking the question before the text
-      task_template: true
-    75cbe764-02f9-4183-9be4-b7bba3d3b1f6: !Template
-      id: 75cbe764-02f9-4183-9be4-b7bba3d3b1f6
-      jinja: "{{tok_context}}\n\nGiven the previous text. What hour (between 0 and 23)\
-        \ does the phrase \"{{time_phrase}}\" indicate?\n\nIt indicates \n|||\n{{hour_reference}}"
-      name: asking_the_time_phrase_explicit_after
-      reference: Ask for the time reported in the text, explicitly mentioning the phrase,
-        asking the question after the text
-      task_template: true
-    9004b87b-2731-4951-976a-9269e28be7be: !Template
-      id: 9004b87b-2731-4951-976a-9269e28be7be
-      jinja: 'Given the following text. What time reference is reported in the text?
-        What time does it indicate?
-
-
-        {{tok_context}}
+      It indicates {{hour_reference}}.'
+    name: asking_the_time_reference_and_actual_time_after
+    reference: Asking time reference and actual time after the text
+    task_template: false
+  4efa58a3-a38b-4bcd-8597-687a7b7f56f8: !Template
+    id: 4efa58a3-a38b-4bcd-8597-687a7b7f56f8
+    jinja: "Given the following text. What hour (between 0 and 23) does the phrase\
+      \ \"{{time_phrase}}\" indicate?\n\n{{tok_context}}\n\nIt indicates \n|||\n{{hour_reference}}"
+    name: asking_the_time_phrase_explicit_before
+    reference: Ask for the time reported in the text, explicitly mentioning the phrase,
+      asking the question before the text
+    task_template: true
+  75cbe764-02f9-4183-9be4-b7bba3d3b1f6: !Template
+    id: 75cbe764-02f9-4183-9be4-b7bba3d3b1f6
+    jinja: "{{tok_context}}\n\nGiven the previous text. What hour (between 0 and 23)\
+      \ does the phrase \"{{time_phrase}}\" indicate?\n\nIt indicates \n|||\n{{hour_reference}}"
+    name: asking_the_time_phrase_explicit_after
+    reference: Ask for the time reported in the text, explicitly mentioning the phrase,
+      asking the question after the text
+    task_template: true
+  9004b87b-2731-4951-976a-9269e28be7be: !Template
+    id: 9004b87b-2731-4951-976a-9269e28be7be
+    jinja: 'Given the following text. What time reference is reported in the text?
+      What time does it indicate?
 
 
-        |||
+      {{tok_context}}
 
 
-        The time reference reported is "{{time_phrase}}".
+      |||
 
-        It indicates {{hour_reference}}.'
-      name: asking_the_time_reference_and_actual_time_before
-      reference: ' Asking time reference and actual time before the text'
-      task_template: false
+
+      The time reference reported is "{{time_phrase}}".
+
+      It indicates {{hour_reference}}.'
+    name: asking_the_time_reference_and_actual_time_before
+    reference: ' Asking time reference and actual time before the text'
+    task_template: false

--- a/templates/gutenberg_time/templates.yaml
+++ b/templates/gutenberg_time/templates.yaml
@@ -2,31 +2,15 @@ dataset: gutenberg_time
 templates:
   06dce7dd-ae32-4acb-a1c8-6a01303b577b: !Template
     id: 06dce7dd-ae32-4acb-a1c8-6a01303b577b
-    jinja: 'Given the following text. What time reference is reported in the text?
-
-
-      {{tok_context}}
-
-
-      |||
-
-
-      The time reference reported is "{{time_phrase}}".'
+    jinja: "Given the following text. What time reference is reported in the text?\n\
+      \n{{tok_context}}\n\nThe time reference reported is \n|||\n{{time_phrase}}"
     name: asking_the_time_reference_before
     reference: Asking the time reference before the text
     task_template: false
   1e880fc4-6df7-4cab-8658-82cae44135cf: !Template
     id: 1e880fc4-6df7-4cab-8658-82cae44135cf
-    jinja: '{{tok_context}}
-
-
-      Given the previous text. What time reference is reported in the text?
-
-
-      |||
-
-
-      The time reference reported is "{{time_phrase}}".'
+    jinja: "{{tok_context}}\n\nGiven the previous text. What time reference is reported\
+      \ in the text?\n\nThe time reference reported is \n|||\n{{time_phrase}}"
     name: asking_the_time_refence_after
     reference: ''
     task_template: false
@@ -44,43 +28,26 @@ templates:
 
       The time reference reported is "{{time_phrase}}".
 
-      It indicates {{hour_reference}}:00.'
+      It indicates {{hour_reference}}.'
     name: asking_the_time_reference_and_actual_time_after
     reference: Asking time reference and actual time after the text
     task_template: false
   4efa58a3-a38b-4bcd-8597-687a7b7f56f8: !Template
     id: 4efa58a3-a38b-4bcd-8597-687a7b7f56f8
-    jinja: 'Given the following text. What time does the phrase "{{time_phrase}}"
-      indicate?
-
-
-      {{tok_context}}
-
-
-      |||
-
-
-      It indicates to {{hour_reference}}:00.'
+    jinja: "Given the following text. What time does the phrase \"{{time_phrase}}\"\
+      \ indicate?\n\n{{tok_context}}\n\nIt indicates \n|||\n{{hour_reference}}"
     name: asking_the_time_phrase_explicit_before
     reference: Ask for the time reported in the text, explicitly mentioning the phrase,
       asking the question before the text
-    task_template: false
+    task_template: true
   75cbe764-02f9-4183-9be4-b7bba3d3b1f6: !Template
     id: 75cbe764-02f9-4183-9be4-b7bba3d3b1f6
-    jinja: '{{tok_context}}
-
-
-      Given the previous text. What time does the phrase "{{time_phrase}}" indicate?
-
-
-      |||
-
-
-      It indicates {{hour_reference}}:00.'
+    jinja: "{{tok_context}}\n\nGiven the previous text. What time does the phrase\
+      \ \"{{time_phrase}}\" indicate?\n\nIt indicates \n|||\n{{hour_reference}}"
     name: asking_the_time_phrase_explicit_after
     reference: Ask for the time reported in the text, explicitly mentioning the phrase,
       asking the question after the text
-    task_template: false
+    task_template: true
   9004b87b-2731-4951-976a-9269e28be7be: !Template
     id: 9004b87b-2731-4951-976a-9269e28be7be
     jinja: 'Given the following text. What time reference is reported in the text?
@@ -95,7 +62,7 @@ templates:
 
       The time reference reported is "{{time_phrase}}".
 
-      It indicates {{hour_reference}}:00.'
+      It indicates {{hour_reference}}.'
     name: asking_the_time_reference_and_actual_time_before
     reference: ' Asking time reference and actual time before the text'
     task_template: false

--- a/templates/gutenberg_time/templates.yaml
+++ b/templates/gutenberg_time/templates.yaml
@@ -1,0 +1,101 @@
+dataset: gutenberg_time
+templates:
+  06dce7dd-ae32-4acb-a1c8-6a01303b577b: !Template
+    id: 06dce7dd-ae32-4acb-a1c8-6a01303b577b
+    jinja: 'Given the following text. What time reference is reported in the text?
+
+
+      {{tok_context}}
+
+
+      |||
+
+
+      The time reference reported is "{{time_phrase}}".'
+    name: asking_the_time_reference_before
+    reference: Asking the time reference before the text
+    task_template: false
+  1e880fc4-6df7-4cab-8658-82cae44135cf: !Template
+    id: 1e880fc4-6df7-4cab-8658-82cae44135cf
+    jinja: '{{tok_context}}
+
+
+      Given the previous text. What time reference is reported in the text?
+
+
+      |||
+
+
+      The time reference reported is "{{time_phrase}}".'
+    name: asking_the_time_refence_after
+    reference: ''
+    task_template: false
+  27e6ef41-5f29-485a-9fa8-7b71feb956c8: !Template
+    id: 27e6ef41-5f29-485a-9fa8-7b71feb956c8
+    jinja: '{{tok_context}}
+
+
+      Given the previous text. What time reference is reported in the text? What time
+      does it indicate?
+
+
+      |||
+
+
+      The time reference reported is "{{time_phrase}}".
+
+      It indicates {{hour_reference}}:00.'
+    name: asking_the_time_reference_and_actual_time_after
+    reference: Asking time reference and actual time after the text
+    task_template: false
+  4efa58a3-a38b-4bcd-8597-687a7b7f56f8: !Template
+    id: 4efa58a3-a38b-4bcd-8597-687a7b7f56f8
+    jinja: 'Given the following text. What time does the phrase "{{time_phrase}}"
+      indicate?
+
+
+      {{tok_context}}
+
+
+      |||
+
+
+      It indicates to {{hour_reference}}:00.'
+    name: asking_the_time_phrase_explicit_before
+    reference: Ask for the time reported in the text, explicitly mentioning the phrase,
+      asking the question before the text
+    task_template: false
+  75cbe764-02f9-4183-9be4-b7bba3d3b1f6: !Template
+    id: 75cbe764-02f9-4183-9be4-b7bba3d3b1f6
+    jinja: '{{tok_context}}
+
+
+      Given the previous text. What time does the phrase "{{time_phrase}}" indicate?
+
+
+      |||
+
+
+      It indicates {{hour_reference}}:00.'
+    name: asking_the_time_phrase_explicit_after
+    reference: Ask for the time reported in the text, explicitly mentioning the phrase,
+      asking the question after the text
+    task_template: false
+  9004b87b-2731-4951-976a-9269e28be7be: !Template
+    id: 9004b87b-2731-4951-976a-9269e28be7be
+    jinja: 'Given the following text. What time reference is reported in the text?
+      What time does it indicate?
+
+
+      {{tok_context}}
+
+
+      |||
+
+
+      The time reference reported is "{{time_phrase}}".
+
+      It indicates {{hour_reference}}:00.'
+    name: asking_the_time_reference_and_actual_time_before
+    reference: ' Asking time reference and actual time before the text'
+    task_template: false


### PR DESCRIPTION
The dataset is super interesting. I initially tried to use the `is_ambiguous` flag to create more interesting prompts where the there was uncertainty on the time of the day (e.g., 5:00 vs. 17:00), but unfortunately after looking at the first 100 examples I realized that it is not reliable. I decided to use the time as is reported, because it seemed more accurate.