### PR TITLE
fixed STSB type errors

### DIFF
--- a/promptsource/templates/glue/stsb/templates.yaml
+++ b/promptsource/templates/glue/stsb/templates.yaml
@@ -4,9 +4,10 @@ templates:
   50e3a541-108c-4b26-a423-956562d9b3af: !Template
     id: 50e3a541-108c-4b26-a423-956562d9b3af
     jinja: Rate on a scale from {{"0.0"}} to {{"5.0"}} how similar the sentences "{{sentence1}}"
-      and "{{sentence2}}" are. ||| {{((5*label)|round)/5}}
+      and "{{sentence2}}" are. ||| {{ (((5*label) | round )/5) }}
     name: rank
     reference: ''
+    task_template: false
   88dcb716-d19c-45bc-9d3a-cdf8fff5500b: !Template
     id: 88dcb716-d19c-45bc-9d3a-cdf8fff5500b
     jinja: 'Please rate how similar these two sentences are from {{"0.0"}} to {{"5.0"}}.
@@ -17,9 +18,10 @@ templates:
 
       |||
 
-      {{((5*label)|round)/5}}'
+      {{ (((5*label) | round )/5) }}'
     name: rate
     reference: ''
+    task_template: false
   a552635f-3a9a-497f-ac04-ef414b24eb16: !Template
     id: a552635f-3a9a-497f-ac04-ef414b24eb16
     jinja: 'Please give me a score denoting the similarity of the following two sentences:
@@ -33,9 +35,10 @@ templates:
 
       |||
 
-      {{((5*label)|round)/5}}'
+      {{ (((5*label) | round )/5) }}'
     name: examples
     reference: ''
+    task_template: false
   ca75788d-4974-440a-a7b7-c42bae814d59: !Template
     id: ca75788d-4974-440a-a7b7-c42bae814d59
     jinja: 'I need to know how similar these two passages are:
@@ -52,9 +55,10 @@ templates:
 
       |||
 
-      {{((5*label)|round)/5}}'
+      {{ (((5*label) | round )/5) }}'
     name: similarity
     reference: ''
+    task_template: false
   d7315518-cfb9-4840-93ab-c52f1bb5e74d: !Template
     id: d7315518-cfb9-4840-93ab-c52f1bb5e74d
     jinja: 'I need to assign a score from {{"0.0 to 5.0"}} that denotes how similar
@@ -68,6 +72,7 @@ templates:
 
       |||
 
-      {{((5*label)|round)/5}}'
+      {{ (((5*label) | round )/5) }}'
     name: score
     reference: ''
+    task_template: false


### PR DESCRIPTION
Jinja seems to require parentheses around arithmetic expressions and also no whitespace around operators. 