### PR TITLE
Add template for Mocha dataset

### DIFF
--- a/templates/mocha/templates.yaml
+++ b/templates/mocha/templates.yaml
@@ -11,6 +11,7 @@ templates:
     name: (Regression) Scoring Candidate against Reference
     reference: Similarity measure between candidate and reference answers (in a regression
       manner)
+    task_template: true
   2816084e-0193-4284-9a4f-9de4ae03e9d6: !Template
     id: 2816084e-0193-4284-9a4f-9de4ae03e9d6
     jinja: "Given the passage and the answers given below, generate a relevant question\
@@ -26,10 +27,11 @@ templates:
       \ answer above? Answer yes or no. \n\n{% if candidate2 and score2 != 3 %}\n\
       Is the answer \"{{ candidate2 }}\" similar to the answer above? Answer yes or\
       \ no. \n{% endif %}\n|||\n{{ [\"no\", \"yes\"][score > 3] }} \n\n{{[\"no\",\
-      \ \"yes\"][score2 > 3] if candidate2 != \"\"}}\n{% endif %}"
+      \ \"yes\"][score2 > 3] if candidate2 != \"\" else \"\"}}\n{% endif %}"
     name: (Classification) Scoring Candidate against Reference
     reference: Similarity measure between candidate and reference answers (in a classification
       manner)
+    task_template: false
   7ebdd3bc-4896-425b-b8c2-3e4ea3944de8: !Template
     id: 7ebdd3bc-4896-425b-b8c2-3e4ea3944de8
     jinja: '{{ context }}
@@ -54,10 +56,20 @@ templates:
       be incorrect), generate the correct answer.
   c06f4d3a-5a95-4b6a-b339-32391c8e6d94: !Template
     id: c06f4d3a-5a95-4b6a-b339-32391c8e6d94
-    jinja: "Passage: {{ context }}\n\nQuestion: {{ question }}\n\nAnswers: \n\n1.\
-      \ {{ reference }}\n\n2. {{ candidate }}\n\n{% if candidate2 %}\n3. {{ candidate2\
-      \ }}\n{% endif %}\n\nSelect all the correct answers to the question, given the\
-      \ passage above.\n|||\n1 {{ \"2\" if score >= 3 }} {{ \"3\" if score2 >= 3 }}"
+    jinja: "{% set candidates = [] %}\n{{ candidates.append(reference) or ''}}\n{{\
+      \ candidates.append(candidate) or ''}}\n\n{% if candidate2 %}\n{{ candidates.append(candidate2)\
+      \ }}\n{% endif %}\n\n{# arbitrarily right shift the candidates list so the answer\
+      \ listed out in prompt looks random #}\n{% set length_text = context | length\
+      \ %}\n{% if length_text % 2 == 1 %}\n{% set new_candidates = candidates[-1:]\
+      \ + candidates[:-1] %}\n{{ candidates.append(candidate2) }}\n{% else %}\n{%\
+      \ set new_candidates = candidates %}\n{% endif %}\n\nPassage: {{ context }}\n\
+      \nQuestion: {{ question }}\n\nAnswers: \n\n{% for cd in new_candidates %}\n\
+      {{loop.index}}. {{cd}}\n{% endfor %}\n\n\nSelect all the correct answers to\
+      \ the question, given the passage above.\n|||\n{% for cd in new_candidates %}\n\
+      {% if cd == reference %}\n{{ loop.index }}\n{% elif cd == candidate and score\
+      \ >= 3%}\n{{ loop.index }}\n{% elif cd == candidate2 and score2 >= 3%}\n{{ loop.index\
+      \ }}\n{% endif %}\n{% endfor %}"
     name: Pick Correct Answers
     reference: Given passage, question, and all possible answers, pick correct answers  (using
       similarity cutoff >=3 to reference answer)
+    task_template: false

--- a/templates/mocha/templates.yaml
+++ b/templates/mocha/templates.yaml
@@ -56,19 +56,19 @@ templates:
       be incorrect), generate the correct answer.
   c06f4d3a-5a95-4b6a-b339-32391c8e6d94: !Template
     id: c06f4d3a-5a95-4b6a-b339-32391c8e6d94
