### PR TITLE
bug-fixes, task template checkbox updated

### DIFF
--- a/templates/paws-x/en/templates.yaml
+++ b/templates/paws-x/en/templates.yaml
@@ -3,96 +3,110 @@ subset: en
 templates:
   289448c3-63fc-4904-8387-86d232424243: !Template
     id: 289448c3-63fc-4904-8387-86d232424243
-    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence2}} \n{% endif\
-      \ %}\n||| \n{{sentence1}} "
+    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence2}} \n||| \n\
+      {{sentence1}} \n{% endif %}"
     name: paraphrase-task-reverse
     reference: Create a generative paraphrase task
+    task_template: false
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
-      \ paraphrase or not?\n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif\
-      \ label == 1 %}\nTrue\n{% endif %}"
+      \ paraphrase or not?\n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1\
+      \ %}\nTrue\n{% endif %}\n{% endif %}"
     name: PAWS-ANLI GPT3-no-label
     reference: ANLI prompt format from Table G7 in the GPT3 paper. Additionally added
       task information without any label.
+    task_template: true
   32c0f3d5-a6c7-4ab2-a922-3a9d66db309f: !Template
     id: 32c0f3d5-a6c7-4ab2-a922-3a9d66db309f
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
       \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? Yes\
-      \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
-      Yes\n{% endif %}"
+      \ or No? \n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}\n{% endif %}"
     name: Rewrite
     reference: Natural Question
+    task_template: true
   568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
     id: 568abe6e-4014-4d20-b4a0-3b0622026e36
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
       \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning\
-      \ or not\n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
-      Yes\n{% endif %}"
+      \ or not\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}\n{% endif %}"
     name: Meaning-no-label
     reference: Natural question without label
+    task_template: true
   60becf78-b280-43e1-aebb-475ee64076c8: !Template
     id: 60becf78-b280-43e1-aebb-475ee64076c8
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\nIs that a paraphrase\
-      \ of the following sentence?\n{{sentence2}}?\n{% endif %}\n||| \n{% if label\
-      \ == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+      \ of the following sentence?\n{{sentence2}}?\n||| \n{% if label == 0 %} \nNo\n\
+      {% elif label == 1 %}\nYes\n{% endif %}\n{% endif %}"
     name: context-question-no-label
     reference: Generalized prompt format, context-question without any label
+    task_template: true
   68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
     id: 68f76857-66f0-4aa4-ad70-3443cce0c7ae
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
-      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? \n{%\
-      \ endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? \n|||\
+      \ \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}\n{% endif\
       \ %}"
     name: Rewrite-no-label
     reference: Natural Question without label
+    task_template: true
   82dbfba2-24f2-401a-9f81-618ca86f464f: !Template
     id: 82dbfba2-24f2-401a-9f81-618ca86f464f
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
-      \ True or False? \n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label\
-      \ == 1 %}\nTrue\n{% endif %}"
+      \ True or False? \n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1 %}\n\
+      True\n{% endif %}\n{% endif %}"
     name: PAWS-ANLI GPT3
     reference: ANLI prompt format from Table G7 in the GPT3 paper
+    task_template: true
   a922400e-f562-4501-bff7-998e78e9866f: !Template
     id: a922400e-f562-4501-bff7-998e78e9866f
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\nIs that a paraphrase\
-      \ of the following sentence?\n{{sentence2}}?\nYes, No\n{% endif %}\n||| \n{%\
-      \ if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+      \ of the following sentence?\n{{sentence2}}?\nYes, No\n||| \n{% if label ==\
+      \ 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}\n{% endif %}"
     name: context-question
     reference: Generalized prompt format, context-question
+    task_template: true
   ae3fbffe-b99d-4080-8aa0-e9040dcb68f9: !Template
     id: ae3fbffe-b99d-4080-8aa0-e9040dcb68f9
     jinja: "{% if label == 0 or label == 1 %} \nDetermine if the following two sentences\
-      \ paraphrase or not.\n{{sentence1}}\n{{sentence2}}\n{% endif %}\n||| \n{% if\
-      \ label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+      \ paraphrase or not.\n{{sentence1}}\n{{sentence2}}\n||| \n{% if label == 0 %}\
+      \ \nNo\n{% elif label == 1 %}\nYes\n{% endif %}\n{% endif %}"
     name: task_description-no-label
     reference: Generalized prompt format, task_description-input.
+    task_template: true
   c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
     id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
       \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? Yes or\
-      \ No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
-      Yes\n{% endif %}"
+      \ No? \n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}\n{% endif %}"
     name: Concatenation
     reference: Concatenation of sentence 1 and sentence 2
