### PR TITLE
True task flags for S/M/X/ANLI, SciTail, HANS

### DIFF
--- a/promptsource/templates/anli/templates.yaml
+++ b/promptsource/templates/anli/templates.yaml
@@ -7,6 +7,7 @@ templates:
       No\n{% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
     name: does S1 contradict S2?
     reference: Copied from Victor's prompts for XNLI.
+    task_template: false
   5459237b-97de-4340-bf7b-2939c3f7ca19: !Template
     id: 5459237b-97de-4340-bf7b-2939c3f7ca19
     jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes, no, or maybe?
@@ -16,6 +17,7 @@ templates:
       \ \", \"is it guaranteed that\u2026\", etc. Ideally there should be a question\
       \ mark after \"does it follow that {hypothesis}?\", but the hypothesis string\
       \ often comes with ending punctuations of its own."
+    task_template: true
   620aa3fc-d5eb-46f5-a1ee-4c754527aa97: !Template
     id: 620aa3fc-d5eb-46f5-a1ee-4c754527aa97
     jinja: '{{premise}}
@@ -25,12 +27,14 @@ templates:
     name: GPT-3 style
     reference: 'Same as reported in Figure G7 of the GPT-3 paper, except that there
       is no task identifying tokens like "anli R1: ".'
+    task_template: true
   9b613182-c6ab-4427-9221-3d68f6d62765: !Template
     id: 9b613182-c6ab-4427-9221-3d68f6d62765
     jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
       Yes, no, or maybe? ||| {{ ["Yes", "Maybe", "No"][label] }}'
     name: based on the previous passage
     reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+    task_template: true
   cf55f09b-bc68-439d-a9b2-781263509f99: !Template
     id: cf55f09b-bc68-439d-a9b2-781263509f99
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
@@ -38,6 +42,7 @@ templates:
       {% elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
     name: does S1 entail S2?
     reference: Copied from Victor's prompts for XNLI.
+    task_template: true
   e0e8b914-c32c-4c85-8b8f-0f61ae79e2b3: !Template
     id: e0e8b914-c32c-4c85-8b8f-0f61ae79e2b3
     jinja: Given that {{premise}}, it {{"must be true, might be true, or must be false"}}
@@ -48,3 +53,4 @@ templates:
       is the most natural way of how I say an NLI sentence pair out loud to humans.
       Caveat: NLI annotations are not meant to be strictly truth-conditional entailment,
       so "must" is not ideal.'
+    task_template: true

--- a/promptsource/templates/hans/templates.yaml
+++ b/promptsource/templates/hans/templates.yaml
@@ -6,12 +6,14 @@ templates:
       ||| {{ ["Yes", "No"][label] }}'
     name: "\u2026does the previous passage support the claim that"
     reference: ''
+    task_template: true
   213f6f71-0987-4cba-8e16-85ed08b6d237: !Template
     id: 213f6f71-0987-4cba-8e16-85ed08b6d237
     jinja: Suppose {{premise}} Can we infer that {{hypothesis}}? ||| {{ ["Yes", "No"][label]
       }}
     name: "Suppose\u2026 Can we infer that\u2026"
     reference: ''
+    task_template: true
   930dbf9e-be95-458c-bf63-0358e36b8f8f: !Template
     id: 930dbf9e-be95-458c-bf63-0358e36b8f8f
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
@@ -19,12 +21,14 @@ templates:
       No\n{% endif %}"
     name: does S1 entail S2?
     reference: Adapted from Victor's prompts for XNLI.
+    task_template: true
   9666d06a-63eb-4992-a1f5-3e582ffe39a6: !Template
     id: 9666d06a-63eb-4992-a1f5-3e582ffe39a6
     jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes or no? |||
       {{ ["Yes", "No"][label] }}
     name: "given\u2026 does it follow that\u2026 "
     reference: ''
+    task_template: true
   9be63780-a784-4a8e-9440-4453c14f8a0e: !Template
     id: 9be63780-a784-4a8e-9440-4453c14f8a0e
     jinja: '{{premise}}
@@ -34,9 +38,11 @@ templates:
     reference: Same as reported in Figure G31 of the GPT-3 paper, although I'm not
       sure about phrasing the not_entailment label (could be either neutral and contradiction)
       simply as "False".
+    task_template: true
   b7676330-5e75-4f3d-96bd-2ab7aa10fbcd: !Template
     id: b7676330-5e75-4f3d-96bd-2ab7aa10fbcd
     jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}?
       ||| {{ ["Yes", "No"][label] }}'
     name: based on the previous passage
     reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+    task_template: true

--- a/promptsource/templates/multi_nli/templates.yaml
+++ b/promptsource/templates/multi_nli/templates.yaml
@@ -10,6 +10,7 @@ templates:
       is the most natural way of how I say an NLI sentence pair out loud to humans.
       Caveat: NLI annotations are not meant to be strictly truth-conditional entailment,
       so "must" is not ideal.'
+    task_template: true
   6c6d824a-89c8-48cc-a4b5-cab04d649117: !Template
     id: 6c6d824a-89c8-48cc-a4b5-cab04d649117
     jinja: '{{premise}}
@@ -19,6 +20,7 @@ templates:
     name: GPT-3 style
     reference: 'Same as reported in Figure G7 of the GPT-3 paper, except that there
       is no task identifying tokens like "anli R1: ".'
+    task_template: true
   b2dcedb3-265e-4dfa-bbd2-9d9d992bd389: !Template
     id: b2dcedb3-265e-4dfa-bbd2-9d9d992bd389
     jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes, no, or maybe?
@@ -28,6 +30,7 @@ templates:
       \ \", \"is it guaranteed that\u2026\", etc. Ideally there should be a question\
       \ mark after \"does it follow that {hypothesis}?\", but the hypothesis string\
       \ often comes with ending punctuations of its own."
+    task_template: true
   ca5a9209-47ed-4ca9-9b03-7ea909f61d96: !Template
     id: ca5a9209-47ed-4ca9-9b03-7ea909f61d96
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
@@ -35,6 +38,7 @@ templates:
       No\n{% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
     name: does S1 contradict S2?
     reference: Copied from Victor's prompts for XNLI.
+    task_template: false
   d067f960-75d9-4fed-bf54-6ddaff123a57: !Template
     id: d067f960-75d9-4fed-bf54-6ddaff123a57
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
@@ -42,9 +46,11 @@ templates:
       {% elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
     name: does S1 entail S2?
     reference: Copied from Victor's prompts for XNLI.
+    task_template: true
   f1a17d8b-78fb-4300-bc13-8c4572a091fa: !Template
     id: f1a17d8b-78fb-4300-bc13-8c4572a091fa
     jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
       Yes, no, or maybe? ||| {{ ["Yes", "Maybe", "No"][label] }}'
     name: based on the previous passage
     reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+    task_template: true

--- a/promptsource/templates/scitail/snli_format/templates.yaml
+++ b/promptsource/templates/scitail/snli_format/templates.yaml
@@ -7,3 +7,4 @@ templates:
       }} to one another?|||\n{{gold_label}}"
     name: Test1
     reference: ''
+    task_template: false

--- a/promptsource/templates/scitail/tsv_format/templates.yaml
+++ b/promptsource/templates/scitail/tsv_format/templates.yaml
@@ -7,24 +7,28 @@ templates:
       or false? ||| {{ {''entails'': ''Yes'', ''neutral'': ''No''}[label] }}'
     name: "\u2026 Therefore, we're licensed to say that\u2026"
     reference: ''
+    task_template: true
   1ff92b02-fefc-49e0-b676-9391fab8f193: !Template
     id: 1ff92b02-fefc-49e0-b676-9391fab8f193
     jinja: 'Suppose {{premise}} Can we infer that {{hypothesis}}? ||| {{ {''entails'':
       ''Yes'', ''neutral'': ''No''}[label] }}'
     name: "Suppose\u2026 Can we infer that\u2026"
     reference: ''
