### PR TITLE
fixed GLUE RTE, WNLI entailment direction

### DIFF
--- a/templates/glue/rte/templates.yaml
+++ b/templates/glue/rte/templates.yaml
@@ -12,16 +12,18 @@ templates:
       {{["yes", "no"][label]}}'
     name: mean
     reference: ''
+    task_template: true
   4ee6ff27-de63-4e7b-a9d4-82a17eba407a: !Template
     id: 4ee6ff27-de63-4e7b-a9d4-82a17eba407a
-    jinja: 'Does "{{sentence2}}" imply that "{{sentence1}}"? Please answer either
-      {{"yes"}} or {{"no"}}.
+    jinja: 'Does the claim "{{sentence2}}" follow from the fact that "{{sentence1}}"?
+      Please answer either {{"yes"}} or {{"no"}}.
 
       |||
 
       {{["yes", "no"][label]}}'
-    name: imply swapped
+    name: "does the claim\u2026 follow the fact\u2026"
     reference: ''
+    task_template: true
   9e2b4267-ec23-44c8-b82a-107e2c890fec: !Template
     id: 9e2b4267-ec23-44c8-b82a-107e2c890fec
     jinja: 'We say that one sentence "{{"entails"}}" another sentence when the first
@@ -31,14 +33,15 @@ templates:
 
       {{sentence2}}
 
-      Is the relationship between these two sentences "{{"entailment"}}" or "{{"not
-      entailment"}}"?
+      Is the relationship from the first to the second sentence "{{"entailment"}}"
+      or "{{"not entailment"}}"?
 
       |||
 
       {{["entailment", "not entailment"][label]}}'
     name: entailment explained
     reference: ''
+    task_template: true
   c8dfc879-40f2-412d-be1e-4cd70107f6e6: !Template
     id: c8dfc879-40f2-412d-be1e-4cd70107f6e6
     jinja: 'Does "{{sentence1}}" imply that "{{sentence2}}"? Please answer either
@@ -49,13 +52,14 @@ templates:
       {{["yes", "no"][label]}}'
     name: imply
     reference: ''
+    task_template: true
   f56ffced-9b16-431a-8a17-501e63cddf73: !Template
     id: f56ffced-9b16-431a-8a17-501e63cddf73
-    jinja: '{{sentence2}}
+    jinja: '{{sentence1}}
 
       Does this imply
 
-      {{sentence1}}
+      {{sentence2}}
 
       Please answer {{"A) yes or B) no."}}
 
@@ -64,3 +68,4 @@ templates:
       {{["yes", "no"][label]}}'
     name: imply separated
     reference: ''
+    task_template: true

--- a/templates/glue/wnli/templates.yaml
+++ b/templates/glue/wnli/templates.yaml
@@ -18,6 +18,7 @@ templates:
       {{["not confident", "very confident"][label]}}'
     name: confident
     reference: ''
+    task_template: true
   3a0e46cb-0b96-4972-83f6-29a6c6a09ba9: !Template
     id: 3a0e46cb-0b96-4972-83f6-29a6c6a09ba9
     jinja: '{{"Entailment"}} means that the second sentence follows from the first
@@ -32,7 +33,7 @@ templates:
       {{["no", "yes"][label]}}'
     name: entailment explained
     reference: ''
-    task_template: false
+    task_template: true
   75f89b05-5a81-401b-8a04-8239211a9a95: !Template
     id: 75f89b05-5a81-401b-8a04-8239211a9a95
     jinja: 'Assume that the following is true:
@@ -46,6 +47,7 @@ templates:
       {{["no", "yes"][label]}}'
     name: mean
     reference: ''
+    task_template: true
   a244158a-a248-4e34-bef7-66e269dd0815: !Template
     id: a244158a-a248-4e34-bef7-66e269dd0815
     jinja: 'Someone told me "{{sentence1}}" Now, I think that "{{sentence2}}" Am I
@@ -56,7 +58,7 @@ templates:
       {{["no", "yes"][label]}}'
     name: justified
     reference: ''
-    task_template: false
+    task_template: true
   a2ce492b-dfd0-4f04-bc44-70c7867ba231: !Template
     id: a2ce492b-dfd0-4f04-bc44-70c7867ba231
     jinja: '{{sentence1}}
@@ -70,3 +72,4 @@ templates:
       {{["no", "yes"][label]}}'
     name: imply
     reference: ''
+    task_template: true

--- a/templates/glue/wnli/templates.yaml
+++ b/templates/glue/wnli/templates.yaml
@@ -20,8 +20,8 @@ templates:
     reference: ''
   3a0e46cb-0b96-4972-83f6-29a6c6a09ba9: !Template
     id: 3a0e46cb-0b96-4972-83f6-29a6c6a09ba9
-    jinja: '{{"Entailment"}} means that one sentence follows from another. Are the
-      following two sentences an example of entailment?
+    jinja: '{{"Entailment"}} means that the second sentence follows from the first
+      sentence. Are the following two sentences an example of entailment?
 
       {{sentence1}}
 
@@ -32,6 +32,7 @@ templates:
       {{["no", "yes"][label]}}'
     name: entailment explained
     reference: ''
+    task_template: false
   75f89b05-5a81-401b-8a04-8239211a9a95: !Template
     id: 75f89b05-5a81-401b-8a04-8239211a9a95
     jinja: 'Assume that the following is true:
@@ -47,14 +48,15 @@ templates:
     reference: ''
   a244158a-a248-4e34-bef7-66e269dd0815: !Template
     id: a244158a-a248-4e34-bef7-66e269dd0815
-    jinja: 'Some told me "{{sentence1}}" Now, I think that "{{sentence2}}" Am I justified
-      in thinking this?
+    jinja: 'Someone told me "{{sentence1}}" Now, I think that "{{sentence2}}" Am I
+      justified in thinking this?
 
       |||
 
       {{["no", "yes"][label]}}'
     name: justified
     reference: ''
+    task_template: false
   a2ce492b-dfd0-4f04-bc44-70c7867ba231: !Template
     id: a2ce492b-dfd0-4f04-bc44-70c7867ba231
     jinja: '{{sentence1}}


### PR DESCRIPTION
Same bug as #52 before but this time for RTE and WNLI (under GLUE, not SuperGLUE): NLI datasets are annotated as “does S1 entail S2” (does the premise entail the hypothesis) not the other way around. Nor could we ask “do they entail each other”. So I rephrased the bidirectional prompts to be unidirectional. 