### PR TITLE
fix: app_review's answer choices with some suggestion/discussion

### DIFF
--- a/promptsource/templates/app_reviews/templates.yaml
+++ b/promptsource/templates/app_reviews/templates.yaml
@@ -1,42 +1,30 @@
 dataset: app_reviews
 templates:
   2da8f134-58db-4f9d-b3b0-8c6b50693ab5: !Template
-    answer_choices: null
-    answer_choices_key: null
+    answer_choices:
+    - Not at all
+    - 'No'
+    - Maybe
+    - 'Yes'
+    - Definitely
+    answer_choices_key: star
     id: 2da8f134-58db-4f9d-b3b0-8c6b50693ab5
-    jinja: 'Given this review: {{review}}
+    jinja: 'Given this review: "{{review}}"
 
-      Would you recommend this app to a friend?
+      Would you recommend this app to a friend? {{answer_choices[0]}}, {{answer_choices[1]}},
+      {{answer_choices[2]}}, {{answer_choices[3]}}, or {{answer_choices[4]}}?
 
       |||
 
-      {% if star==5 %}
-
-      Definitely
-
-      {% elif star==4%}
-
-      Yes
-
-      {% elif star==3%}
-
-      Maybe
-
-      {% elif star==2%}
-
-      No
-
-      {% else %}
-
-      Not at all
-
-      {% endif %}'
+      {{answer_choices[star-1]}}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
-      choices_in_prompt: false
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      - Spearman Correlation
+      original_task: false
     name: categorize_rating_using_review
     reference: Given the review, return a categorical answer.
   8086b434-a75e-45a4-87fb-4364601e2e05: !Template
@@ -58,47 +46,33 @@ templates:
     name: generate_review
     reference: Generate a review from the rating.
   9746ce4b-ac58-4dfb-9783-d77c95cb62cf: !Template
-    answer_choices: null
-    answer_choices_key: null
+    answer_choices:
+    - "\u2605"
+    - "\u2605\u2605"
+    - "\u2605\u2605\u2605"
+    - "\u2605\u2605\u2605\u2605"
+    - "\u2605\u2605\u2605\u2605\u2605"
+    answer_choices_key: star
     id: 9746ce4b-ac58-4dfb-9783-d77c95cb62cf
-    jinja: 'What would be the *-rating of this review (* being lowest and ***** being
-      highest) : {{review}}?
-
-      |||{% if star==5 %}
-
-      *****
-
-      {% elif star==4%}
-
-      ****
-
-      {% elif star==3%}
-
-      ***
-
-      {% elif star==2%}
-
-      **
-
-      {% else %}
-
-      *
-
-      {% endif %}'
+    jinja: "What would be the \u2605-rating of this review (\u2605 being the lowest\
+      \ and \u2605\u2605\u2605\u2605\u2605 being the highest)? \"{{review}}\"\n|||\n\
+      {{answer_choices[star-1]}}"
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      - Spearman Correlation
+      original_task: false
     name: convert_to_star_rating
     reference: Given the review, generate a star rating.
   d34e1413-2699-4701-baa2-05d931d012ba: !Template
     answer_choices: null
     answer_choices_key: null
     id: d34e1413-2699-4701-baa2-05d931d012ba
-    jinja: 'How would you rate this review from 1 to 5 (1 being lowest and 5 being
-      highest): {{review}}?
+    jinja: 'On a scale of 1-5 (with 1 being least favorable and 5 being most favorable),
+      how would you rate this review? "{{review}}"
 
       |||
 
@@ -106,8 +80,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
-      choices_in_prompt: true
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      - Spearman Correlation
+      original_task: false
     name: convert_to_rating
     reference: Convert review to rating


### PR DESCRIPTION
1. `*` is changed to ★ for streamlit compatibility;
2. `choices_in_prompt` may be a bit ambiguous;
3. Review-rating are positively correlated but imperfect; e.g., a positive review can be either a 5 or a 4;
4. Based on (3), perhaps the metrics can be some rank correlation instead of accuracy?
5. Kinda like to know what will happen if reversing the hypothesis and the premise. Not exactly long distance but suspicious to me;
6. Or even more nitpicking: wouldn't those rating be interpreted as the quality of the review, not the app?