### PR TITLE
Prompts for SuperGLUE: BoolQ, COPA, MultiRC, ReCoRD, WSC

### DIFF
--- a/templates/super_glue/boolq/templates.yaml
+++ b/templates/super_glue/boolq/templates.yaml
@@ -7,12 +7,28 @@ templates:
       True\"][label] }} "
     name: GPT-3 Style
     reference: Same as Figure G29, p. 58 of the GPT-3 paper
+    task_template: true
+  6cb6a026-c070-470a-b75d-bb8fdf424e35: !Template
+    id: 6cb6a026-c070-470a-b75d-bb8fdf424e35
+    jinja: "{{ passage }} \n\nHaving read that, I wonder {{ question }}? ||| {{ [\"\
+      No\", \"Yes\"][label] }} "
+    name: "I wonder\u2026"
+    reference: ''
+    task_template: true
+  7d21d974-0624-4d4f-9e8c-644e2d009cb5: !Template
+    id: 7d21d974-0624-4d4f-9e8c-644e2d009cb5
+    jinja: "{{ passage }} \n\nHaving read that, could you tell me {{ question }}?\
+      \ ||| {{ [\"No\", \"Yes\"][label] }} "
+    name: "could you tell me\u2026"
+    reference: ''
+    task_template: true
   9a1bf459-8047-437c-9def-f21e960429cc: !Template
     id: 9a1bf459-8047-437c-9def-f21e960429cc
     jinja: "Based on the following passage, {{ passage }} \n{{ question }}? ||| {{\
       \ [\"No\", \"Yes\"][label] }} "
     name: based on the following passage
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+    task_template: true
   b2b3cb60-d6e3-491c-a09a-8201e13e417e: !Template
     id: b2b3cb60-d6e3-491c-a09a-8201e13e417e
     jinja: '{{ passage }}
@@ -20,3 +36,4 @@ templates:
       Based on the previous passage, {{ question }}? ||| {{ ["No", "Yes"][label] }} '
     name: based on the previous passage
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+    task_template: true

--- a/templates/super_glue/cb/templates.yaml
+++ b/templates/super_glue/cb/templates.yaml
@@ -10,10 +10,11 @@ templates:
     reference: Copied from Victor's prompts for XNLI.
   5bca1a90-340b-42b4-9c0d-e5eb1c25605e: !Template
     id: 5bca1a90-340b-42b4-9c0d-e5eb1c25605e