+    task_template: true
   c873732e-c424-417f-a474-f19eff2caf35: !Template
     id: c873732e-c424-417f-a474-f19eff2caf35
-    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence1}} \n{% endif\
-      \ %}\n||| \n{{sentence2}} "
+    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence1}} \n||| \n\
+      {{sentence2}} \n{% endif %}"
     name: paraphrase-task
     reference: Create a generative paraphrase task
+    task_template: false
   d94a57f5-7344-42e8-b8a8-b1fb731d39f8: !Template
     id: d94a57f5-7344-42e8-b8a8-b1fb731d39f8
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
       \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning?\
-      \ Yes or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label ==\
-      \ 1 %}\nYes\n{% endif %}"
+      \ Yes or No? \n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n\
+      {% endif %}\n{% endif %}"
     name: Meaning
     reference: Natural question
+    task_template: true
   e94388e1-bf2f-4be1-8693-23c6ce8277e6: !Template
     id: e94388e1-bf2f-4be1-8693-23c6ce8277e6
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
-      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? \n{% endif\
-      \ %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? \n|||\
+      \ \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}\n{% endif\
+      \ %}"
     name: Concatenation-no-label
     reference: Concatenation of sentence 1 and sentence 2 without any label
+    task_template: true

--- a/templates/paws/labeled_final/templates.yaml
+++ b/templates/paws/labeled_final/templates.yaml
@@ -3,96 +3,110 @@ subset: labeled_final
 templates:
   289448c3-63fc-4904-8387-86d232424243: !Template
     id: 289448c3-63fc-4904-8387-86d232424243
-    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence2}} \n{% endif\
-      \ %}\n||| \n{{sentence1}} "
+    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence2}} \n||| \n\
+      {{sentence1}} \n{% endif %}"
     name: paraphrase-task-reverse
     reference: Create a generative paraphrase task
+    task_template: false
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
-      \ paraphrase or not?\n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif\
-      \ label == 1 %}\nTrue\n{% endif %}"
+      \ paraphrase or not?\n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1\
+      \ %}\nTrue\n{% endif %}\n{% endif %}"
     name: PAWS-ANLI GPT3-no-label
     reference: ANLI prompt format from Table G7 in the GPT3 paper. Additionally added
       task information without any label.
+    task_template: true
   32c0f3d5-a6c7-4ab2-a922-3a9d66db309f: !Template
     id: 32c0f3d5-a6c7-4ab2-a922-3a9d66db309f
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
       \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? Yes\
-      \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
-      Yes\n{% endif %}"
+      \ or No? \n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}\n{% endif %}"
     name: Rewrite
     reference: Natural Question
+    task_template: true
   568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
     id: 568abe6e-4014-4d20-b4a0-3b0622026e36
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
       \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning\
-      \ or not\n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
-      Yes\n{% endif %}"
+      \ or not\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}\n{% endif %}"
     name: Meaning-no-label
     reference: Natural question without label
+    task_template: true
   60becf78-b280-43e1-aebb-475ee64076c8: !Template
     id: 60becf78-b280-43e1-aebb-475ee64076c8
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\nIs that a paraphrase\
-      \ of the following sentence?\n{{sentence2}}?\n{% endif %}\n||| \n{% if label\
-      \ == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+      \ of the following sentence?\n{{sentence2}}?\n||| \n{% if label == 0 %} \nNo\n\
+      {% elif label == 1 %}\nYes\n{% endif %}\n{% endif %}"
     name: context-question-no-label
     reference: Generalized prompt format, context-question without any label
+    task_template: true
   68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
     id: 68f76857-66f0-4aa4-ad70-3443cce0c7ae
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
-      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? \n{%\
-      \ endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? \n|||\
+      \ \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}\n{% endif\
       \ %}"
     name: Rewrite-no-label
     reference: Natural Question without label
+    task_template: true
   82dbfba2-24f2-401a-9f81-618ca86f464f: !Template
     id: 82dbfba2-24f2-401a-9f81-618ca86f464f
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
-      \ True or False? \n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label\
-      \ == 1 %}\nTrue\n{% endif %}"
+      \ True or False? \n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1 %}\n\
+      True\n{% endif %}\n{% endif %}"
     name: PAWS-ANLI GPT3
     reference: ANLI prompt format from Table G7 in the GPT3 paper
