### PR TITLE
Switch to indexing format where missing

### DIFF
--- a/promptsource/templates/anli/templates.yaml
+++ b/promptsource/templates/anli/templates.yaml
@@ -2,9 +2,13 @@ dataset: anli
 templates:
   391acb43-732a-4c09-8c10-e02d226d8854: !Template
     id: 391acb43-732a-4c09-8c10-e02d226d8854
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
-      \ 1 contradict Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \n\
-      No\n{% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 contradict Sentence 2? Yes, No, or Neutral? |||
+
+      {{["No", "Neutral", "Yes"][label]}}'
     name: does S1 contradict S2?
     reference: Copied from Victor's prompts for XNLI.
     task_template: false
@@ -37,9 +41,13 @@ templates:
     task_template: true
   cf55f09b-bc68-439d-a9b2-781263509f99: !Template
     id: cf55f09b-bc68-439d-a9b2-781263509f99
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
-      \ 1 entail Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \nYes\n\
-      {% elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 entail Sentence 2? Yes, No, or Neutral? |||
+
+      {{["Yes", "Neutral", "No"][label]}}'
     name: does S1 entail S2?
     reference: Copied from Victor's prompts for XNLI.
     task_template: true

--- a/promptsource/templates/esnli/templates.yaml
+++ b/promptsource/templates/esnli/templates.yaml
@@ -100,16 +100,18 @@ templates:
   c6cce628-8e69-418b-8676-deae7a782e7f: !Template
     id: c6cce628-8e69-418b-8676-deae7a782e7f
     jinja: "Does this statement: \n\n{{ premise }} \n\nimply that: \n\n{{ hypothesis\
-      \ }}?\n|||\n{{ [\"Yes\", \"No\"][0 if label==0 else 1] }}"
+      \ }}?\n|||\n{{ [\"Yes\", \"No\", \"No\"][label] }}"
     name: entail_1
     reference: ''
+    task_template: false
   ef034633-d4d9-47b8-9152-b025b1d61e5b: !Template
     id: ef034633-d4d9-47b8-9152-b025b1d61e5b
     jinja: "First statement: \n{{ premise }}\n\nSecond statement: \n{{ hypothesis\
-      \ }}\n\nDo the statements above contradict each other?\n|||\n{{ [\"Yes\", \"\
-      No\"][0 if label==2 else 1] }}"
+      \ }}\n\nDo the statements above contradict each other?\n|||\n{{ [\"No\", \"\
+      No\", \"Yes\"][label] }}"
     name: '  contradict_1'
     reference: ''
+    task_template: false
   f64d6196-370b-4501-acb5-e11a5ebf0c5e: !Template
     id: f64d6196-370b-4501-acb5-e11a5ebf0c5e
     jinja: "If we know that:\n{{premise}}\n{% if label == 0 %} \nWhy is it always\

--- a/promptsource/templates/hans/templates.yaml
+++ b/promptsource/templates/hans/templates.yaml
@@ -16,9 +16,13 @@ templates:
     task_template: true
   930dbf9e-be95-458c-bf63-0358e36b8f8f: !Template
     id: 930dbf9e-be95-458c-bf63-0358e36b8f8f
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
-      \ 1 entail Sentence 2? Yes or no? |||\n{% if label == 0 %} \nYes\n{% else %}\n\
-      No\n{% endif %}"
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 entail Sentence 2? Yes or no? |||
+
+      {{["Yes", "No"][label]}}'
     name: does S1 entail S2?
     reference: Adapted from Victor's prompts for XNLI.
     task_template: true

--- a/promptsource/templates/multi_nli/templates.yaml
+++ b/promptsource/templates/multi_nli/templates.yaml
@@ -33,17 +33,25 @@ templates:
     task_template: true
   ca5a9209-47ed-4ca9-9b03-7ea909f61d96: !Template
     id: ca5a9209-47ed-4ca9-9b03-7ea909f61d96
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
-      \ 1 contradict Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \n\
-      No\n{% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 contradict Sentence 2? Yes, No, or Neutral? |||
+
+      {{ ["No", "Neutral", "Yes"][label] }}'
     name: does S1 contradict S2?
     reference: Copied from Victor's prompts for XNLI.
     task_template: false
   d067f960-75d9-4fed-bf54-6ddaff123a57: !Template
     id: d067f960-75d9-4fed-bf54-6ddaff123a57
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
-      \ 1 entail Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \nYes\n\
-      {% elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 entail Sentence 2? Yes, No, or Neutral? |||
+
+      {{ ["Yes", "Neutral", "No"][label] }}'
     name: does S1 entail S2?
     reference: Copied from Victor's prompts for XNLI.
     task_template: true

--- a/promptsource/templates/multi_nli_mismatch/templates.yaml
+++ b/promptsource/templates/multi_nli_mismatch/templates.yaml
@@ -2,43 +2,50 @@ dataset: multi_nli_mismatch
 templates:
   08024afb-d156-46eb-9697-d3f6fcfeb460: !Template
     id: 08024afb-d156-46eb-9697-d3f6fcfeb460
-    jinja: "{{premise}}\nQuestion: {{hypothesis}} Yes, maybe, or no? ||| \n{% if label\
-      \ == \"entailment\" %} \nYes\n{% elif label == \"neutral\" %}\nMaybe\n{% else\
-      \ %}\nNo\n{% endif %}"
+    jinja: "{{premise}}\nQuestion: {{hypothesis}} Yes, maybe, or no? ||| \n{{ {\"\
+      entailment\": \"Yes\", \"neutral\": \"Maybe\", \"contradiction\": \"No\"}[label]\
+      \ }}"
     name: GPT3-style
     reference: Similar to the Multi-NLI template
     task_template: true
   2d88a6db-69c0-4a1b-b63d-c296827fb3ca: !Template
     id: 2d88a6db-69c0-4a1b-b63d-c296827fb3ca
     jinja: "{{premise}} Based on the previous passage, is it true that {{hypothesis}}\
-      \ Yes, maybe, or no?\n||| \n{% if label == \"entailment\" %} \nYes\n{% elif\
-      \ label == \"neutral\" %}\nNeutral\n{% else %}\nNo\n{% endif %}"
+      \ Yes, maybe, or no?\n||| \n{{ {\"entailment\": \"Yes\", \"neutral\": \"Neutral\"\
+      , \"contradiction\": \"No\"}[label] }}"
     name: Based on the previous passage
     reference: Similar to the MNLI template
     task_template: true
   33cd3db0-ec12-4fe4-8e67-2ed2547e3102: !Template
     id: 33cd3db0-ec12-4fe4-8e67-2ed2547e3102
     jinja: "Given that {{premise}} Does it follow that {{hypothesis}} Yes, no, or\
-      \ maybe?\n||| \n{% if label == \"entailment\" %} \nYes\n{% elif label == \"\
-      neutral\" %}\nMaybe\n{% else %}\nNo\n{% endif %}"
+      \ maybe?\n||| \n{{ {\"entailment\": \"Yes\", \"neutral\": \"Maybe\", \"contradiction\"\
+      : \"No\"}[label] }}"
     name: "given\u2026 does it follow that\u2026 "
     reference: Similar to the MNLI template
     task_template: true
   eb305885-3cf3-49b0-92de-6b9f51628007: !Template
     id: eb305885-3cf3-49b0-92de-6b9f51628007
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
-      \ 1 entail Sentence 2? Yes, No, or Neutral? |||\n{% if label == \"entailment\"\
-      \ %} \nYes\n{% elif label == \"neutral\" %}\nNeutral\n{% else %}\nNo\n{% endif\
-      \ %}"
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 entail Sentence 2? Yes, No, or Neutral? |||
+
+      {{ {"entailment": "Yes", "neutral": "Neutral", "contradiction": No}[label] }}'
     name: Does S1 entail S2?
     reference: Similar to the MNLI template
     task_template: true
   ece94a4c-cfa1-4eb5-9af7-204d0c5791ea: !Template
     id: ece94a4c-cfa1-4eb5-9af7-204d0c5791ea
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
-      \ 1 contradict Sentence 2? Yes, No, or Neutral? |||\n{% if label == \"entailment\"\
-      \ %} \nNo\n{% elif label == \"neutral\" %}\nNeutral\n{% else %}\nYes\n{% endif\
-      \ %}"
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 contradict Sentence 2? Yes, No, or Neutral? |||
+
+      {{ {"entailment": "No", "neutral": "Neutral", "contradiction": "Yes"}[label]
+      }}'
     name: Does S1 contradict S2?
     reference: Similar to the MNLI template
     task_template: true

--- a/promptsource/templates/multi_nli_mismatch/templates.yaml
+++ b/promptsource/templates/multi_nli_mismatch/templates.yaml
@@ -32,7 +32,8 @@ templates:
 
       Question: Does Sentence 1 entail Sentence 2? Yes, No, or Neutral? |||
 
-      {{ {"entailment": "Yes", "neutral": "Neutral", "contradiction": No}[label] }}'
+      {{ {"entailment": "Yes", "neutral": "Neutral", "contradiction": "No"}[label]
+      }}'
     name: Does S1 entail S2?
     reference: Similar to the MNLI template
     task_template: true

--- a/promptsource/templates/snli/templates.yaml
+++ b/promptsource/templates/snli/templates.yaml
@@ -12,9 +12,13 @@ templates:
     task_template: true
   5f0ef86f-2b8f-4a0c-8bca-a8b8d9ac015e: !Template
     id: 5f0ef86f-2b8f-4a0c-8bca-a8b8d9ac015e
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
-      \ 1 entail Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \nYes\n\
-      {% elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 entail Sentence 2? Yes, No, or Neutral? |||
+
+      {{["Yes", "Neutral", "No"][label]}}'
     name: does S1 entail S2?
     reference: Copied from Victor's prompts for XNLI.
     task_template: true
@@ -31,9 +35,13 @@ templates:
     task_template: true
   94c87dc3-865e-4321-a696-bbc5a54d7096: !Template
     id: 94c87dc3-865e-4321-a696-bbc5a54d7096
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
-      \ 1 contradict Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \n\
-      No\n{% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 contradict Sentence 2? Yes, No, or Neutral? |||
+
+      {{["No", "Neutral", "Yes"][label]}}'
     name: does S1 contradict S2?
     reference: Copied from Victor's prompts for XNLI.
     task_template: false

--- a/promptsource/templates/super_glue/cb/templates.yaml
+++ b/promptsource/templates/super_glue/cb/templates.yaml
@@ -3,9 +3,13 @@ subset: cb
 templates:
   0acadc5c-8cd0-4e33-b117-379321bc0df1: !Template
     id: 0acadc5c-8cd0-4e33-b117-379321bc0df1
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
-      \ 1 contradict Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \n\
-      No\n{% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 contradict Sentence 2? Yes, No, or Neutral? |||
+
+      {{["No", "Neutral", "Yes"][label]}}'
     name: does S1 contradict S2?
     reference: Copied from Victor's prompts for XNLI.
     task_template: false
@@ -36,9 +40,13 @@ templates:
     task_template: true
   86120953-771a-4dca-a681-d628117ba6d2: !Template
     id: 86120953-771a-4dca-a681-d628117ba6d2
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
-      \ 1 entail Sentence 2? Yes, No, or Neutral? |||\n{% if label == 0 %} \nYes\n\
-      {% elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 entail Sentence 2? Yes, No, or Neutral? |||
+
+      {{["Yes", "Neutral", "No"][label]}}'
     name: does S1 entail S2?
     reference: Copied from Victor's prompts for XNLI.
     task_template: true

--- a/promptsource/templates/super_glue/rte/templates.yaml
+++ b/promptsource/templates/super_glue/rte/templates.yaml
@@ -10,9 +10,13 @@ templates:
     task_template: true
   1abaa658-e7f0-4e54-b7ad-312ba009d544: !Template
     id: 1abaa658-e7f0-4e54-b7ad-312ba009d544
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
-      \ 1 entail Sentence 2? Yes or no? |||\n{% if label == 0 %} \nYes\n{% else %}\n\
-      No\n{% endif %}"
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 entail Sentence 2? Yes or no? |||
+
+      {{["Yes", "No"][label]}}'
     name: does S1 entail S2?
     reference: Adapted from Victor's prompts for XNLI.
     task_template: true

--- a/promptsource/templates/super_glue/wic/templates.yaml
+++ b/promptsource/templates/super_glue/wic/templates.yaml
@@ -4,48 +4,44 @@ templates:
   14e73f39-a0d1-44c2-b9a4-4e48f9f1608e: !Template
     id: 14e73f39-a0d1-44c2-b9a4-4e48f9f1608e
     jinja: "Does the word \"{{word}}\" have the same meaning in these two sentences?\
-      \ Yes, No?\n{{sentence1}}\n{{sentence2}}\n||| \n{% if label == 0 %} \nNo\n{%\
-      \ elif label == 1 %}\nYes\n{% endif %}"
+      \ Yes, No?\n{{sentence1}}\n{{sentence2}}\n||| \n{{[\"No\", \"Yes\"][label]}}"
     name: question-context-meaning-with-label
     reference: Generalized question-context format with label
     task_template: true
   3503ead5-4fa5-4f77-95dc-f0c2ed3eecdc: !Template
     id: 3503ead5-4fa5-4f77-95dc-f0c2ed3eecdc
     jinja: "Does the word \"{{word}}\" have the same meaning in these two sentences?\n\
-      {{sentence1}}\n{{sentence2}}\n||| \n{% if label == 0 %} \nNo\n{% elif label\
-      \ == 1 %}\nYes\n{% endif %}"
+      {{sentence1}}\n{{sentence2}}\n||| \n{{[\"No\", \"Yes\"][label]}}"
     name: question-context-meaning
     reference: Generalized question-context format
     task_template: true
   c3a0a5d8-cfe9-4a7f-8a3c-3c526e0ad0c6: !Template
     id: c3a0a5d8-cfe9-4a7f-8a3c-3c526e0ad0c6
     jinja: "{{sentence1}}\n{{sentence2}}\nQuestion: Is the word '{{word}}' used in\
-      \ the same way in the two sentences above?\n||| \n{% if label == 0 %} \nNo\n\
-      {% elif label == 1 %}\nYes\n{% endif %}"
+      \ the same way in the two sentences above?\n||| \n{{[\"No\", \"Yes\"][label]}}"
     name: GPT-3-prompt
     reference: Following table G32. https://arxiv.org/pdf/2005.14165.pdf
     task_template: true
   cfbc1637-10b8-4f20-a31c-55292f3cebd0: !Template
     id: cfbc1637-10b8-4f20-a31c-55292f3cebd0
     jinja: "Determine if the word '{{word}}' is used in the same way in the two sentences\
-      \ below. \n{{sentence1}}\n{{sentence2}}\n||| \n{% if label == 0 %} \nNo\n{%\
-      \ elif label == 1 %}\nYes\n{% endif %}"
+      \ below. \n{{sentence1}}\n{{sentence2}}\n||| \n{{[\"No\", \"Yes\"][label]}}"
     name: question-context
     reference: Generalized question-context format
     task_template: true
   d9e1db2a-ab0b-4621-bb41-01d5788d3873: !Template
     id: d9e1db2a-ab0b-4621-bb41-01d5788d3873
     jinja: "{{sentence1}}\n{{sentence2}}\nQuestion: Is the word '{{word}}' used in\
-      \ the same way in the two sentences above? Yes, No?\n||| \n{% if label == 0\
-      \ %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+      \ the same way in the two sentences above? Yes, No?\n||| \n{{[\"No\", \"Yes\"\
+      ][label]}}"
     name: GPT-3-prompt-with-label
     reference: Following table G32. https://arxiv.org/pdf/2005.14165.pdf add additional
       label
     task_template: true
   f934a96d-fe4d-4075-aa47-5595b9a604c7: !Template
     id: f934a96d-fe4d-4075-aa47-5595b9a604c7
-    jinja: "{{sentence1}}\n{{sentence2}}\nSimilar sense of {{word}}?\n||| \n{% if\
-      \ label == 0 %} \nNo\n{% elif label == 1 %}\nYes\n{% endif %}"
+    jinja: "{{sentence1}}\n{{sentence2}}\nSimilar sense of {{word}}?\n||| \n{{[\"\
+      No\", \"Yes\"][label]}}"
     name: similar-sense
     reference: Following https://arxiv.org/abs/2105.11447, https://github.com/ethanjperez/true_few_shot/tree/main/templates.super_glue
     task_template: true

--- a/promptsource/templates/xnli/en/templates.yaml
+++ b/promptsource/templates/xnli/en/templates.yaml
@@ -3,9 +3,14 @@ subset: en
 templates:
   4e122d26-7e79-49c0-961b-cf8ee134759e: !Template
     id: 4e122d26-7e79-49c0-961b-cf8ee134759e
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
-      \ 1 contradict Sentence 2? Yes, No, or {{\"Neutral\"}}? |||\n{% if label ==\
-      \ 0 %} \nNo\n{% elif label == 1 %}\nNeutral\n{% else %}\nYes\n{% endif %}"
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 contradict Sentence 2? Yes, No, or {{"Neutral"}}?
+      |||
+
+      {{["No", "Neutral", "Yes"][label]}}'
     name: Concatenation contraposition
     reference: Concatenation contraposition
     task_template: false
@@ -22,9 +27,13 @@ templates:
     task_template: true
   c62a3048-018e-4d93-bc46-645f3f763ee6: !Template
     id: c62a3048-018e-4d93-bc46-645f3f763ee6
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
-      \ 1 contradict Sentence 2? Yes or No? |||\n{% if label == 2 %} \nYes\n{% else\
-      \ %}\nNo\n{% endif %}"
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 contradict Sentence 2? Yes or No? |||
+
+      {{["No", "No", "Yes"][label]}}'
     name: Label binarization contraposition
     reference: Inspired from https://arxiv.org/pdf/1902.01007.pdf Section 4 - Implementation
       and evaluation
@@ -42,16 +51,19 @@ templates:
   d9e13133-267e-46c4-afad-c2379dcc5272: !Template
     id: d9e13133-267e-46c4-afad-c2379dcc5272
     jinja: "{{premise}}\nQuestion: {{hypothesis}} True, False, or Neither? ||| \n\
-      {% if label == 0 %} \nTrue\n{% elif label == 1 %}\nNeither\n{% else %}\nFalse\n\
-      {% endif %}"
+      {{[\"True\", \"Neither\", \"False\"][label]}}"
     name: ANLI GPT3
     reference: ANLI prompt format from Table G7 in the GPT3 paper
     task_template: true
   dd4276e6-aebd-44a3-b3cf-baf8a4c237f0: !Template
     id: dd4276e6-aebd-44a3-b3cf-baf8a4c237f0
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
-      \ 1 entail Sentence 2? Yes or No? |||\n{% if label == 0 %} \nYes\n{% else %}\n\
-      No\n{% endif %}"
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 entail Sentence 2? Yes or No? |||
+
+      {{["Yes", "No", "No"][label]}}'
     name: Label binarization
     reference: Grouping "neutral" and "contradiction" as a single label following
       https://arxiv.org/pdf/1902.01007.pdf Section 4 - Implementation and evaluation
@@ -65,9 +77,13 @@ templates:
     task_template: true
   e174f56a-b0af-4937-b6ae-1897cac26eba: !Template
     id: e174f56a-b0af-4937-b6ae-1897cac26eba
-    jinja: "Sentence 1: {{premise}}\nSentence 2: {{hypothesis}}\nQuestion: Does Sentence\
-      \ 1 entail Sentence 2? Yes, No, or {{\"Neutral\"}}? |||\n{% if label == 0 %}\
-      \ \nYes\n{% elif label == 1 %}\nNeutral\n{% else %}\nNo\n{% endif %}"
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 entail Sentence 2? Yes, No, or {{"Neutral"}}? |||
+
+      {{["Yes", "Neutral", "No"][label]}}'
     name: Concatenation
     reference: Concatenation of premise and hypothesis
     task_template: true


### PR DESCRIPTION
Some prompts had their targets in the format `{% if label == "entailment" %} Yes` etc. It's harder to figure out what the label strings are in this case. This switches them all to indexing notation, like `{{ ["Yes", "Maybe", "No"][label]`. Please scrutinize this carefully to think about whether it changes any of the tasks by mistake!