-    jinja: "{% set candidates = [] %}\n{{ candidates.append(reference) or ''}}\n{{\
-      \ candidates.append(candidate) or ''}}\n\n{% if candidate2 %}\n{{ candidates.append(candidate2)\
-      \ }}\n{% endif %}\n\n{# arbitrarily right shift the candidates list so the answer\
-      \ listed out in prompt looks random #}\n{% set length_text = context | length\
-      \ %}\n\n{% if length_text % 2 == 1 %}\n{% set new_candidates = candidates[-1:]\
-      \ + candidates[:-1] %}\n{% else %}\n{% set new_candidates = candidates[:] %}\n\
-      {% endif %}\n\nPassage: {{ context }}\n\nQuestion: {{ question }}\n\nAnswers:\
-      \ \n\n{% for cd in new_candidates %}\n{{loop.index}}. {{cd}}\n{% endfor %}\n\
-      \n\nSelect all the correct answers to the question, given the passage above.\n\
-      |||\n{% for cd in new_candidates %}\n{% if cd == reference %}\n{{ loop.index\
-      \ }}\n{% elif cd == candidate and score >= 3%}\n{{ loop.index }}\n{% elif cd\
-      \ == candidate2 and score2 >= 3%}\n{{ loop.index }}\n{% endif %}\n{% endfor\
-      \ %}"
+    jinja: "{% set candidates = [] %}\n{% set new_candidates = [] %}\n{{ candidates.append(reference)\
+      \ or ''}}\n{{ candidates.append(candidate) or ''}}\n\n{% if candidate2 %}\n\
+      {{ candidates.append(candidate2) }}\n{% endif %}\n\n{# arbitrarily right shift\
+      \ the candidates list so the answer listed out in prompt looks random #}\n{%\
+      \ set length_text = context | length %}\n\n{% if length_text % 2 == 1 %}\n{%\
+      \ set new_candidates = candidates[-1:] + candidates[:-1] %}\n{% else %}\n{%\
+      \ set new_candidates = candidates[:] %}\n{% endif %}\n\nPassage: {{ context\
+      \ }}\n\nQuestion: {{ question }}\n\nAnswers: \n\n{% for cd in new_candidates\
+      \ %}\n{{loop.index}}. {{cd}}\n{% endfor %}\n\n\nSelect all the correct answers\
+      \ to the question, given the passage above.\n|||\n{% for cd in new_candidates\
+      \ %}\n{% if cd == reference %}\n{{ loop.index }}\n{% elif cd == candidate and\
+      \ score >= 3%}\n{{ loop.index }}\n{% elif cd == candidate2 and score2 >= 3%}\n\
+      {{ loop.index }}\n{% endif %}\n{% endfor %}"
     name: Pick Correct Answers
     reference: Given passage, question, and all possible answers, pick correct answers  (using
       similarity cutoff >=3 to reference answer)

