### PR TITLE
Skip empty answers in private test sets

### DIFF
--- a/promptsource/templates/super_glue/record/templates.yaml
+++ b/promptsource/templates/super_glue/record/templates.yaml
@@ -3,36 +3,40 @@ subset: record
 templates:
   014b669e-2e3b-40ce-bdde-418966c7d666: !Template
     id: 014b669e-2e3b-40ce-bdde-418966c7d666
-    jinja: "{{ passage }} \n{{ query }} \nWhich one is the \"@placeholder\"? {{ entities\
-      \ | join(\", \") }}? ||| {{ answers | choice }}"
+    jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nWhich\
+      \ one is the \"@placeholder\"? {{ entities | join(\", \") }}? ||| {{ answers\
+      \ | choice }}\n{% endif %}"
     name: Which one is the placeholder?
     reference: ''
     task_template: true
   91555c1c-c1e4-469b-a2a4-fc952ce1a145: !Template
     id: 91555c1c-c1e4-469b-a2a4-fc952ce1a145
-    jinja: "{{ passage }} \n{{ query }} \nIn the question above, the \"@placeholder\" stands\
-      \ for ||| {{ answers | choice }}"
+    jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nIn the\
+      \ question above, the \"@placeholder\" stands for ||| {{ answers | choice }}\n\
+      {% endif %}"
     name: In the question above, the placeholder stands for
     reference: ''
     task_template: true
   99dd38ce-32f3-4d58-93c5-59821002b9cc: !Template
     id: 99dd38ce-32f3-4d58-93c5-59821002b9cc
-    jinja: "{{ passage }} \n{{ query }} \nWhat could the \"@placeholder\" be? {{ entities\
-      \ | join(\", \") }}? ||| {{ answers | choice }}"
+    jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nWhat\
+      \ could the \"@placeholder\" be? {{ entities | join(\", \") }}? ||| {{ answers\
+      \ | choice }}\n{% endif %}"
     name: What could the placeholder be?
     reference: ''
     task_template: true
   a5ed27ed-162b-4ac1-9c7a-85059d5214be: !Template
     id: a5ed27ed-162b-4ac1-9c7a-85059d5214be
-    jinja: "{{ passage }} \n{{ query }} \nHere, the placeholder refers to ||| {{ answers\
-      \ | choice }}"
+    jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nHere,\
+      \ the placeholder refers to ||| {{ answers | choice }}\n{% endif %}"
     name: "the placeholder refers to\u2026"
     reference: ''
     task_template: true
   e68d13c5-df75-4de0-b59e-f2eaf4af6ce7: !Template
     id: e68d13c5-df75-4de0-b59e-f2eaf4af6ce7
-    jinja: "{{ passage }} \n{{ query }} \nCan you figure out what does the \"@placeholder\"\
-      \ mean? It means ||| {{ answers | choice }}"
+    jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nCan\
+      \ you figure out what does the \"@placeholder\" mean? It means ||| {{ answers\
+      \ | choice }}\n{% endif %}"
     name: "Can you figure out\u2026"
     reference: ''
     task_template: true


### PR DESCRIPTION
Per [discussion](https://huggingface.slack.com/archives/C020GCD4YTV/p1624470853227200?thread_ts=1624382646.187700&cid=C020GCD4YTV) in Slack, this adds an if condition that skips the private test set of SuperGLUE ReCoRD, which has empty `answers` that cause seqio_cache_tasks to fail.