### PR TITLE
new-line removed from prompt

### DIFF
--- a/promptsource/templates/nq_open/templates.yaml
+++ b/promptsource/templates/nq_open/templates.yaml
@@ -12,7 +12,7 @@ templates:
     task_template: false
   91d9f950-a25a-4557-a16f-952d74629584: !Template
     id: 91d9f950-a25a-4557-a16f-952d74629584
-    jinja: 'Answer the following question. \n{{question}}
+    jinja: 'Answer the following question. {{question}}
 
       |||
 
@@ -28,15 +28,13 @@ templates:
 
       {{answer|choice}} '
     name: context_self_description
-    reference: Ask a question by self self description
+    reference: Ask a question by self description
     task_template: true
   c29c7072-0535-4e38-ba0c-b7ac0acdacf8: !Template
     id: c29c7072-0535-4e38-ba0c-b7ac0acdacf8
-    jinja: 'Question : {{question}} \nAnswer :
-
+    jinja: 'Question : {{question}}  Answer :
 
       |||
-
 
       {{answer | choice}}'
     name: question_answer

--- a/promptsource/templates/trivia_qa/rc/templates.yaml
+++ b/promptsource/templates/trivia_qa/rc/templates.yaml
@@ -9,7 +9,9 @@ templates:
       the following text-snippet on Wikipedia and I think it has the answer. Can you
       tell me the answer?
 
-      \n{{entity_pages.wiki_context|choice}}
+
+      {{entity_pages.wiki_context|choice}}
+
 
       ||| {{answer.aliases|choice}}
 
@@ -26,8 +28,8 @@ templates:
     task_template: false
   91d9f950-a25a-4557-a16f-952d74629584: !Template
     id: 91d9f950-a25a-4557-a16f-952d74629584
-    jinja: '{% if answer.aliases %} Answer the following question. \n{{question}}
-      |||{{answer.aliases|choice}} {% endif %}'
+    jinja: '{% if answer.aliases %} Answer the following question. {{question}} |||{{answer.aliases|choice}}
+      {% endif %}'
     name: question_with_instruction
     reference: Question followed by an instruction
     task_template: false
@@ -39,7 +41,9 @@ templates:
       the following text-snippet on the internet and I think it has the answer. Can
       you tell me the answer?
 
-      \n{{search_results.search_context|choice}}
+
+      {{search_results.search_context|choice}}
+
 
       ||| {{answer.aliases|choice}}
 
@@ -56,7 +60,7 @@ templates:
     task_template: false
   c29c7072-0535-4e38-ba0c-b7ac0acdacf8: !Template
     id: c29c7072-0535-4e38-ba0c-b7ac0acdacf8
-    jinja: '{% if answer.aliases %} Question : {{question}} \nAnswer : ||| {{answer.aliases|choice}}
+    jinja: '{% if answer.aliases %} Question : {{question}} Answer : ||| {{answer.aliases|choice}}
       {% endif %}'
     name: question_answer
     reference: Plain Question


### PR DESCRIPTION
Earlier before submitting the prompt, I tested `question_answer` prompt with open-ai `da-vinci` api and it worked perfectly with a "\n"

However, according to the recent suggestion of @awebson  I removed the `\n` from the prompts. Hope it helps. 

 