### PR TITLE
Added templates for fever subsets 1.0 and 2.0

### DIFF
--- a/templates/fever/v1.0/templates.yaml
+++ b/templates/fever/v1.0/templates.yaml
@@ -4,38 +4,35 @@ templates:
   0870481e-e5d1-43a1-821e-b11c6bfd2483: !Template
     id: 0870481e-e5d1-43a1-821e-b11c6bfd2483
     jinja: "{{claim}} Is this true?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
-      : \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n}}"
+      : \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     name: cbqa_fever_postprompt
     reference: CBQA fever, prompt after claim
     task_template: false
   17967f69-187f-4c98-9c32-624736e04412: !Template
     id: 17967f69-187f-4c98-9c32-624736e04412
     jinja: "I've heard that {{claim}} Is this correct?\n|||\n{{\n{\"SUPPORTS\": \"\
-      Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n\
-      }}"
+      Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     name: cbqa_fever_dialog_style_surrounded
     reference: CBQA fever, like a conversation, with prompts surrounding claim
     task_template: false
   6cc8f145-3fb4-43a9-aaf1-8c25dd6e2cdf: !Template
     id: 6cc8f145-3fb4-43a9-aaf1-8c25dd6e2cdf
     jinja: "Is this statement correct? {{claim}} ||| \n{{\n{\"SUPPORTS\": \"Yes\"\
-      ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n\
-      }}"
+      ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     name: cbqa_fever_preprompt
     reference: Closed-book QA from only the claim, prompt before the content
     task_template: false
   948f41ab-e6bb-4de6-af3e-7f0b5d5f39a8: !Template
     id: 948f41ab-e6bb-4de6-af3e-7f0b5d5f39a8
     jinja: "\"{{claim}}\" Yes or no?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
-      : \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n}}"
+      : \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     name: cbqa_fever_short
     reference: CBQA fever, minimal
     task_template: false
   b888ac7f-7482-4b5b-b94d-1ee096eefee5: !Template
     id: b888ac7f-7482-4b5b-b94d-1ee096eefee5
     jinja: "\"{{claim}}\", I have heard. Correct?\n|||\n{{\n{\"SUPPORTS\": \"Yes\"\
-      ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n\
-      }}"
+      ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     name: cbqa_fever_dialog_style_postprompt
     reference: CBQA fever, like a conversation, prompt after output
     task_template: false

--- a/templates/fever/v1.0/templates.yaml
+++ b/templates/fever/v1.0/templates.yaml
@@ -1,0 +1,41 @@
+dataset: fever
+subset: v1.0
+templates:
+  0870481e-e5d1-43a1-821e-b11c6bfd2483: !Template
+    id: 0870481e-e5d1-43a1-821e-b11c6bfd2483
+    jinja: "{{claim}} Is this true?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
+      : \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n}}"
+    name: cbqa_fever_postprompt
+    reference: CBQA fever, prompt after claim
+    task_template: false
+  17967f69-187f-4c98-9c32-624736e04412: !Template
+    id: 17967f69-187f-4c98-9c32-624736e04412
+    jinja: "I've heard that {{claim}} Is this correct?\n|||\n{{\n{\"SUPPORTS\": \"\
+      Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n\
+      }}"
+    name: cbqa_fever_dialog_style_surrounded
+    reference: CBQA fever, like a conversation, with prompts surrounding claim
+    task_template: false
+  6cc8f145-3fb4-43a9-aaf1-8c25dd6e2cdf: !Template
+    id: 6cc8f145-3fb4-43a9-aaf1-8c25dd6e2cdf
+    jinja: "Is this statement correct? {{claim}} ||| \n{{\n{\"SUPPORTS\": \"Yes\"\
+      ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n\
+      }}"
+    name: cbqa_fever_preprompt
+    reference: Closed-book QA from only the claim, prompt before the content
+    task_template: false
+  948f41ab-e6bb-4de6-af3e-7f0b5d5f39a8: !Template
+    id: 948f41ab-e6bb-4de6-af3e-7f0b5d5f39a8
+    jinja: "\"{{claim}}\" Yes or no?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
+      : \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n}}"
+    name: cbqa_fever_short
+    reference: CBQA fever, minimal
+    task_template: false
+  b888ac7f-7482-4b5b-b94d-1ee096eefee5: !Template
+    id: b888ac7f-7482-4b5b-b94d-1ee096eefee5
+    jinja: "\"{{claim}}\", I have heard. Correct?\n|||\n{{\n{\"SUPPORTS\": \"Yes\"\
+      ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n\
+      }}"
+    name: cbqa_fever_dialog_style_postprompt
+    reference: CBQA fever, like a conversation, prompt after output
+    task_template: false

