### PR TITLE
fixed CommitmentBank label indexing bug

### DIFF
--- a/promptsource/templates/super_glue/cb/templates.yaml
+++ b/promptsource/templates/super_glue/cb/templates.yaml
@@ -9,21 +9,21 @@ templates:
 
       Question: Does Sentence 1 contradict Sentence 2? Yes, No, or Neutral? |||
 
-      {{["No", "Neutral", "Yes"][label]}}'
+      {{["No", "Yes", "Neutral"][label]}}'
     name: does S1 contradict S2?
     reference: Copied from Victor's prompts for XNLI.
     task_template: false
   5bca1a90-340b-42b4-9c0d-e5eb1c25605e: !Template
     id: 5bca1a90-340b-42b4-9c0d-e5eb1c25605e
     jinja: Given that {{premise}} Does it follow that {{hypothesis}}? {{"Yes, no,
-      or maybe?"}} ||| {{ ["Yes", "Maybe", "No"][label] }}
+      or maybe?"}} ||| {{ ["Yes", "No", "Maybe"][label] }}
     name: "given\u2026 does it follow that\u2026 "
     reference: ''
     task_template: true
   684f44af-f09a-4231-a318-94473a9624b7: !Template
     id: 684f44af-f09a-4231-a318-94473a9624b7
     jinja: Given that {{premise}}, it {{"must be true, might be true, or must be false"}}
-      that {{hypothesis}}? ||| It {{ ["must be true", "might be true", "must be false"][label]
+      that {{hypothesis}}? ||| It {{ ["must be true", "must be false", "might be true"][label]
       }}.
     name: "given\u2026 it must be true that\u2026"
     reference: 'Maybe a little verbose for a generative model, but anecdotally this
@@ -34,7 +34,7 @@ templates:
   774c170e-9fff-4b0b-871a-30967b0186f6: !Template
     id: 774c170e-9fff-4b0b-871a-30967b0186f6
     jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
-      Yes, no, or maybe? ||| {{ ["Yes", "Maybe", "No"][label] }}'
+      Yes, no, or maybe? ||| {{ ["Yes", "No", "Maybe"][label] }}'
     name: based on the previous passage
     reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
     task_template: true
@@ -46,7 +46,7 @@ templates:
 
       Question: Does Sentence 1 entail Sentence 2? Yes, No, or Neutral? |||
 
-      {{["Yes", "Neutral", "No"][label]}}'
+      {{["Yes", "No", "Neutral"][label]}}'
     name: does S1 entail S2?
     reference: Copied from Victor's prompts for XNLI.
     task_template: true
@@ -54,8 +54,8 @@ templates:
     id: bab42d43-d1e6-4a42-8112-75a398fd582c
     jinja: '{{premise}}
 
-      Question: {{hypothesis}}. True, False, or Neither? ||| {{ ["True", "Neither",
-      "False"][label] }}'
+      Question: {{hypothesis}}. True, False, or Neither? ||| {{ ["True", "False",
+      "Neither"][label] }}'
     name: GPT-3 style
     reference: 'Same as reported in Figure G7 of the GPT-3 paper, except that there
       is no task identifying tokens like "anli R1: ".'


### PR DESCRIPTION
Upon some error analyses I found a bug in my prompts for CommitmentBank: Its label 1 is contradiction, when usually label 2 is contradiction and label 1 is neutral among 3-way NLI sets. Sorry! Can't believe I didn't catch this earlier. That explains why our performance on CB was so bad even though we were good on other NLI sets.

@VictorSanh @craffel You don't have to rerun any eval now, but please re-cache seqio before you run the next series of evaluations. (And maybe pull #321 as well to fix a small bug in Natural Questions.)