### PR TITLE
Fix truncate for non-str variables

### DIFF
--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -341,7 +341,7 @@ class Template(yaml.YAMLObject):
         """
         jinja = self.jinja
         if truncate:
-            trunc_command = f" | truncate({TEXT_VAR_LENGTH}) }}}}"  # Escaping curly braces require to double them
+            trunc_command = f" | truncate({TEXT_VAR_LENGTH}) }}}}"  # Escaping curly braces requires to double them
             jinja = jinja.replace("}}", trunc_command)
         if highlight_variables:
             jinja = jinja.replace("}}", " | highlight }}")

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -12,7 +12,7 @@ from jinja2 import BaseLoader, Environment
 
 # Truncation of jinja template variables
 # 1710 = 300 words x 4.7 avg characters per word + 300 spaces
-TEXT_VAR_LENGTH = 1710
+TEXT_VAR_LENGTH = 2048
 
 # Local path to the folder containing the templates
 TEMPLATES_FOLDER_PATH = pkg_resources.resource_filename(__name__, "templates")

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -341,7 +341,7 @@ class Template(yaml.YAMLObject):
         """
         jinja = self.jinja
         if truncate:
-            trunc_command = f" | truncate({TEXT_VAR_LENGTH}) }}}}"  # Escaping curly braces requires doubling them
+            trunc_command = f" | string | truncate({TEXT_VAR_LENGTH}) }}}}"  # Escaping curly braces requires doubling them
             jinja = jinja.replace("}}", trunc_command)
         if highlight_variables:
             jinja = jinja.replace("}}", " | highlight }}")

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -10,6 +10,10 @@ import yaml
 from jinja2 import BaseLoader, Environment
 
 
+# Truncation of jinja template variables
+# 1710 = 300 words x 4.7 avg characters per word + 300 spaces
+TEXT_VAR_LENGTH = 1710
+
 # Local path to the folder containing the templates
 TEMPLATES_FOLDER_PATH = pkg_resources.resource_filename(__name__, "templates")
 
@@ -327,7 +331,7 @@ class Template(yaml.YAMLObject):
         else:
             return False
 
-    def apply(self, example, highlight_variables=False):
+    def apply(self, example, truncate=True, highlight_variables=False):
         """
         Creates a prompt by applying this template to an example
 
@@ -336,6 +340,9 @@ class Template(yaml.YAMLObject):
         :return: tuple of 2 strings, for prompt and output
         """
         jinja = self.jinja
+        if truncate:
+            trunc_command = f" | truncate({TEXT_VAR_LENGTH}) }}}}"  # Escaping curly braces require to double them
+            jinja = jinja.replace("}}", trunc_command)
         if highlight_variables:
             jinja = jinja.replace("}}", " | highlight }}")
         rtemplate = env.from_string(jinja)

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -341,7 +341,7 @@ class Template(yaml.YAMLObject):
         """
         jinja = self.jinja
         if truncate:
-            trunc_command = f" | truncate({TEXT_VAR_LENGTH}) }}}}"  # Escaping curly braces requires to double them
+            trunc_command = f" | truncate({TEXT_VAR_LENGTH}) }}}}"  # Escaping curly braces requires doubling them
             jinja = jinja.replace("}}", trunc_command)
         if highlight_variables:
             jinja = jinja.replace("}}", " | highlight }}")

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -341,7 +341,9 @@ class Template(yaml.YAMLObject):
         """
         jinja = self.jinja
         if truncate:
-            trunc_command = f" | string | truncate({TEXT_VAR_LENGTH}) }}}}"  # Escaping curly braces requires doubling them
+            trunc_command = (
+                f" | string | truncate({TEXT_VAR_LENGTH}) }}}}"  # Escaping curly braces requires doubling them
+            )
             jinja = jinja.replace("}}", trunc_command)
         if highlight_variables:
             jinja = jinja.replace("}}", " | highlight }}")

--- a/promptsource/templates/adversarial_qa/dbert/templates.yaml
+++ b/promptsource/templates/adversarial_qa/dbert/templates.yaml
@@ -99,7 +99,7 @@ templates:
       {{answers.text[0]}}
 
 
