### PR TITLE
Clean PIQA

### DIFF
--- a/promptsource/templates/piqa/templates.yaml
+++ b/promptsource/templates/piqa/templates.yaml
@@ -110,7 +110,7 @@ templates:
 
       Choices:
 
-      -  {{sol1}}
+      - {{sol1}}
 
       - {{sol2}}
 

--- a/promptsource/templates/piqa/templates.yaml
+++ b/promptsource/templates/piqa/templates.yaml
@@ -1,41 +1,18 @@
 dataset: piqa
 templates:
-  1a1d13ee-2ef5-4c80-89dc-b9e003d4ef45: !Template
+  16e97a16-c958-4956-bfba-279f88dafd5b: !Template
     answer_choices: null
     answer_choices_key: null
-    id: 1a1d13ee-2ef5-4c80-89dc-b9e003d4ef45
-    jinja: 'Given a goal and a correct solution, generate a similar but wrong solution.
+    id: 16e97a16-c958-4956-bfba-279f88dafd5b
+    jinja: 'Goal: {{goal}}
 
-      Goal: {{goal}}
 
-      Correct solution: {{[sol1, sol2][label]}}
+      Which is the correct ending?
 
-      Wrong solution:
+      - {{sol1}}
 
-      |||
+      - {{sol2}}
 
-      {{[sol1, sol2][1 - label]}}
-
-      '
-    metadata: !TemplateMetadata
-      _do_eval: false
-      _do_train: true
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: Generate a similar but wrong solution
-    reference: ''
-  45773b41-4d13-4ade-9102-afe1543f5776: !Template
-    answer_choices: null
-    answer_choices_key: null
-    id: 45773b41-4d13-4ade-9102-afe1543f5776
-    jinja: 'Given a goal and 2 solutions, choose the most appropriate solution.
-
-      Goal: {{goal}}
-
-      {{"Solution 1"}}: {{sol2}}
-
-      {{"Solution 2"}}: {{sol1}}
 
       Answer:
 
@@ -43,12 +20,69 @@ templates:
 
       {{[sol1, sol2][label]}}'
     metadata: !TemplateMetadata
-      _do_eval: false
-      _do_train: false
       choices_in_prompt: true