--- a/templates/mocha/templates.yaml
+++ b/templates/mocha/templates.yaml
@@ -1,0 +1,63 @@
+dataset: mocha
+templates:
+  1c390ee6-fab9-4b16-8028-2649fca56866: !Template
+    id: 1c390ee6-fab9-4b16-8028-2649fca56866
+    jinja: "On a scale of 1 to 5, how similar are these two sentences \n\n(1) \"{{candidate}}\"\
+      \n\n(2) \"{{reference}}\" \n\ngiven the question of \"{{ question }}\" and the\
+      \ context of \"{{ context }}\"?\n\n{% if candidate2 %}\nFollow-up question:\
+      \ What about these two sentences: \n(1) \"{{reference}}\"\n(2) \"{{ candidate2\
+      \ }}\"\n{% endif %}\n|||\n{{ score }} \n\n{{ score2 if candidate2 else \"\"\
+      \ }}\n"
+    name: (Regression) Scoring Candidate against Reference
+    reference: Similarity measure between candidate and reference answers (in a regression
+      manner)
+  2816084e-0193-4284-9a4f-9de4ae03e9d6: !Template
+    id: 2816084e-0193-4284-9a4f-9de4ae03e9d6
+    jinja: "Given the passage and the answers given below, generate a relevant question\
+      \ and pick the corresponding answer.\n\nPassage: {{ context }}\n\nAnswer 1 (Gold):\
+      \ {{ reference }}\n\nAnswer 2: {{ candidate }}\n\n{% if candidate2 %}\nAnswer\
+      \ 3: {{ candidate2 }}\n{% endif %} \n|||\n{{ question }}"
+    name: Generate Question
+    reference: Given passage and the answers, generate a question for the gold answer.
+  6269d541-6e7b-48c1-ae7a-2808385c40c6: !Template
+    id: 6269d541-6e7b-48c1-ae7a-2808385c40c6
+    jinja: "{% if score != 3 %}\nPassage: {{ context }}\n\nQuestion: {{ question }}\n\
+      \nAnswer: {{ reference }}\n\nIs the answer \"{{ candidate }}\" similar to the\
+      \ answer above? Answer yes or no. \n\n{% if candidate2 and score2 != 3 %}\n\
+      Is the answer \"{{ candidate2 }}\" similar to the answer above? Answer yes or\
+      \ no. \n{% endif %}\n|||\n{{ [\"no\", \"yes\"][score > 3] }} \n\n{{[\"no\",\
+      \ \"yes\"][score2 > 3] if candidate2 != \"\"}}\n{% endif %}"
+    name: (Classification) Scoring Candidate against Reference
+    reference: Similarity measure between candidate and reference answers (in a classification
+      manner)
+  7ebdd3bc-4896-425b-b8c2-3e4ea3944de8: !Template
+    id: 7ebdd3bc-4896-425b-b8c2-3e4ea3944de8
+    jinja: '{{ context }}
+
+
+      Given the passage above, what is the answer to the question "{{ question }}"
+
+
+      You can refer to the following candidate answer(s):
+
+
+      Candidate Answer 1: {{ candidate }}
+
+
+      Candidate Answer 2: {{ candidate2 if candidate2 else "-" }}
+
+      |||
+
+      {{ reference }}'
+    name: Generate Correct Answer using Noisy Candidate
+    reference: Given the passage, the question, and the candidate answer (that may
+      be incorrect), generate the correct answer.
+  c06f4d3a-5a95-4b6a-b339-32391c8e6d94: !Template
+    id: c06f4d3a-5a95-4b6a-b339-32391c8e6d94
+    jinja: "Passage: {{ context }}\n\nQuestion: {{ question }}\n\nAnswers: \n\n1.\
+      \ {{ reference }}\n\n2. {{ candidate }}\n\n{% if candidate2 %}\n3. {{ candidate2\
+      \ }}\n{% endif %}\n\nSelect all the correct answers to the question, given the\
+      \ passage above.\n|||\n1 {{ \"2\" if score >= 3 }} {{ \"3\" if score2 >= 3 }}"
+    name: Pick Correct Answers
+    reference: Given passage, question, and all possible answers, pick correct answers  (using
+      similarity cutoff >=3 to reference answer)

--- a/templates/mocha/templates.yaml
+++ b/templates/mocha/templates.yaml
@@ -5,7 +5,7 @@ templates:
     jinja: "On a scale of 1 to 5, how similar are these two sentences \n\n(1) \"{{candidate}}\"\
       \n\n(2) \"{{reference}}\" \n\ngiven the question of \"{{ question }}\" and the\
       \ context of \"{{ context }}\"?\n\n{% if candidate2 %}\nFollow-up question:\
-      \ What about these two sentences: \n(1) \"{{reference}}\"\n(2) \"{{ candidate2\
+      \ What about these two sentences: \n\n(1) \"{{reference}}\"\n\n(2) \"{{ candidate2\
       \ }}\"\n{% endif %}\n|||\n{{ score }} \n\n{{ score2 if candidate2 else \"\"\
       \ }}\n"
     name: (Regression) Scoring Candidate against Reference