-      {{answers.answer_start[0] | string}}'
+      {{answers.answer_start[0]}}'
     name: adversarial_qa_dbert_10
     reference: 'Input: Question, Context Output: Answer+Index (Python format)'
     task_template: true
@@ -148,7 +148,7 @@ templates:
       I know the answer to Q is in C. I don''t want the complete answer. I just want
       the index of the character from where the answer starts (as a hint). |||
 
-      {{answers.answer_start[0] | string}}'
+      {{answers.answer_start[0]}}'
     name: adversarial_qa_dbert_8
     reference: 'Input: QC, Output: beginning offset of A'
     task_template: true

--- a/promptsource/templates/adversarial_qa/dbidaf/templates.yaml
+++ b/promptsource/templates/adversarial_qa/dbidaf/templates.yaml
@@ -40,7 +40,7 @@ templates:
       I know the answer to Q is in C. I don''t want the complete answer. I just want
       the index of the character from where the answer starts (as a hint). |||
 
-      {{answers.answer_start[0] | string}}'
+      {{answers.answer_start[0]}}'
     name: adversarial_qa_dbidaf_8
     reference: 'Input: QC, Output: beginning offset of A'
     task_template: true
@@ -132,7 +132,7 @@ templates:
       {{answers.text[0]}}
 
 
-      {{answers.answer_start[0] | string}}'
+      {{answers.answer_start[0]}}'
     name: adversarial_qa_dbidaf_10
     reference: 'Input: Question, Context Output: Answer+Index (Python format)'
     task_template: true

--- a/promptsource/templates/adversarial_qa/droberta/templates.yaml
+++ b/promptsource/templates/adversarial_qa/droberta/templates.yaml
@@ -36,7 +36,7 @@ templates:
       {{answers.text[0]}}
 
 
-      {{answers.answer_start[0] | string}}'
+      {{answers.answer_start[0]}}'
     name: adversarial_qa_droberta_10
     reference: 'Input: Question, Context Output: Answer+Index (Python format)'
     task_template: true
@@ -114,7 +114,7 @@ templates:
       I know the answer to Q is in C. I don''t want the complete answer. I just want
       the index of the character from where the answer starts (as a hint). |||
 
-      {{answers.answer_start[0] | string}}'
+      {{answers.answer_start[0]}}'
     name: adversarial_qa_droberta_8
     reference: 'Input: QC, Output: beginning offset of A'
     task_template: true

--- a/promptsource/templates/generated_reviews_enth/templates.yaml
+++ b/promptsource/templates/generated_reviews_enth/templates.yaml
@@ -3,35 +3,35 @@ templates:
   7f158fb6-bbdd-41b8-bed7-21508c9f3c80: !Template
     id: 7f158fb6-bbdd-41b8-bed7-21508c9f3c80
     jinja: Does "{{translation.en}}" seem like a positive review to you? ||| {{["no","yes"][0
-      if review_star<3 else 1]}}'
+      if review_star<3 else 1]}}
     name: sentiment_analysis_4
     reference: stsb_multi_mt_en
     task_template: true
   95136948-3402-4bd4-8a69-1aa7b85461cc: !Template
     id: 95136948-3402-4bd4-8a69-1aa7b85461cc
     jinja: 'Rate the positivity of this review: ({{"1"}} being the lowest and {{"5"}}