+    task_template: true
   a922400e-f562-4501-bff7-998e78e9866f: !Template
     id: a922400e-f562-4501-bff7-998e78e9866f
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\nIs that a paraphrase\
-      \ of the following sentence?\n{{sentence2}}?\nYes, No\n{% endif %}\n||| \n{%\
-      \ if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+      \ of the following sentence?\n{{sentence2}}?\nYes, No\n||| \n{% if label ==\
+      \ 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}\n{% endif %}"
     name: context-question
     reference: Generalized prompt format, context-question
+    task_template: true
   ae3fbffe-b99d-4080-8aa0-e9040dcb68f9: !Template
     id: ae3fbffe-b99d-4080-8aa0-e9040dcb68f9
     jinja: "{% if label == 0 or label == 1 %} \nDetermine if the following two sentences\
-      \ paraphrase or not.\n{{sentence1}}\n{{sentence2}}\n{% endif %}\n||| \n{% if\
-      \ label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+      \ paraphrase or not.\n{{sentence1}}\n{{sentence2}}\n||| \n{% if label == 0 %}\
+      \ \nNo\n{% elif label == 1 %}\nYes\n{% endif %}\n{% endif %}"
     name: task_description-no-label
     reference: Generalized prompt format, task_description-input.
+    task_template: true
   c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
     id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
       \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? Yes or\
-      \ No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
-      Yes\n{% endif %}"
+      \ No? \n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}\n{% endif %}"
     name: Concatenation
     reference: Concatenation of sentence 1 and sentence 2
+    task_template: true
   c873732e-c424-417f-a474-f19eff2caf35: !Template
     id: c873732e-c424-417f-a474-f19eff2caf35
-    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence1}} \n{% endif\
-      \ %}\n||| \n{{sentence2}} "
+    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence1}} \n||| \n\
+      {{sentence2}} \n{% endif %}"
     name: paraphrase-task
     reference: Create a generative paraphrase task
+    task_template: false
   d94a57f5-7344-42e8-b8a8-b1fb731d39f8: !Template
     id: d94a57f5-7344-42e8-b8a8-b1fb731d39f8
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
       \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning?\
-      \ Yes or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label ==\
-      \ 1 %}\nYes\n{% endif %}"
+      \ Yes or No? \n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n\
+      {% endif %}\n{% endif %}"
     name: Meaning
     reference: Natural question
+    task_template: true
   e94388e1-bf2f-4be1-8693-23c6ce8277e6: !Template
     id: e94388e1-bf2f-4be1-8693-23c6ce8277e6
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
-      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? \n{% endif\
-      \ %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? \n|||\
+      \ \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}\n{% endif\
+      \ %}"
     name: Concatenation-no-label
     reference: Concatenation of sentence 1 and sentence 2 without any label
+    task_template: true

--- a/templates/paws/labeled_swap/templates.yaml
+++ b/templates/paws/labeled_swap/templates.yaml
@@ -3,96 +3,110 @@ subset: labeled_swap
 templates:
   289448c3-63fc-4904-8387-86d232424243: !Template
     id: 289448c3-63fc-4904-8387-86d232424243
-    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence2}} \n{% endif\
-      \ %}\n||| \n{{sentence1}} "
+    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence2}} \n||| \n\
+      {{sentence1}} \n{% endif %}"
     name: paraphrase-task-reverse
     reference: Create a generative paraphrase task
