### PR TITLE
Truncate

### DIFF
--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -341,7 +341,7 @@ class Template(yaml.YAMLObject):
         """
         jinja = self.jinja
         if truncate:
-            trunc_command = f" | truncate({TEXT_VAR_LENGTH}) }}}}"  # Escaping curly braces require to double them
+            trunc_command = f" | truncate({TEXT_VAR_LENGTH}) }}}}"  # Escaping curly braces requires to double them
             jinja = jinja.replace("}}", trunc_command)
         if highlight_variables:
             jinja = jinja.replace("}}", " | highlight }}")

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -12,7 +12,7 @@ from jinja2 import BaseLoader, Environment
 
 # Truncation of jinja template variables
 # 1710 = 300 words x 4.7 avg characters per word + 300 spaces
-TEXT_VAR_LENGTH = 1710
+TEXT_VAR_LENGTH = 2048
 
 # Local path to the folder containing the templates
 TEMPLATES_FOLDER_PATH = pkg_resources.resource_filename(__name__, "templates")

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -10,6 +10,10 @@ import yaml
 from jinja2 import BaseLoader, Environment
 
 
+# Truncation of jinja template variables
+# 1710 = 300 words x 4.7 avg characters per word + 300 spaces
+TEXT_VAR_LENGTH = 1710
+
 # Local path to the folder containing the templates
 TEMPLATES_FOLDER_PATH = pkg_resources.resource_filename(__name__, "templates")
 
@@ -327,7 +331,7 @@ class Template(yaml.YAMLObject):
         else:
             return False
 
-    def apply(self, example, highlight_variables=False):
+    def apply(self, example, truncate=True, highlight_variables=False):
         """
         Creates a prompt by applying this template to an example
 
@@ -336,6 +340,9 @@ class Template(yaml.YAMLObject):
         :return: tuple of 2 strings, for prompt and output
         """
         jinja = self.jinja
+        if truncate:
+            trunc_command = f" | truncate({TEXT_VAR_LENGTH}) }}}}"  # Escaping curly braces require to double them
+            jinja = jinja.replace("}}", trunc_command)
         if highlight_variables:
             jinja = jinja.replace("}}", " | highlight }}")
         rtemplate = env.from_string(jinja)

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -341,7 +341,7 @@ class Template(yaml.YAMLObject):
         """
         jinja = self.jinja
         if truncate:
-            trunc_command = f" | truncate({TEXT_VAR_LENGTH}) }}}}"  # Escaping curly braces requires to double them
+            trunc_command = f" | truncate({TEXT_VAR_LENGTH}) }}}}"  # Escaping curly braces requires doubling them
             jinja = jinja.replace("}}", trunc_command)
         if highlight_variables:
             jinja = jinja.replace("}}", " | highlight }}")


### PR DESCRIPTION
Truncate jinja variables to a maximum length ( in characters).
Arbitrarily chose 1710 character length (300 words x 4.7 characters per words + 300 white spaces) -> we can adjust this number once we have a quantitative sense of the length distribution.
This is the simplest truncation logic possible and scrolling through the datasets, it covers the majority of the cases (300 words is quite long...). It doesn't consider cases where there are 2 or more very long variables in the template.

This first truncated example is from `yelp_polarity_full`:
<img width="1283" alt="Capture d’écran 2021-06-22 à 3 20 39 PM" src="https://user-images.githubusercontent.com/16107619/122988021-4658fe00-d36f-11eb-99cb-833e49115f28.png">


The second is from `cnn_daily`:
<img width="1328" alt="Capture d’écran 2021-06-22 à 3 31 50 PM" src="https://user-images.githubusercontent.com/16107619/122988029-49ec8500-d36f-11eb-8e58-b2ac512aebf0.png">