-      metrics: []
-      original_task: null
-    name: 'choose the most appropriate solution: reorder solution'
+      metrics:
+      - Accuracy
+      original_task: true
+    name: what_is_the_correct_ending
+    reference: ''
+  3f336295-c1f7-410a-8fc6-d2ed79487aa4: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: 3f336295-c1f7-410a-8fc6-d2ed79487aa4
+    jinja: '{{"Solution 1"}}: {{sol1}}
+
+      {{"Solution 2"}}: {{sol2}}
+
+
+      Goal: {{goal}}
+
+
+      Given the goal, what is the correct solution?
+
+
+      Answer:
+
+      |||
+
+      {{[sol1, sol2][label]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: pick_correct_choice_with_choice_given_before_goal
+    reference: ''
+  44778818-7b73-4262-a294-c00fc32b6c2c: !Template
+    answer_choices:
+    - '1'
+    - '2'
+    answer_choices_key: null
+    id: 44778818-7b73-4262-a294-c00fc32b6c2c
+    jinja: 'Sentence: {{goal}}
+
+
+      Choice {{answer_choices[0]}}: {{sol1}}
+
+
+      Choice {{answer_choices[1]}}: {{sol2}}
+
+
+      What is the index of the correct choice for ending for the sentence?
+
+
+      Answer:
+
+
+      |||
+
+      {{answer_choices[label]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: pick_correct_choice_index
     reference: ''
   5f4b4645-9438-4375-9062-083130e6d04e: !Template
     answer_choices: null
@@ -60,10 +94,39 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
     name: Correct the solution
+    reference: ''
+  94c39589-7bfb-4c09-9337-672369459545: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: 94c39589-7bfb-4c09-9337-672369459545
+    jinja: 'Finish the following sentence with the best choice: {{goal}}
+
+
+      Choices:
+
+      -  {{sol1}}
+
+      - {{sol2}}
+
+
+      Answer:
+
+
+      |||
+
+      {{[sol1, sol2][label]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: finish_sentence_with_correct_choice
     reference: ''
   99565244-4eaf-4004-a28b-4362ba5bcac3: !Template
     answer_choices:
@@ -82,8 +145,9 @@ templates:
       _do_eval: false
       _do_train: true
       choices_in_prompt: false
-      metrics: []
-      original_task: null
+      metrics:
+      - Accuracy
+      original_task: false
     name: Does this solution make sense? sol2
     reference: ''
   adfef248-f856-44fa-affd-e3223718854e: !Template
@@ -94,9 +158,10 @@ templates:
 
       Goal: {{goal}}
 
-      {{"Solution 1"}}: {{sol1}}
+      - {{"Solution 1"}}: {{sol1}}
 
-      {{"Solution 2"}}: {{sol2}}
+      - {{"Solution 2"}}: {{sol2}}
+
 
       Answer:
 
@@ -107,8 +172,9 @@ templates:
       _do_eval: false
       _do_train: true
       choices_in_prompt: true
-      metrics: []
-      original_task: null
+      metrics:
+      - Accuracy
+      original_task: true
     name: choose the most appropriate solution
     reference: ''
   b5c69473-eedb-4c4f-a5fa-d4e266e43535: !Template
@@ -129,9 +195,11 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
     name: 'Correct the solution if false: from sol 2'
     reference: ''
   c8c45ef1-2ffc-43d7-8710-b98c2fc4f699: !Template
@@ -146,9 +214,11 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
     name: no prompt needed
     reference: ''
   f044def7-01c2-42de-b6ad-4e8c63ab2bf1: !Template
@@ -157,9 +227,11 @@ templates:
     - 'No'
     answer_choices_key: null
     id: f044def7-01c2-42de-b6ad-4e8c63ab2bf1
-    jinja: '{{goal}} {{sol1[0].lower() + sol1[1:]}}
+    jinja: 'Does this phrase make sense?
 
-      Does this phrase make sense?
+      {{goal}} {{sol1[0].lower() + sol1[1:]}}
+
+      Answer with {{answer_choices[0]}} or {{answer_choices[1]}}
 
       |||
 
@@ -167,20 +239,21 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
-      choices_in_prompt: false
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: false
     name: Does this solution make sense? sol1
     reference: ''
   f42cd457-a14b-465a-a139-d7d2407a3bac: !Template
     answer_choices: null
     answer_choices_key: null
     id: f42cd457-a14b-465a-a139-d7d2407a3bac
-    jinja: 'Given a sentence, correct it if it doesn''t make sense.
+    jinja: 'Sentence: {{goal}} {{sol1[0].lower() + sol1[1:]}}
 
-      Input: {{goal}} {{sol1[0].lower() + sol1[1:]}}
+      If the sentence does not make sense, correct it so that it does make sense.
 
-      Output:
+      Answer:
 
       |||
 
@@ -190,8 +263,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
     name: 'Correct the solution if false: from sol 1'
     reference: ''

--- a/promptsource/templates/piqa/templates.yaml
+++ b/promptsource/templates/piqa/templates.yaml
@@ -41,7 +41,7 @@ templates:
       Given the goal, what is the correct solution?
 
 
-      Answer:
+      Answer by copying the correct solution
 
       |||
 
@@ -151,7 +151,9 @@ templates:
     name: Does this solution make sense? sol2
     reference: ''
   adfef248-f856-44fa-affd-e3223718854e: !Template
-    answer_choices: null
+    answer_choices:
+    - Solution 1
+    - Solution 2
     answer_choices_key: null
     id: adfef248-f856-44fa-affd-e3223718854e
     jinja: 'Given a goal and 2 solutions, choose the most appropriate solution.
@@ -163,11 +165,11 @@ templates:
       - {{"Solution 2"}}: {{sol2}}
 
 
-      Answer:
+      Answer by returning either {{"Solution 1"}} or {{"Solution 2"}}
 
       |||
 
-      {{[sol1, sol2][label]}}'
+      {{answer_choices[label]}}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -181,7 +183,8 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: b5c69473-eedb-4c4f-a5fa-d4e266e43535
-    jinja: 'Given a sentence, correct it if it doesn''t make sense.
+    jinja: 'Given a sentence, correct it if it doesn''t make sense. If it makes sense,
+      just return it as the answer.
 
       Input: {{goal}} {{sol2[0].lower() + sol2[1:]}}
 
@@ -252,6 +255,7 @@ templates:
     jinja: 'Sentence: {{goal}} {{sol1[0].lower() + sol1[1:]}}
 
       If the sentence does not make sense, correct it so that it does make sense.
+      Otherwise, just copy it.
 
       Answer:
 

--- a/promptsource/templates/piqa/templates.yaml
+++ b/promptsource/templates/piqa/templates.yaml
@@ -2,7 +2,7 @@ dataset: piqa
 templates:
   16e97a16-c958-4956-bfba-279f88dafd5b: !Template
     answer_choices: null
-    answer_choices_key: null
+    answer_choices_key: '{{sol1}} ||| {{sol2}}'
     id: 16e97a16-c958-4956-bfba-279f88dafd5b
     jinja: 'Goal: {{goal}}
 
@@ -18,7 +18,7 @@ templates:
 
       |||
 
-      {{[sol1, sol2][label]}}'
+      {{answer_choices[label]}}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -28,7 +28,7 @@ templates:
     reference: ''
   3f336295-c1f7-410a-8fc6-d2ed79487aa4: !Template
     answer_choices: null
-    answer_choices_key: null
+    answer_choices_key: '{{sol1}} ||| {{sol2}}'
     id: 3f336295-c1f7-410a-8fc6-d2ed79487aa4
     jinja: '{{"Solution 1"}}: {{sol1}}
 
@@ -45,7 +45,7 @@ templates:
 
       |||
 
-      {{[sol1, sol2][label]}}'
+      {{answer_choices[label]}}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -103,7 +103,7 @@ templates:
     reference: ''
   94c39589-7bfb-4c09-9337-672369459545: !Template
     answer_choices: null
-    answer_choices_key: null
+    answer_choices_key: '{{sol1}} ||| {{sol2}}'
     id: 94c39589-7bfb-4c09-9337-672369459545
     jinja: 'Finish the following sentence with the best choice: {{goal}}
 
@@ -120,7 +120,7 @@ templates:
 
       |||
 
-      {{[sol1, sol2][label]}}'
+      {{answer_choices[label]}}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:


### PR DESCRIPTION
Added original task templates (we now have 5):
- finish_sentence_with_correct_choice
- pick_correct_choice_index
- pick_correct_choice_with_choice_given_before_goal
- what_is_the_correct_ending

Addressing the comments in the spreadsheet: 
- choose_the_most_appropriate_solution_reorder_solution -> removed
- Does_this_solution_make_sense_sol1 and Does_this_solution_make_sense_sol2 -> now using jinja for the choices

Misc changes:
- Deleted : Generate a similar but wrong solution -> very vague, and unnatural task IMO

- Changed template  "Does this solution make sense? sol1" -> so that it’s not a duplicate of "Does this solution make sense? sol1"
- Changed template "Correct the solution if false: from sol 1" -> so that it’s not a duplicate of "Correct the solution if false: from sol 2"