### PR TITLE
Clean nq_open.

### DIFF
--- a/promptsource/templates/nq_open/templates.yaml
+++ b/promptsource/templates/nq_open/templates.yaml
@@ -1,11 +1,34 @@
 dataset: nq_open
 templates:
+  05b8ac63-5aa1-4ce7-8257-ade0fca889ae: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: 05b8ac63-5aa1-4ce7-8257-ade0fca889ae
+    jinja: 'The goal is to predict an English answer string for an input English question.
+      All questions can be answered using the contents of English Wikipedia.
+
+      Question: {{question}}
+
+      Answer:
+
+      |||
+
+      {{answer|choice}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Sequence Accuracy
+      - Other
+      original_task: true
+    name: formal_description
+    reference: Copied from the dataset description.
   0b23fe26-c659-4a84-834f-f19622d11412: !Template
     answer_choices: null
     answer_choices_key: null
     id: 0b23fe26-c659-4a84-834f-f19622d11412
-    jinja: 'Question : {{question}} \nAnswer :
+    jinja: 'Question : {{question}}
 
+      Answer :
 
       |||
 
@@ -14,8 +37,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Sequence Accuracy
+      - Other
       original_task: true
     name: question_answer
     reference: Plain Question
@@ -23,7 +48,7 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: 35113036-4cb4-4db5-a92e-d208e1b48b7c
-    jinja: 'Guess a question from the topic "{{answer|choice}}"
+    jinja: 'Guess a question that has the answer "{{answer|choice}}"
 
       |||
 
@@ -31,8 +56,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: false
     name: guess_question
     reference: Guess a question. It will show if model can evaluate entity in question.
@@ -48,16 +75,20 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Sequence Accuracy
+      - Other
       original_task: true
-    name: context_self_description
-    reference: Ask a question by self self description
+    name: first_person_context
+    reference: Ask a question in first person
   cf937d15-48e0-4ae3-a4eb-9098cccc58ce: !Template
     answer_choices: null
     answer_choices_key: null
     id: cf937d15-48e0-4ae3-a4eb-9098cccc58ce
-    jinja: 'Answer the following question. \n{{question}}
+    jinja: 'Answer the following question.
+
+      {{question}}
 
       |||
 
@@ -65,8 +96,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Sequence Accuracy
+      - Other
       original_task: true
     name: question_with_instruction
-    reference: Question followed by an instruction
+    reference: Instruction before question.

--- a/promptsource/templates/nq_open/templates.yaml
+++ b/promptsource/templates/nq_open/templates.yaml
@@ -82,6 +82,24 @@ templates:
       original_task: true
     name: first_person_context
     reference: Ask a question in first person
+  cd157288-0211-46a8-a00c-ba0e07980e37: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: cd157288-0211-46a8-a00c-ba0e07980e37
+    jinja: 'Search query: {{question}}
+
+      Response:
+
+      |||
+
+      {{answer|choice}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: search query
+    reference: ''
   cf937d15-48e0-4ae3-a4eb-9098cccc58ce: !Template
     answer_choices: null
     answer_choices_key: null

--- a/promptsource/templates/nq_open/templates.yaml
+++ b/promptsource/templates/nq_open/templates.yaml
@@ -52,7 +52,7 @@ templates:
 
       |||
 
-      {{question}}'
+      {{question}}?'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false


### PR DESCRIPTION
The "Other" in the metrics refers to accuracy computed after "minor normalization" mentioned here:
https://efficientqa.github.io/assets/report.pdf
referencing 
Lee, K., M.-W. Chang, K. Toutanova. Latent retrieval for weakly supervised open domain question answering. In Proceedings of the Conference of Association for Computational Linguistics. 2019.