+    task_template: false
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
-      \ paraphrase or not?\n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif\
-      \ label == 1 %}\nTrue\n{% endif %}"
+      \ paraphrase or not?\n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1\
+      \ %}\nTrue\n{% endif %}\n{% endif %}"
     name: PAWS-ANLI GPT3-no-label
     reference: ANLI prompt format from Table G7 in the GPT3 paper. Additionally added
       task information without any label.
+    task_template: true
   32c0f3d5-a6c7-4ab2-a922-3a9d66db309f: !Template
     id: 32c0f3d5-a6c7-4ab2-a922-3a9d66db309f
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
       \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? Yes\
-      \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
-      Yes\n{% endif %}"
+      \ or No? \n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}\n{% endif %}"
     name: Rewrite
     reference: Natural Question
+    task_template: true
   568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
     id: 568abe6e-4014-4d20-b4a0-3b0622026e36
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
       \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning\
-      \ or not\n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
-      Yes\n{% endif %}"
+      \ or not\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}\n{% endif %}"
     name: Meaning-no-label
     reference: Natural question without label
+    task_template: true
   60becf78-b280-43e1-aebb-475ee64076c8: !Template
     id: 60becf78-b280-43e1-aebb-475ee64076c8
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\nIs that a paraphrase\
-      \ of the following sentence?\n{{sentence2}}?\n{% endif %}\n||| \n{% if label\
-      \ == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+      \ of the following sentence?\n{{sentence2}}?\n||| \n{% if label == 0 %} \nNo\n\
+      {% elif label == 1 %}\nYes\n{% endif %}\n{% endif %}"
     name: context-question-no-label
     reference: Generalized prompt format, context-question without any label
+    task_template: true
   68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
     id: 68f76857-66f0-4aa4-ad70-3443cce0c7ae
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
-      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? \n{%\
-      \ endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? \n|||\
+      \ \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}\n{% endif\
       \ %}"
     name: Rewrite-no-label
     reference: Natural Question without label
+    task_template: true
   82dbfba2-24f2-401a-9f81-618ca86f464f: !Template
     id: 82dbfba2-24f2-401a-9f81-618ca86f464f
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
-      \ True or False? \n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label\
-      \ == 1 %}\nTrue\n{% endif %}"
+      \ True or False? \n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1 %}\n\
+      True\n{% endif %}\n{% endif %}"
     name: PAWS-ANLI GPT3
     reference: ANLI prompt format from Table G7 in the GPT3 paper
+    task_template: true
   a922400e-f562-4501-bff7-998e78e9866f: !Template
     id: a922400e-f562-4501-bff7-998e78e9866f
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\nIs that a paraphrase\
-      \ of the following sentence?\n{{sentence2}}?\nYes, No\n{% endif %}\n||| \n{%\
-      \ if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+      \ of the following sentence?\n{{sentence2}}?\nYes, No\n||| \n{% if label ==\
+      \ 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}\n{% endif %}"
     name: context-question
     reference: Generalized prompt format, context-question
+    task_template: true
   ae3fbffe-b99d-4080-8aa0-e9040dcb68f9: !Template
     id: ae3fbffe-b99d-4080-8aa0-e9040dcb68f9
     jinja: "{% if label == 0 or label == 1 %} \nDetermine if the following two sentences\
-      \ paraphrase or not.\n{{sentence1}}\n{{sentence2}}\n{% endif %}\n||| \n{% if\
-      \ label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+      \ paraphrase or not.\n{{sentence1}}\n{{sentence2}}\n||| \n{% if label == 0 %}\
+      \ \nNo\n{% elif label == 1 %}\nYes\n{% endif %}\n{% endif %}"
     name: task_description-no-label
     reference: Generalized prompt format, task_description-input.
+    task_template: true
   c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
     id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
       \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? Yes or\
-      \ No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
-      Yes\n{% endif %}"
+      \ No? \n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}\n{% endif %}"
     name: Concatenation
     reference: Concatenation of sentence 1 and sentence 2
+    task_template: true
   c873732e-c424-417f-a474-f19eff2caf35: !Template
     id: c873732e-c424-417f-a474-f19eff2caf35