+    task_template: true
   5aa53544-73a6-4486-b8c8-623345353fa7: !Template
     id: 5aa53544-73a6-4486-b8c8-623345353fa7
     jinja: '{{premise}} Does the previous passage support the claim that {{hypothesis}}?
       ||| {{ {''entails'': ''Yes'', ''neutral'': ''No''}[label] }}'
     name: "\u2026does the previous passage support the claim that"
     reference: ''
+    task_template: true
   705fa099-0650-4de5-b72f-881aea0fa208: !Template
     id: 705fa099-0650-4de5-b72f-881aea0fa208
     jinja: 'Given that {{premise}} Does it follow that {{hypothesis}} Yes or no? |||
       {{ {''entails'': ''Yes'', ''neutral'': ''No''}[label] }}'
     name: "given\u2026 does it follow that\u2026 "
     reference: ''
+    task_template: true
   9aa89dee-6cef-43bc-bdf4-e38cdf0796a6: !Template
     id: 9aa89dee-6cef-43bc-bdf4-e38cdf0796a6
     jinja: 'Sentence 1: {{premise}}
@@ -36,3 +40,4 @@ templates:
       {{ {''entails'': ''Yes'', ''neutral'': ''No''}[label] }}'
     name: does S1 entail S2?
     reference: Adapted from Victor's prompts for XNLI.