@@ -20,6 +20,30 @@ templates:
       \ 3: {{ candidate2 }}\n{% endif %} \n|||\n{{ question }}"
     name: Generate Question
     reference: Given passage and the answers, generate a question for the gold answer.
+  31e49d18-800f-4d16-8d84-86509db30499: !Template
+    id: 31e49d18-800f-4d16-8d84-86509db30499
+    jinja: "{% if score != 3 %}\nPerson A: {{ question }}\n\nPerson B: {{ reference\
+      \ }}\n\nPerson C: {{ candidate }}\n\n{% if candidate2 and score2 != 3 %}\nPerson\
+      \ D: {{ candidate2 }}\n{% endif %}\n\nDoes Person B give a similar answer as\
+      \ Person C? {{ \" What about Person B's answer to Person D's?\" if candidate2\
+      \ else \"\" }} Answer \"similar\" or \"not similar\".\n\n\n|||\n{{ [\"not similar\"\
+      , \"similar\"][score > 3] }} \n\n{{[\"not similar\", \"similar\"][score2 > 3]\
+      \ if candidate2 != \"\" else \"\"}}\n{% endif %}"
+    name: (Classification) Scoring Candidate against Reference w/o Context
+    reference: Similarity measure between candidate and reference answers (in a classification
+      manner)
+    task_template: false
+  5098f807-5558-4d19-af12-7bb87cbc59f0: !Template
+    id: 5098f807-5558-4d19-af12-7bb87cbc59f0
+    jinja: "Question: {{ question }}\n\nAnswer A: \"{{reference}}\"\n\nAnswer B: \"\
+      {{candidate}}\" \n\n{% if candidate2 %}\nAnswer C: \"{{ candidate2 }}\"\n{%\
+      \ endif %}\n\nGive the similarity measure (on a scale of 1 to 5) for answers\
+      \ A and B. {{ \"Do the same for answers A and C.\" if candidate2 else \"\" }}\n\
+      \n|||\n{{ score }} \n\n{{ score2 if candidate2 else \"\" }}\n"
+    name: (Regression) Scoring Candidate against Reference w/o Context
+    reference: Similarity measure between candidate and reference answers (in a regression
+      manner)
+    task_template: false
   6269d541-6e7b-48c1-ae7a-2808385c40c6: !Template
     id: 6269d541-6e7b-48c1-ae7a-2808385c40c6
     jinja: "{% if score != 3 %}\nPassage: {{ context }}\n\nQuestion: {{ question }}\n\
@@ -30,6 +54,18 @@ templates:
       \ \"yes\"][score2 > 3] if candidate2 != \"\" else \"\"}}\n{% endif %}"
     name: (Classification) Scoring Candidate against Reference
     reference: Similarity measure between candidate and reference answers (in a classification
+      manner)
+    task_template: false
+  6570aa7f-de3d-489e-8565-72fb535b1f10: !Template
+    id: 6570aa7f-de3d-489e-8565-72fb535b1f10
+    jinja: "Sentence (1): \"{{candidate}}\"\n\nSentence (2): \"{{reference}}\" \n\n\
+      {% if candidate2 %}\nSentence (3): \"{{ candidate2 }}\"\n{% endif %}\n\nHow\
+      \ similar are Sentence (1) and (2)?{{ \" What about Sentence (2) and (3)?\"\
+      \ if candidate2 else \"\" }} Output the result value between 1 (completely different)\
+      \ and 5 (identical). \n|||\n{{ score }} \n\n{{ score2 if candidate2 else \"\"\
+      \ }}\n"
+    name: (Regression) Scoring Candidate against Reference w/o Question and Context
+    reference: Similarity measure between candidate and reference answers (in a regression
       manner)
     task_template: false
   7ebdd3bc-4896-425b-b8c2-3e4ea3944de8: !Template
@@ -54,6 +90,17 @@ templates:
     name: Generate Correct Answer using Noisy Candidate
     reference: Given the passage, the question, and the candidate answer (that may
       be incorrect), generate the correct answer.