-    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence1}} \n{% endif\
-      \ %}\n||| \n{{sentence2}} "
+    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence1}} \n||| \n\
+      {{sentence2}} \n{% endif %}"
     name: paraphrase-task
     reference: Create a generative paraphrase task
+    task_template: false
   d94a57f5-7344-42e8-b8a8-b1fb731d39f8: !Template
     id: d94a57f5-7344-42e8-b8a8-b1fb731d39f8
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
       \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning?\
-      \ Yes or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label ==\
-      \ 1 %}\nYes\n{% endif %}"
+      \ Yes or No? \n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n\
+      {% endif %}\n{% endif %}"
     name: Meaning
     reference: Natural question
+    task_template: true
   e94388e1-bf2f-4be1-8693-23c6ce8277e6: !Template
     id: e94388e1-bf2f-4be1-8693-23c6ce8277e6
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
-      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? \n{% endif\
-      \ %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? \n|||\
+      \ \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}\n{% endif\
+      \ %}"
     name: Concatenation-no-label
     reference: Concatenation of sentence 1 and sentence 2 without any label
+    task_template: true

--- a/templates/paws/unlabeled_final/templates.yaml
+++ b/templates/paws/unlabeled_final/templates.yaml
@@ -3,96 +3,110 @@ subset: unlabeled_final
 templates:
   289448c3-63fc-4904-8387-86d232424243: !Template
     id: 289448c3-63fc-4904-8387-86d232424243
-    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence2}} \n{% endif\
-      \ %}\n||| \n{{sentence1}} "
+    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence2}} \n||| \n\
+      {{sentence1}} \n{% endif %}"
     name: paraphrase-task-reverse
     reference: Create a generative paraphrase task
+    task_template: false
   2ff509a8-2712-4406-97bd-ce86824cdc18: !Template
     id: 2ff509a8-2712-4406-97bd-ce86824cdc18
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
-      \ paraphrase or not?\n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif\
-      \ label == 1 %}\nTrue\n{% endif %}"
+      \ paraphrase or not?\n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1\
+      \ %}\nTrue\n{% endif %}\n{% endif %}"
     name: PAWS-ANLI GPT3-no-label
     reference: ANLI prompt format from Table G7 in the GPT3 paper. Additionally added
       task information without any label.
+    task_template: true
   32c0f3d5-a6c7-4ab2-a922-3a9d66db309f: !Template
     id: 32c0f3d5-a6c7-4ab2-a922-3a9d66db309f
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
       \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? Yes\
-      \ or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
-      Yes\n{% endif %}"
+      \ or No? \n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}\n{% endif %}"
     name: Rewrite
     reference: Natural Question
+    task_template: true
   568abe6e-4014-4d20-b4a0-3b0622026e36: !Template
     id: 568abe6e-4014-4d20-b4a0-3b0622026e36
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
       \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning\
-      \ or not\n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
-      Yes\n{% endif %}"
+      \ or not\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}\n{% endif %}"
     name: Meaning-no-label
     reference: Natural question without label
+    task_template: true
   60becf78-b280-43e1-aebb-475ee64076c8: !Template
     id: 60becf78-b280-43e1-aebb-475ee64076c8
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\nIs that a paraphrase\
-      \ of the following sentence?\n{{sentence2}}?\n{% endif %}\n||| \n{% if label\
-      \ == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+      \ of the following sentence?\n{{sentence2}}?\n||| \n{% if label == 0 %} \nNo\n\
+      {% elif label == 1 %}\nYes\n{% endif %}\n{% endif %}"
     name: context-question-no-label
     reference: Generalized prompt format, context-question without any label
+    task_template: true
   68f76857-66f0-4aa4-ad70-3443cce0c7ae: !Template
     id: 68f76857-66f0-4aa4-ad70-3443cce0c7ae
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
-      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? \n{%\
-      \ endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ 2: {{sentence2}}\\nQuestion: Can we rewrite Sentence 1 by Sentence 2? \n|||\
+      \ \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}\n{% endif\
       \ %}"
     name: Rewrite-no-label
     reference: Natural Question without label
+    task_template: true
   82dbfba2-24f2-401a-9f81-618ca86f464f: !Template
     id: 82dbfba2-24f2-401a-9f81-618ca86f464f
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}} Question: {{sentence2}}\
-      \ True or False? \n{% endif %}\n||| \n{% if label == 0 %} \nFalse\n{% elif label\
-      \ == 1 %}\nTrue\n{% endif %}"
+      \ True or False? \n||| \n{% if label == 0 %} \nFalse\n{% elif label == 1 %}\n\
+      True\n{% endif %}\n{% endif %}"
     name: PAWS-ANLI GPT3
     reference: ANLI prompt format from Table G7 in the GPT3 paper
