### PR TITLE
Fix prompt imports

### DIFF
--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -10,8 +10,9 @@ from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import DjangoLexer
 from session import _get_state
-from templates import Template, TemplateCollection
 from utils import get_dataset, get_dataset_confs, list_datasets, removeHyphen, renameDatasetColumn, render_features
+
+from templates import Template, TemplateCollection
 
 
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black
 datasets==1.7.0
 flake8
-isort
+isort==5.8.0
 pytest
 pyyaml>=5
 streamlit>=0.82.0


### PR DESCRIPTION
For some reason this is what isort wants our imports to be currently. 

Long term we should put promptsource in a package so these make more sense. 