-      the highest) "{{translation.en}}" ||| {{review_star | string}}'
+      the highest) "{{translation.en}}" ||| {{review_star}}'
     name: sentiment_analysis_5
     reference: stsb_multi_mt
     task_template: true
   ad12212f-a230-4750-a199-9791628856c4: !Template
     id: ad12212f-a230-4750-a199-9791628856c4
     jinja: "How positive is the review \"{{translation.en}}\"? Give a score between\n\
-      \      {{\"0\"}} and {{\"5\"}}. ||| {{review_star | string}}"
+      \      {{\"0\"}} and {{\"5\"}}. ||| {{review_star}}"
     name: sentiment_analysis_1
     reference: stsb_multi_mt_en
     task_template: true
   cf8f4dcb-f527-4944-b9ec-a1a3e476c13f: !Template
     id: cf8f4dcb-f527-4944-b9ec-a1a3e476c13f
     jinja: On a scale from {{"1"}} to {{"5"}}, how positive is the review "{{translation.en}}"?
-      ||| {{review_star | string}}
+      ||| {{review_star}}
     name: sentiment_analysis_3
     reference: stsb_multi_mt_en
     task_template: true
   e6c55d56-23d4-41a4-9908-e9366cc2e167: !Template
     id: e6c55d56-23d4-41a4-9908-e9366cc2e167
     jinja: Do you think "{{translation.en}}" is a positive review? ||| {{["no","yes"][0
-      if review_star < 3 else 1]}}'
+      if review_star < 3 else 1]}}
     name: sentiment_analysis_2
     reference: stsb_multi_mt_en
     task_template: true

--- a/promptsource/templates/head_qa/en/templates.yaml
+++ b/promptsource/templates/head_qa/en/templates.yaml
@@ -14,7 +14,7 @@ templates:
 
       {% for answer in answers %}
 
-      {{answer["aid"] | string}}. {{answer["atext"]}}
+      {{answer["aid"]}}. {{answer["atext"]}}
 
       {% endfor %}
 
@@ -22,7 +22,7 @@ templates:
       |||
 
 
-      Answer number {{ra | string}}'
+      Answer number {{ra}}'
     name: multiple_choice_q_and_a_index_with_context_en
     reference: Pose a multi-choice question using the index as an answer and the category
       as context
@@ -62,7 +62,7 @@ templates:
 
       {% for answer in answers %}
 
-      {{answer["aid"] | string}}. {{answer["atext"]}}
+      {{answer["aid"]}}. {{answer["atext"]}}
 
       {% endfor %}
 
@@ -70,7 +70,7 @@ templates:
       |||
 
 
-      Answer number {{ra | string}}'
+      Answer number {{ra}}'
     name: multiple_choice_q_and_a_index_en
     reference: Pose a multi-choice question using as anwer the index
   df12d7e1-2168-46e0-9400-c3a7ca27b42c: !Template

--- a/promptsource/templates/limit/templates.yaml
+++ b/promptsource/templates/limit/templates.yaml
@@ -69,7 +69,7 @@ templates:
     task_template: false
   766ab346-6fa6-4496-915f-65e7b06ab8ac: !Template
     id: 766ab346-6fa6-4496-915f-65e7b06ab8ac
-    jinja: "{{sentence}}\nHow many moving entities are mentioned in the sentence?\n|||\n{{motion_entities | length | string}}"
+    jinja: "{{sentence}}\nHow many moving entities are mentioned in the sentence?\n|||\n{{motion_entities | length}}"
     name: count_entities
     reference: ''
     task_template: false
@@ -107,7 +107,7 @@ templates:
     task_template: false
   b847d63c-0b52-4b6e-a62f-12e47439ce54: !Template
     id: b847d63c-0b52-4b6e-a62f-12e47439ce54
-    jinja: "Count the number of moving entities in the following sentence.\n{{sentence}}\n|||\n{{motion_entities | length | string}}"
+    jinja: "Count the number of moving entities in the following sentence.\n{{sentence}}\n|||\n{{motion_entities | length}}"
     name: count_entities_affirm
     reference: ''
     task_template: false

--- a/promptsource/templates/ncbi_disease/templates.yaml
+++ b/promptsource/templates/ncbi_disease/templates.yaml
@@ -60,7 +60,7 @@ templates:
 
       {{ vars.update({''no_disease'': False}) | default("", True) }}
 
-      - {{(loop.index - 1) | string}}
+      - {{(loop.index - 1)}}
 
       {% endif %}
 


### PR DESCRIPTION
Fix truncation for non-str variables by systematically converting the variable to a string (in practice it doesn't change anything).
I also moved the conversion to string upstream (directly in the `apply` method) instead of in the templates for the truncation (which requires a string argument).
