### PR TITLE
blank template output detection.

### DIFF
--- a/test/show_templates.py
+++ b/test/show_templates.py
@@ -55,12 +55,7 @@ for template_name in template_list:
         print("\tExample ", example)
         print("\t--------")
         output = template.apply(example)
-        flag=True
-        for idx, val in enumerate(output):
-            output[idx] = val.strip()
-            if output[idx] != "":
-                flag=False
-        if flag:
+        if output[0].strip() == "" or (len(output) > 1 and output[1].strip() == ""):
             print("\t Blank result")
             continue
 

--- a/test/show_templates.py
+++ b/test/show_templates.py
@@ -55,7 +55,12 @@ for template_name in template_list:
         print("\tExample ", example)
         print("\t--------")
         output = template.apply(example)
-        if output == [""]:
+        flag=True
+        for idx, val in enumerate(output):
+            output[idx] = val.strip()
+            if output[idx] != "":
+                flag=False
+        if flag:
             print("\t Blank result")
             continue
 


### PR DESCRIPTION
The current `blank-output-detection` implementation here is https://github.com/bigscience-workshop/promptsource/blob/main/test/show_templates.py#L58 
However it could happen that a template sometimes generates only newline like `["\n\n"]` which should be also considered as empty line. For this reason one of the test is failing here, https://github.com/bigscience-workshop/promptsource/pull/214/checks?check_run_id=2809192166
I wasn't able to understand why a template generates only new line. The templates that generates double new line ("\n\n") is here  https://github.com/sbmaruf/promptsource/blob/tydiqa/templates/tydiqa/primary_task/templates.yaml#L87
I believe this pull should solve the issue without any conflict.