+    task_template: true

--- a/promptsource/templates/snli/templates.yaml
+++ b/promptsource/templates/snli/templates.yaml
@@ -9,6 +9,7 @@ templates:
     name: GPT-3 style
     reference: 'Same as reported in Figure G7 of the GPT-3 paper, except that there
       is no task identifying tokens like "anli R1: ".'
+    task_template: true
   5f0ef86f-2b8f-4a0c-8bca-a8b8d9ac015e: !Template
     id: 5f0ef86f-2b8f-4a0c-8bca-a8b8d9ac015e
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
@@ -16,6 +17,7 @@ templates:
       {% elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
     name: does S1 entail S2?
     reference: Copied from Victor's prompts for XNLI.
+    task_template: true
   68afa6d2-547d-4c2f-bcac-71507b1fe778: !Template
     id: 68afa6d2-547d-4c2f-bcac-71507b1fe778
     jinja: Given that {{premise}}, it {{"must be true, might be true, or must be false"}}
@@ -26,6 +28,7 @@ templates:
       is the most natural way of how I say an NLI sentence pair out loud to humans.
       Caveat: NLI annotations are not meant to be strictly truth-conditional entailment,
       so "must" is not ideal.'
+    task_template: true
   94c87dc3-865e-4321-a696-bbc5a54d7096: !Template
     id: 94c87dc3-865e-4321-a696-bbc5a54d7096
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
@@ -33,6 +36,7 @@ templates:
       No\n{% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
     name: does S1 contradict S2?
     reference: Copied from Victor's prompts for XNLI.
+    task_template: false
   b6abcb2e-a0b0-4046-810c-d27f316b1bd5: !Template
     id: b6abcb2e-a0b0-4046-810c-d27f316b1bd5
     jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes, no, or maybe?
@@ -42,9 +46,11 @@ templates:
       \ \", \"is it guaranteed that\u2026\", etc. Ideally there should be a question\
       \ mark after \"does it follow that {hypothesis}?\", but the hypothesis string\
       \ often comes with ending punctuations of its own."
+    task_template: true
   f227d882-7838-4c7a-93fc-c2b68d2464fb: !Template
     id: f227d882-7838-4c7a-93fc-c2b68d2464fb
     jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
       Yes, no, or maybe? ||| {{ ["Yes", "Maybe", "No"][label] }}'
     name: based on the previous passage
     reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+    task_template: true

--- a/promptsource/templates/super_glue/cb/templates.yaml
+++ b/promptsource/templates/super_glue/cb/templates.yaml
@@ -8,6 +8,7 @@ templates:
       No\n{% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
     name: does S1 contradict S2?
     reference: Copied from Victor's prompts for XNLI.
+    task_template: false
   5bca1a90-340b-42b4-9c0d-e5eb1c25605e: !Template
     id: 5bca1a90-340b-42b4-9c0d-e5eb1c25605e
     jinja: Given that {{premise}} Does it follow that {{hypothesis}}? {{"Yes, no,

--- a/promptsource/templates/xnli/en/templates.yaml
+++ b/promptsource/templates/xnli/en/templates.yaml
@@ -8,6 +8,7 @@ templates:
       \ 0 %} \nNo\n{% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
     name: Concatenation contraposition
     reference: Concatenation contraposition
+    task_template: false
   a1506390-8d7a-4b8f-922c-6135e23094d7: !Template
     id: a1506390-8d7a-4b8f-922c-6135e23094d7
     jinja: Given that {{premise}}, it {{"must be true, might be true, or must be false"}}
@@ -18,6 +19,7 @@ templates:
       is the most natural way of how I say an NLI sentence pair out loud to humans.
       Caveat: NLI annotations are not meant to be strictly truth-conditional entailment,
       so "must" is not ideal.'
+    task_template: true
   c62a3048-018e-4d93-bc46-645f3f763ee6: !Template
     id: c62a3048-018e-4d93-bc46-645f3f763ee6
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
@@ -26,6 +28,7 @@ templates:
     name: Label binarization contraposition
     reference: Inspired from https://arxiv.org/pdf/1902.01007.pdf Section 4 - Implementation
       and evaluation
+    task_template: false
   d027ab50-a86b-45ba-99fa-018c0e4cac4a: !Template
     id: d027ab50-a86b-45ba-99fa-018c0e4cac4a
     jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes, no, or maybe?
@@ -35,6 +38,7 @@ templates:
       \ \", \"is it guaranteed that\u2026\", etc. Ideally there should be a question\
       \ mark after \"does it follow that {hypothesis}?\", but the hypothesis string\
       \ often comes with ending punctuations of its own."
+    task_template: true
   d9e13133-267e-46c4-afad-c2379dcc5272: !Template
     id: d9e13133-267e-46c4-afad-c2379dcc5272
     jinja: "{{premise}}\nQuestion: {{hypothesis}} True, False, or Neither? ||| \n\
@@ -42,6 +46,7 @@ templates:
       {% endif %}"
     name: ANLI GPT3
     reference: ANLI prompt format from Table G7 in the GPT3 paper
+    task_template: true
   dd4276e6-aebd-44a3-b3cf-baf8a4c237f0: !Template
     id: dd4276e6-aebd-44a3-b3cf-baf8a4c237f0
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
@@ -50,12 +55,14 @@ templates:
     name: Label binarization
     reference: Grouping "neutral" and "contradiction" as a single label following
       https://arxiv.org/pdf/1902.01007.pdf Section 4 - Implementation and evaluation
+    task_template: false
   ddfd2eb1-96a4-42db-ad5e-91d7cb011b4e: !Template
     id: ddfd2eb1-96a4-42db-ad5e-91d7cb011b4e
     jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
       Yes, no, or maybe? ||| {{ ["Yes", "Maybe", "No"][label] }}'
     name: based on the previous passage
     reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+    task_template: true
   e174f56a-b0af-4937-b6ae-1897cac26eba: !Template
     id: e174f56a-b0af-4937-b6ae-1897cac26eba
     jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
@@ -63,3 +70,4 @@ templates:
       \ \nYes\n{% elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
     name: Concatenation
     reference: Concatenation of premise and hypothesis
+    task_template: true


### PR DESCRIPTION
Checked the `task template` checkboxes for the NLI prompts I wrote prior to the introduction of this flag. 

As noted in #59, contrapositive prompts like "does the premise contradict the hypothesis" while naively negating the annotation label sometimes lead to weird pragmatic effects, especially when the text itself contains negation words. So to err on the cautious side I only marked the premise-entails-hypothesis prompts with the true task flag. 