-    jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes, no, or maybe?
-      ||| {{ ["Yes", "Maybe", "No"][label] }}
+    jinja: Given that {{premise}} Does it follow that {{hypothesis}}? {{"Yes, no,
+      or maybe?"}} ||| {{ ["Yes", "Maybe", "No"][label] }}
     name: "given\u2026 does it follow that\u2026 "
     reference: ''
+    task_template: true
   684f44af-f09a-4231-a318-94473a9624b7: !Template
     id: 684f44af-f09a-4231-a318-94473a9624b7
     jinja: Given that {{premise}}, it {{"must be true, might be true, or must be false"}}
@@ -24,12 +25,14 @@ templates:
       is the most natural way of how I say an NLI sentence pair out loud to humans.
       Caveat: NLI annotations are not meant to be strictly truth-conditional entailment,
       so "must" is not ideal.'
+    task_template: false
   774c170e-9fff-4b0b-871a-30967b0186f6: !Template
     id: 774c170e-9fff-4b0b-871a-30967b0186f6
     jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
       Yes, no, or maybe? ||| {{ ["Yes", "Maybe", "No"][label] }}'
     name: based on the previous passage
     reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+    task_template: true
   86120953-771a-4dca-a681-d628117ba6d2: !Template
     id: 86120953-771a-4dca-a681-d628117ba6d2
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
@@ -37,12 +40,14 @@ templates:
       {% elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
     name: does S1 entail S2?
     reference: Copied from Victor's prompts for XNLI.
+    task_template: true
   bab42d43-d1e6-4a42-8112-75a398fd582c: !Template
     id: bab42d43-d1e6-4a42-8112-75a398fd582c
     jinja: '{{premise}}
 
-      Question: {{hypothesis}} True, False, or Neither? ||| {{ ["True", "Neither",
+      Question: {{hypothesis}}. True, False, or Neither? ||| {{ ["True", "Neither",
       "False"][label] }}'
     name: GPT-3 style
     reference: 'Same as reported in Figure G7 of the GPT-3 paper, except that there
       is no task identifying tokens like "anli R1: ".'
+    task_template: true

--- a/templates/super_glue/copa/templates.yaml
+++ b/templates/super_glue/copa/templates.yaml
@@ -1,9 +1,47 @@
 dataset: super_glue
 subset: copa
 templates:
+  150789fe-e309-47a1-82c9-0a4dc2c6b12b: !Template
+    id: 150789fe-e309-47a1-82c9-0a4dc2c6b12b
+    jinja: "{% if question == \"effect\" %} \n{{ premise }} What could happen next,\
+      \ \"{{ choice1 }}\" or \"{{ choice2 }}\"? ||| {{ [choice1, choice2][label] }}\n\
+      {% endif %}"
+    name: "\u2026What could happen next, C1 or C2?"
+    reference: ''
+    task_template: true
   744047dc-1298-45a2-8d68-d67e3f834ded: !Template
     id: 744047dc-1298-45a2-8d68-d67e3f834ded
     jinja: '"{{ choice1 }}" or "{{ choice2 }}"? {{ premise }} {% if question == "cause"
       %} because {% else %} so {% endif %} ||| {{ [choice1, choice2][label] }}'
     name: "C1 or C2? premise, so/because\u2026"
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+    task_template: true
+  84da62c2-9440-4cfc-bdd4-d70c65e33a82: !Template
+    id: 84da62c2-9440-4cfc-bdd4-d70c65e33a82
+    jinja: "{% if question == \"effect\" %} \n{{ premise }} As a result, \"{{ choice1\
+      \ }}\" or \"{{ choice2 }}\"? ||| {{ [choice1, choice2][label] }}\n{% endif %}"
+    name: "\u2026As a result, C1 or C2?"
+    reference: ''
+    task_template: true
+  8cf2ba73-aee5-4651-b5d4-b1b88afe4abb: !Template
+    id: 8cf2ba73-aee5-4651-b5d4-b1b88afe4abb
+    jinja: "{% if question == \"cause\" %} \n{{ premise }} Which may be caused by\
+      \ \"{{ choice1 }}\" or \"{{ choice2 }}\"? ||| {{ [choice1, choice2][label] }}\n\
+      {% endif %}"
+    name: "\u2026which may be caused by"
+    reference: ''
+    task_template: true
+  a8bf11c3-bea2-45ba-a533-957d8bee5e2e: !Template
+    id: a8bf11c3-bea2-45ba-a533-957d8bee5e2e
+    jinja: "{% if question == \"cause\" %} \n{{ premise }} Why? \"{{ choice1 }}\"\
+      \ or \"{{ choice2 }}\"? ||| {{ [choice1, choice2][label] }}\n{% endif %}"
+    name: "\u2026why? C1 or C2"
+    reference: ''
+    task_template: true
+  f794f8d0-e81b-4ba9-bc3d-dc8201c38954: !Template
+    id: f794f8d0-e81b-4ba9-bc3d-dc8201c38954
+    jinja: "{% if question == \"effect\" %} \n{{ premise }} Which may cause \"{{ choice1\
+      \ }}\" or \"{{ choice2 }}\"? ||| {{ [choice1, choice2][label] }}\n{% endif %}"
+    name: "\u2026which may cause C1 or C2?"
+    reference: ''
+    task_template: true

--- a/templates/super_glue/multirc/templates.yaml
+++ b/templates/super_glue/multirc/templates.yaml
@@ -7,15 +7,32 @@ templates:
       {{ answer }}\" a correct answer? ||| {{ [\"No\", \"Yes\"][label] }}"
     name: "is\u2026 a correct answer?"
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+    task_template: true
+  4fc9e1ea-7451-4dba-a2cb-ce870e35ef8b: !Template
+    id: 4fc9e1ea-7451-4dba-a2cb-ce870e35ef8b
+    jinja: "{{ paragraph }}\n{{ question }} \nWould it be good to answer \"{{ answer\
+      \ }}\"? ||| {{ [\"No\", \"Yes\"][label] }}"
+    name: "Would it be good to answer\u2026"
+    reference: ''
+    task_template: true
   59a2d847-27f3-4002-a125-cf9a291b3098: !Template
     id: 59a2d847-27f3-4002-a125-cf9a291b3098
     jinja: "{{ paragraph }}\nQuestion: {{ question }} \nIs it {{ answer }}? ||| {{\
       \ [\"No\", \"Yes\"][label] }}"
     name: "paragraph\u2026 question\u2026 is it\u2026 ?"
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+    task_template: true
   7d878b89-2774-429a-82fb-ac801379e3ae: !Template
     id: 7d878b89-2774-429a-82fb-ac801379e3ae
     jinja: "{{ paragraph }}\nQuestion: {{ question }} \nIs the correct answer {{ answer\
       \ }}? ||| {{ [\"No\", \"Yes\"][label] }}"
     name: "is the correct answer\u2026"
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+    task_template: true
+  d2d78b88-8845-45b5-935a-6451da00b285: !Template
+    id: d2d78b88-8845-45b5-935a-6451da00b285
+    jinja: "{{ paragraph }}\n{{ question }} \nI was going to say \"{{ answer }}\"\
+      . Does that sound right? ||| {{ [\"No\", \"Yes\"][label] }}"
+    name: "I was going to say\u2026"
+    reference: ''
+    task_template: true

--- a/templates/super_glue/record/templates.yaml
+++ b/templates/super_glue/record/templates.yaml
@@ -1,15 +1,38 @@
 dataset: super_glue
 subset: record
 templates:
+  014b669e-2e3b-40ce-bdde-418966c7d666: !Template
+    id: 014b669e-2e3b-40ce-bdde-418966c7d666
+    jinja: "{{ passage }} \n{{ query }} \nWhich one is the placeholder? {{ entities\
+      \ | join(\", \") }}? ||| {{ answers | choice }}"
+    name: Which one is the placeholder?
+    reference: ''
+    task_template: true
+  91555c1c-c1e4-469b-a2a4-fc952ce1a145: !Template
+    id: 91555c1c-c1e4-469b-a2a4-fc952ce1a145
+    jinja: "{{ passage }} \n{{ query }} \nIn the passage and question above, the placeholders\
+      \ stand for ||| {{ answers | choice }}"
+    name: stand for
+    reference: ''
+    task_template: true
+  99dd38ce-32f3-4d58-93c5-59821002b9cc: !Template
+    id: 99dd38ce-32f3-4d58-93c5-59821002b9cc
+    jinja: "{{ passage }} \n{{ query }} \nWhat could the placeholders be? {{ entities\
+      \ | join(\", \") }}? ||| {{ answers | choice }}"
+    name: What could the placeholders be?
+    reference: ''
+    task_template: true
   a5ed27ed-162b-4ac1-9c7a-85059d5214be: !Template
     id: a5ed27ed-162b-4ac1-9c7a-85059d5214be
-    jinja: "{{ passage }} \n{{ query }} \nThe{% if answers | length < 2 %} placeholder\
-      \ refers {% else %} placeholders refer {% endif %}to ||| {{ answers | join(\"\
-      , \") }}"
+    jinja: "{{ passage }} \n{{ query }} \nHere, the placeholders refer to ||| {{ answers\
+      \ | choice }}"
     name: "the placeholders refer to\u2026"
     reference: ''
-  ff9aee36-c6da-48ca-816d-b4222526f8cd: !Template
-    id: ff9aee36-c6da-48ca-816d-b4222526f8cd
-    jinja: "{{ passage }} \n{{ query }} ||| {{ answers | join(\", \") }}"
-    name: naive LM
-    reference: "Adapted from Schick & Sch\xFCtz 2021."
+    task_template: true
+  e68d13c5-df75-4de0-b59e-f2eaf4af6ce7: !Template
+    id: e68d13c5-df75-4de0-b59e-f2eaf4af6ce7
+    jinja: "{{ passage }} \n{{ query }} \nCan you figure out what do the placeholders\
+      \ mean? It means ||| {{ answers | choice }}"
+    name: "Can you figure out\u2026"
+    reference: ''
+    task_template: true

--- a/templates/super_glue/record/templates.yaml
+++ b/templates/super_glue/record/templates.yaml
@@ -10,28 +10,28 @@ templates:
     task_template: true
   91555c1c-c1e4-469b-a2a4-fc952ce1a145: !Template
     id: 91555c1c-c1e4-469b-a2a4-fc952ce1a145
-    jinja: "{{ passage }} \n{{ query }} \nIn the passage and question above, the placeholders\
-      \ stand for ||| {{ answers | choice }}"
-    name: stand for
+    jinja: "{{ passage }} \n{{ query }} \nIn the question above, the placeholder stands\
+      \ for ||| {{ answers | choice }}"
+    name: In the question above, the placeholder stands for
     reference: ''
     task_template: true
   99dd38ce-32f3-4d58-93c5-59821002b9cc: !Template
     id: 99dd38ce-32f3-4d58-93c5-59821002b9cc
-    jinja: "{{ passage }} \n{{ query }} \nWhat could the placeholders be? {{ entities\
+    jinja: "{{ passage }} \n{{ query }} \nWhat could the placeholder be? {{ entities\
       \ | join(\", \") }}? ||| {{ answers | choice }}"
-    name: What could the placeholders be?
+    name: What could the placeholder be?
     reference: ''
     task_template: true
   a5ed27ed-162b-4ac1-9c7a-85059d5214be: !Template
     id: a5ed27ed-162b-4ac1-9c7a-85059d5214be
-    jinja: "{{ passage }} \n{{ query }} \nHere, the placeholders refer to ||| {{ answers\
+    jinja: "{{ passage }} \n{{ query }} \nHere, the placeholder refers to ||| {{ answers\
       \ | choice }}"
-    name: "the placeholders refer to\u2026"
+    name: "the placeholder refers to\u2026"
     reference: ''
     task_template: true
   e68d13c5-df75-4de0-b59e-f2eaf4af6ce7: !Template
     id: e68d13c5-df75-4de0-b59e-f2eaf4af6ce7
-    jinja: "{{ passage }} \n{{ query }} \nCan you figure out what do the placeholders\
+    jinja: "{{ passage }} \n{{ query }} \nCan you figure out what does the placeholder\
       \ mean? It means ||| {{ answers | choice }}"
     name: "Can you figure out\u2026"
     reference: ''

--- a/templates/super_glue/record/templates.yaml
+++ b/templates/super_glue/record/templates.yaml
@@ -3,21 +3,21 @@ subset: record
 templates:
   014b669e-2e3b-40ce-bdde-418966c7d666: !Template
     id: 014b669e-2e3b-40ce-bdde-418966c7d666
-    jinja: "{{ passage }} \n{{ query }} \nWhich one is the placeholder? {{ entities\
+    jinja: "{{ passage }} \n{{ query }} \nWhich one is the \"@placeholder\"? {{ entities\
       \ | join(\", \") }}? ||| {{ answers | choice }}"
     name: Which one is the placeholder?
     reference: ''
     task_template: true
   91555c1c-c1e4-469b-a2a4-fc952ce1a145: !Template
     id: 91555c1c-c1e4-469b-a2a4-fc952ce1a145
-    jinja: "{{ passage }} \n{{ query }} \nIn the question above, the placeholder stands\
+    jinja: "{{ passage }} \n{{ query }} \nIn the question above, the \"@placeholder\" stands\
       \ for ||| {{ answers | choice }}"
     name: In the question above, the placeholder stands for
     reference: ''
     task_template: true
   99dd38ce-32f3-4d58-93c5-59821002b9cc: !Template
     id: 99dd38ce-32f3-4d58-93c5-59821002b9cc
-    jinja: "{{ passage }} \n{{ query }} \nWhat could the placeholder be? {{ entities\
+    jinja: "{{ passage }} \n{{ query }} \nWhat could the \"@placeholder\" be? {{ entities\
       \ | join(\", \") }}? ||| {{ answers | choice }}"
     name: What could the placeholder be?
     reference: ''
@@ -31,7 +31,7 @@ templates:
     task_template: true
   e68d13c5-df75-4de0-b59e-f2eaf4af6ce7: !Template
     id: e68d13c5-df75-4de0-b59e-f2eaf4af6ce7
-    jinja: "{{ passage }} \n{{ query }} \nCan you figure out what does the placeholder\
+    jinja: "{{ passage }} \n{{ query }} \nCan you figure out what does the \"@placeholder\"\
       \ mean? It means ||| {{ answers | choice }}"
     name: "Can you figure out\u2026"
     reference: ''

--- a/templates/super_glue/rte/templates.yaml
+++ b/templates/super_glue/rte/templates.yaml
@@ -3,12 +3,11 @@ subset: rte
 templates:
   0583671e-b717-4353-a0d4-ea1e4ac56429: !Template
     id: 0583671e-b717-4353-a0d4-ea1e4ac56429
-    jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes or no? |||
-      {{ ["Yes", "No"][label] }}
+    jinja: Given that {{premise}} Does it follow that "{{hypothesis}}"? ||| {{ ["Yes",
+      "No"][label] }}
     name: "given\u2026 does it follow that\u2026 "
-    reference: Ideally there should be a question mark after "does it follow that
-      {hypothesis}?", but the hypothesis string often comes with ending punctuations
-      of its own.
+    reference: ''
+    task_template: true
   1abaa658-e7f0-4e54-b7ad-312ba009d544: !Template
     id: 1abaa658-e7f0-4e54-b7ad-312ba009d544
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
@@ -16,12 +15,14 @@ templates:
       No\n{% endif %}"
     name: does S1 entail S2?
     reference: Adapted from Victor's prompts for XNLI.
+    task_template: true
   1bf2eee4-448b-48df-98e0-dee86edf7b96: !Template
     id: 1bf2eee4-448b-48df-98e0-dee86edf7b96
-    jinja: '{{premise}} Therefore, we are licensed to say that {{hypothesis}} True
-      or false? ||| {{ ["True", "False"][label] }}'
+    jinja: '{{premise}} Therefore, we are licensed to say that "{{hypothesis}}", right?
+      ||| {{ ["Yes", "No"][label] }}'
     name: "\u2026 Therefore, we're licensed to say that\u2026"
     reference: ''
+    task_template: true
   2721e378-68b2-40e6-be7e-fc2783b16042: !Template
     id: 2721e378-68b2-40e6-be7e-fc2783b16042
     jinja: '{{premise}}
@@ -31,21 +32,25 @@ templates:
     reference: Same as reported in Figure G31 of the GPT-3 paper, although I'm not
       sure about phrasing the not_entailment label (could be either neutral and contradiction)
       simply as "False".
+    task_template: true
   325dbe5c-167d-4b17-95db-1d93d8806782: !Template
     id: 325dbe5c-167d-4b17-95db-1d93d8806782
     jinja: Suppose {{premise}} Can we infer that {{hypothesis}}? ||| {{ ["Yes", "No"][label]
       }}
     name: "Suppose\u2026 Can we infer that\u2026"
     reference: ''
+    task_template: true
   4aac6388-3e90-4d06-be90-68fc31a89fa4: !Template
     id: 4aac6388-3e90-4d06-be90-68fc31a89fa4
-    jinja: '{{premise}} Does the previous passage support the claim that {{hypothesis}}?
+    jinja: '{{premise}} Does the previous passage support the claim that "{{hypothesis}}"?
       ||| {{ ["Yes", "No"][label] }}'
     name: "\u2026does the previous passage support the claim that"
     reference: ''
+    task_template: true
   ad3361d7-505f-4b5d-93dd-e426394a3943: !Template
     id: ad3361d7-505f-4b5d-93dd-e426394a3943
     jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}?
       ||| {{ ["Yes", "No"][label] }}'
     name: based on the previous passage
     reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+    task_template: true

--- a/templates/super_glue/wic/templates.yaml
+++ b/templates/super_glue/wic/templates.yaml
@@ -3,18 +3,20 @@ subset: wic
 templates:
   14e73f39-a0d1-44c2-b9a4-4e48f9f1608e: !Template
     id: 14e73f39-a0d1-44c2-b9a4-4e48f9f1608e
-    jinja: "Does the word {{word}} has the same meaning in these two sentences? Yes,\
-      \ No?\n{{sentence1}}\n{{sentence2}}\n||| \n{% if label == 0 %} \nNo\n{% elif\
-      \ label == 1 %}\nYes\n{% endif %}"
+    jinja: "Does the word \"{{word}}\" have the same meaning in these two sentences?\
+      \ Yes, No?\n{{sentence1}}\n{{sentence2}}\n||| \n{% if label == 0 %} \nNo\n{%\
+      \ elif label == 1 %}\nYes\n{% endif %}"
     name: question-context-meaning-with-label
     reference: Generalized question-context format with label
+    task_template: true
   3503ead5-4fa5-4f77-95dc-f0c2ed3eecdc: !Template
     id: 3503ead5-4fa5-4f77-95dc-f0c2ed3eecdc
-    jinja: "Does the word {{word}} has the same meaning in these two sentences?\n\
+    jinja: "Does the word \"{{word}}\" have the same meaning in these two sentences?\n\
       {{sentence1}}\n{{sentence2}}\n||| \n{% if label == 0 %} \nNo\n{% elif label\
       \ == 1 %}\nYes\n{% endif %}"
     name: question-context-meaning
     reference: Generalized question-context format
+    task_template: true
   c3a0a5d8-cfe9-4a7f-8a3c-3c526e0ad0c6: !Template
     id: c3a0a5d8-cfe9-4a7f-8a3c-3c526e0ad0c6
     jinja: "{{sentence1}}\n{{sentence2}}\nQuestion: Is the word '{{word}}' used in\
@@ -22,6 +24,7 @@ templates:
       {% elif label == 1 %}\nYes\n{% endif %}"
     name: GPT-3-prompt
     reference: Following table G32. https://arxiv.org/pdf/2005.14165.pdf
+    task_template: true
   cfbc1637-10b8-4f20-a31c-55292f3cebd0: !Template
     id: cfbc1637-10b8-4f20-a31c-55292f3cebd0
     jinja: "Determine if the word '{{word}}' is used in the same way in the two sentences\
@@ -29,6 +32,7 @@ templates:
       \ elif label == 1 %}\nYes\n{% endif %}"
     name: question-context
     reference: Generalized question-context format
+    task_template: true
   d9e1db2a-ab0b-4621-bb41-01d5788d3873: !Template
     id: d9e1db2a-ab0b-4621-bb41-01d5788d3873
     jinja: "{{sentence1}}\n{{sentence2}}\nQuestion: Is the word '{{word}}' used in\
@@ -37,9 +41,11 @@ templates:
     name: GPT-3-prompt-with-label
     reference: Following table G32. https://arxiv.org/pdf/2005.14165.pdf add additional
       label
+    task_template: true
   f934a96d-fe4d-4075-aa47-5595b9a604c7: !Template
     id: f934a96d-fe4d-4075-aa47-5595b9a604c7
     jinja: "{{sentence1}}\n{{sentence2}}\nSimilar sense of {{word}}?\n||| \n{% if\
       \ label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
     name: similar-sense
     reference: Following https://arxiv.org/abs/2105.11447, https://github.com/ethanjperez/true_few_shot/tree/main/templates.super_glue
+    task_template: true

--- a/templates/super_glue/wsc.fixed/templates.yaml
+++ b/templates/super_glue/wsc.fixed/templates.yaml
@@ -3,19 +3,38 @@ subset: wsc.fixed
 templates:
   212fb8b1-8436-4f64-8f37-a9094fe029f4: !Template
     id: 212fb8b1-8436-4f64-8f37-a9094fe029f4
-    jinja: "{{ text }} \nIn the passage above, what does the  pronoun \"{{ span2_text\
-      \ }}\" refer to? ||| {{ span1_text }}"
-    name: in the passage above, what does the pronoun refer to?
+    jinja: '{{ text }} In the previous sentence, the pronoun "{{ span2_text.lower()
+      }}" refers to ||| {{ span1_text }}'
+    name: "In the previous sentence, the pronoun refers to\u2026"
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+    task_template: true
+  7482d24f-cf45-4013-b82d-369489fc958b: !Template
+    id: 7482d24f-cf45-4013-b82d-369489fc958b
+    jinja: '{{ text }} Here, "{{ span2_text.lower() }}" stands for ||| {{ span1_text
+      }}'
+    name: "Here, p stands for\u2026"
+    reference: Not ideal because sometimes the queried pronoun is in the possessive
+      case.
+    task_template: true
   7d377293-d043-4b6c-8ec1-d61eaf14ec67: !Template
     id: 7d377293-d043-4b6c-8ec1-d61eaf14ec67
     jinja: "Passage: {{ text }} \nQuestion: In the passage above, what does the pronoun\
       \ \"{{ span2_text }}\" refer to? \nAnswer: ||| {{ span1_text }}"
     name: "passage\u2026 what does the pronoun refer to?"
     reference: Adapted from Figure G33, p. 59, Brown et al. 2020
+    task_template: true
   aae24b54-c3a7-4f69-8b77-f6dc115988f8: !Template
     id: aae24b54-c3a7-4f69-8b77-f6dc115988f8
     jinja: "{{ text }} \nIn the passage above, the pronoun \"{{ span2_text }}\" refers\
       \ to ||| {{ span1_text }}"
     name: "in the passage above, the pronoun X refers to\u2026"
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+    task_template: true
+  d88f3e21-42dc-49a5-924d-69b764a14816: !Template
+    id: d88f3e21-42dc-49a5-924d-69b764a14816
+    jinja: "{{ text }} \n{% if span2_text  == \"they\" or span2_text == \"them\" %}\n\
+      Question: Who are \"{{ span2_text.lower() }}\"?\n{% else %}\nQuestion: Who is\
+      \ \"{{ span2_text.lower() }}\"?\n{% endif %}\nAnswer: ||| {{ span1_text }}"
+    name: "Who is/are\u2026?"
+    reference: I double checked the only plural pronouns in WSC are "they" and "them".
+    task_template: true


### PR DESCRIPTION
Sorry for the delay. I originally wrote the NLI prompts for SuperGLUE and was thinking that surely someone else who does more work in QA will help out with the rest. No one did so I finished them up. Now each SuperGLUE task has at least 5 prompts. 

Some minor notes:
1. I marked all applicable prompts with the "Task Template?" checkbox, which were most of them. Except COPA could be recasted as a really interesting task of predicting whether S2 is a cause or an effect of S1. I may revisit this later. 
2. For ReCoRD, I changed the predicted output from enumerating all answers (which are just surface variants of each other) to using the random `choice` feature selecting just one of the answers, which made the prompted text more natural. That being said, ReCoRD is originally a masked LM task and I still don't love the prompts I wrote so far, so future changes are more than welcome.
3. Typo fixes for @sbmaruf's WiC prompts "Does the word {{word}} ~has~ have the same meaning in these two sentences?".