+  900786a8-1841-438e-b79a-9ceb350c3271: !Template
+    id: 900786a8-1841-438e-b79a-9ceb350c3271
+    jinja: "{% if score != 3 %}\nDoes the pair of sentences have similar meanings?\
+      \ Answer yes or no.\n\n\"{{ reference }}\" / \"{{ candidate }}\"\n\n{% if candidate2\
+      \ and score2 != 3 %}\n\"{{ reference }}\" / \"{{ candidate2 }}\"\n{% endif %}\n\
+      |||\n{{ [\"no\", \"yes\"][score > 3] }} \n\n{{[\"no\", \"yes\"][score2 > 3]\
+      \ if candidate2 != \"\" else \"\"}}\n{% endif %}"
+    name: (Classification) Scoring Candidate against Reference w/o Context and Question
+    reference: Similarity measure between candidate and reference answers (in a classification
+      manner)
+    task_template: false
   c06f4d3a-5a95-4b6a-b339-32391c8e6d94: !Template
     id: c06f4d3a-5a95-4b6a-b339-32391c8e6d94
     jinja: "{% set candidates = [] %}\n{% set new_candidates = [] %}\n{{ candidates.append(reference)\

--- a/templates/mocha/templates.yaml
+++ b/templates/mocha/templates.yaml
@@ -60,15 +60,15 @@ templates:
       \ candidates.append(candidate) or ''}}\n\n{% if candidate2 %}\n{{ candidates.append(candidate2)\
       \ }}\n{% endif %}\n\n{# arbitrarily right shift the candidates list so the answer\
       \ listed out in prompt looks random #}\n{% set length_text = context | length\
-      \ %}\n{% if length_text % 2 == 1 %}\n{% set new_candidates = candidates[-1:]\
-      \ + candidates[:-1] %}\n{{ candidates.append(candidate2) }}\n{% else %}\n{%\
-      \ set new_candidates = candidates %}\n{% endif %}\n\nPassage: {{ context }}\n\
-      \nQuestion: {{ question }}\n\nAnswers: \n\n{% for cd in new_candidates %}\n\
-      {{loop.index}}. {{cd}}\n{% endfor %}\n\n\nSelect all the correct answers to\
-      \ the question, given the passage above.\n|||\n{% for cd in new_candidates %}\n\
-      {% if cd == reference %}\n{{ loop.index }}\n{% elif cd == candidate and score\
-      \ >= 3%}\n{{ loop.index }}\n{% elif cd == candidate2 and score2 >= 3%}\n{{ loop.index\
-      \ }}\n{% endif %}\n{% endfor %}"
+      \ %}\n\n{% if length_text % 2 == 1 %}\n{% set new_candidates = candidates[-1:]\
+      \ + candidates[:-1] %}\n{% else %}\n{% set new_candidates = candidates[:] %}\n\
+      {% endif %}\n\nPassage: {{ context }}\n\nQuestion: {{ question }}\n\nAnswers:\
+      \ \n\n{% for cd in new_candidates %}\n{{loop.index}}. {{cd}}\n{% endfor %}\n\
+      \n\nSelect all the correct answers to the question, given the passage above.\n\
+      |||\n{% for cd in new_candidates %}\n{% if cd == reference %}\n{{ loop.index\
+      \ }}\n{% elif cd == candidate and score >= 3%}\n{{ loop.index }}\n{% elif cd\
+      \ == candidate2 and score2 >= 3%}\n{{ loop.index }}\n{% endif %}\n{% endfor\
+      \ %}"
     name: Pick Correct Answers
     reference: Given passage, question, and all possible answers, pick correct answers  (using
       similarity cutoff >=3 to reference answer)


### PR DESCRIPTION
Notes:
1. The dataset has a "minimal_pairs" split that has two candidate answers instead of one (as in the "train", "validation", "test" split). I have include if-else blocks to handle them. 
2. For the `Pick Correct Answer` template, to prevent the reference answer from always showing up as the first answer, I use the following hack: use the length of the passage to determine if we should right shift the list of answers (that includes reference and candidates). If so, perform the right shift before listing the answers out. 