+    task_template: true
   a922400e-f562-4501-bff7-998e78e9866f: !Template
     id: a922400e-f562-4501-bff7-998e78e9866f
     jinja: "{% if label == 0 or label == 1 %} \n{{sentence1}}\nIs that a paraphrase\
-      \ of the following sentence?\n{{sentence2}}?\nYes, No\n{% endif %}\n||| \n{%\
-      \ if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+      \ of the following sentence?\n{{sentence2}}?\nYes, No\n||| \n{% if label ==\
+      \ 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}\n{% endif %}"
     name: context-question
     reference: Generalized prompt format, context-question
+    task_template: true
   ae3fbffe-b99d-4080-8aa0-e9040dcb68f9: !Template
     id: ae3fbffe-b99d-4080-8aa0-e9040dcb68f9
     jinja: "{% if label == 0 or label == 1 %} \nDetermine if the following two sentences\
-      \ paraphrase or not.\n{{sentence1}}\n{{sentence2}}\n{% endif %}\n||| \n{% if\
-      \ label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+      \ paraphrase or not.\n{{sentence1}}\n{{sentence2}}\n||| \n{% if label == 0 %}\
+      \ \nNo\n{% elif label == 1 %}\nYes\n{% endif %}\n{% endif %}"
     name: task_description-no-label
     reference: Generalized prompt format, task_description-input.
+    task_template: true
   c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad: !Template
     id: c7e71c01-ea6d-4cff-ad2d-c05d4a7ce9ad
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
       \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? Yes or\
-      \ No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\n\
-      Yes\n{% endif %}"
+      \ No? \n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif\
+      \ %}\n{% endif %}"
     name: Concatenation
     reference: Concatenation of sentence 1 and sentence 2
+    task_template: true
   c873732e-c424-417f-a474-f19eff2caf35: !Template
     id: c873732e-c424-417f-a474-f19eff2caf35
-    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence1}} \n{% endif\
-      \ %}\n||| \n{{sentence2}} "
+    jinja: "{% if label == 1 %} \nParaphrase the sentence: {{sentence1}} \n||| \n\
+      {{sentence2}} \n{% endif %}"
     name: paraphrase-task
     reference: Create a generative paraphrase task
+    task_template: false
   d94a57f5-7344-42e8-b8a8-b1fb731d39f8: !Template
     id: d94a57f5-7344-42e8-b8a8-b1fb731d39f8
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
       \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 and Sentence 2 express same meaning?\
-      \ Yes or No? \n{% endif %}\n||| \n{% if label == 0 %} \nNo\n{% elif label ==\
-      \ 1 %}\nYes\n{% endif %}"
+      \ Yes or No? \n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n\
+      {% endif %}\n{% endif %}"
     name: Meaning
     reference: Natural question
+    task_template: true
   e94388e1-bf2f-4be1-8693-23c6ce8277e6: !Template
     id: e94388e1-bf2f-4be1-8693-23c6ce8277e6
     jinja: "{% if label == 0 or label == 1 %} \nSentence 1: {{sentence1}}\\nSentence\
-      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? \n{% endif\
-      \ %}\n||| \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+      \ 2: {{sentence2}}\\nQuestion: Does Sentence 1 paraphrase Sentence 2? \n|||\
+      \ \n{% if label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}\n{% endif\
+      \ %}"
     name: Concatenation-no-label
     reference: Concatenation of sentence 1 and sentence 2 without any label
+    task_template: true


### PR DESCRIPTION
Earlier there was a bug in the template.
The templates were written targeting specific labels. For some cases, if the condition fails, it stills augments text on the target (label).
Now, if the condition fails no text will be generated both for input and label. 