--- a/templates/fever/v2.0/templates.yaml
+++ b/templates/fever/v2.0/templates.yaml
@@ -4,38 +4,35 @@ templates:
   0870481e-e5d1-43a1-821e-b11c6bfd2483: !Template
     id: 0870481e-e5d1-43a1-821e-b11c6bfd2483
     jinja: "{{claim}} Is this true?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
-      : \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n}}"
+      : \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     name: cbqa_fever_postprompt
     reference: CBQA fever, prompt after claim
     task_template: false
   17967f69-187f-4c98-9c32-624736e04412: !Template
     id: 17967f69-187f-4c98-9c32-624736e04412
     jinja: "I've heard that {{claim}} Is this correct?\n|||\n{{\n{\"SUPPORTS\": \"\
-      Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n\
-      }}"
+      Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     name: cbqa_fever_dialog_style_surrounded
     reference: CBQA fever, like a conversation, with prompts surrounding claim
     task_template: false
   6cc8f145-3fb4-43a9-aaf1-8c25dd6e2cdf: !Template
     id: 6cc8f145-3fb4-43a9-aaf1-8c25dd6e2cdf
     jinja: "Is this statement correct? {{claim}} ||| \n{{\n{\"SUPPORTS\": \"Yes\"\
-      ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n\
-      }}"
+      ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     name: cbqa_fever_preprompt
     reference: Closed-book QA from only the claim, prompt before the content
     task_template: false
   948f41ab-e6bb-4de6-af3e-7f0b5d5f39a8: !Template
     id: 948f41ab-e6bb-4de6-af3e-7f0b5d5f39a8
     jinja: "\"{{claim}}\" Yes or no?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
-      : \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n}}"
+      : \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     name: cbqa_fever_short
     reference: CBQA fever, minimal
     task_template: false
   b888ac7f-7482-4b5b-b94d-1ee096eefee5: !Template
     id: b888ac7f-7482-4b5b-b94d-1ee096eefee5
     jinja: "\"{{claim}}\", I have heard. Correct?\n|||\n{{\n{\"SUPPORTS\": \"Yes\"\
-      ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n\
-      }}"
+      ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     name: cbqa_fever_dialog_style_postprompt
     reference: CBQA fever, like a conversation, prompt after output
     task_template: false

--- a/templates/fever/v2.0/templates.yaml
+++ b/templates/fever/v2.0/templates.yaml
@@ -1,0 +1,41 @@
+dataset: fever
+subset: v2.0
+templates:
+  0870481e-e5d1-43a1-821e-b11c6bfd2483: !Template
+    id: 0870481e-e5d1-43a1-821e-b11c6bfd2483
+    jinja: "{{claim}} Is this true?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
+      : \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n}}"
+    name: cbqa_fever_postprompt
+    reference: CBQA fever, prompt after claim
+    task_template: false
+  17967f69-187f-4c98-9c32-624736e04412: !Template
+    id: 17967f69-187f-4c98-9c32-624736e04412
+    jinja: "I've heard that {{claim}} Is this correct?\n|||\n{{\n{\"SUPPORTS\": \"\
+      Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n\
+      }}"
+    name: cbqa_fever_dialog_style_surrounded
+    reference: CBQA fever, like a conversation, with prompts surrounding claim
+    task_template: false
+  6cc8f145-3fb4-43a9-aaf1-8c25dd6e2cdf: !Template
+    id: 6cc8f145-3fb4-43a9-aaf1-8c25dd6e2cdf
+    jinja: "Is this statement correct? {{claim}} ||| \n{{\n{\"SUPPORTS\": \"Yes\"\
+      ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n\
+      }}"
+    name: cbqa_fever_preprompt
+    reference: Closed-book QA from only the claim, prompt before the content
+    task_template: false
+  948f41ab-e6bb-4de6-af3e-7f0b5d5f39a8: !Template
+    id: 948f41ab-e6bb-4de6-af3e-7f0b5d5f39a8
+    jinja: "\"{{claim}}\" Yes or no?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
+      : \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n}}"
+    name: cbqa_fever_short
+    reference: CBQA fever, minimal
+    task_template: false
+  b888ac7f-7482-4b5b-b94d-1ee096eefee5: !Template
+    id: b888ac7f-7482-4b5b-b94d-1ee096eefee5
+    jinja: "\"{{claim}}\", I have heard. Correct?\n|||\n{{\n{\"SUPPORTS\": \"Yes\"\
+      ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"I don't know\"\n}[label]\n\
+      }}"
+    name: cbqa_fever_dialog_style_postprompt
+    reference: CBQA fever, like a conversation, prompt after output
+    task_template: false


### PR DESCRIPTION
This PR adds templates for the fever dataset, treating it like closed-book QA (instead of the original task, fact-verification with a source)