### PR TITLE
fix cos_e original task flags

### DIFF
--- a/promptsource/templates/cos_e/v1.11/templates.yaml
+++ b/promptsource/templates/cos_e/v1.11/templates.yaml
@@ -22,7 +22,7 @@ templates:
       choices_in_prompt: true
       metrics:
       - Accuracy
-      original_task: false
+      original_task: true
     name: question_description_option_text
     reference: ''
   046ce4df-c847-4dc2-b53c-9f02d32aff8a: !Template
@@ -44,7 +44,7 @@ templates:
       choices_in_prompt: true
       metrics:
       - Accuracy
-      original_task: false
+      original_task: true
     name: question_description_option_id
     reference: ''
   25863d16-34be-4c5f-9040-11d5c6398b4b: !Template
@@ -58,7 +58,7 @@ templates:
       metrics:
       - BLEU
       - ROUGE
-      original_task: true
+      original_task: false
     name: rationale
     reference: ''
   4b946a87-b39c-4f01-9041-832d82da48af: !Template
@@ -81,7 +81,7 @@ templates:
       choices_in_prompt: true
       metrics:
       - Accuracy
-      original_task: false
+      original_task: true
     name: question_option_description_text
     reference: ''
   55dd7471-c01e-4197-a8cd-d8e6359ef582: !Template
@@ -96,7 +96,7 @@ templates:
       metrics:
       - BLEU
       - ROUGE
-      original_task: true
+      original_task: false
     name: aligned_with_common_sense
     reference: ''
   60354294-f30a-4a5b-be18-372c3c1a3491: !Template
@@ -129,7 +129,7 @@ templates:
       choices_in_prompt: true
       metrics:
       - Accuracy
-      original_task: false
+      original_task: true
     name: description_question_option_id
     reference: ''
   73f0f76b-c7f9-41fd-b4df-705625ab8241: !Template
@@ -155,7 +155,7 @@ templates:
       metrics:
       - BLEU
       - ROUGE
-      original_task: true
+      original_task: false
     name: explain_why_human
     reference: ''
   90a7d84f-0316-4b28-a4fe-2f61c0126158: !Template
@@ -181,12 +181,12 @@ templates:
       metrics:
       - BLEU
       - ROUGE
-      original_task: true
+      original_task: false
     name: generate_explanation_given_text
     reference: ''
   a8036e94-ad4a-4f26-9765-cf7223800138: !Template
     answer_choices: null
-    answer_choices_key: null
+    answer_choices_key: choices
     id: a8036e94-ad4a-4f26-9765-cf7223800138
     jinja: 'Pick the option in line with common sense to answer the question.
 
@@ -205,7 +205,7 @@ templates:
       choices_in_prompt: true
       metrics:
       - Accuracy
-      original_task: false
+      original_task: true
     name: description_question_option_text
     reference: ''
   e57a5c48-209c-4e82-b061-dbc8d124dffa: !Template
@@ -230,7 +230,7 @@ templates:
       metrics:
       - BLEU
       - ROUGE
-      original_task: true
+      original_task: false
     name: i_think
     reference: ''
   f678d224-23f0-488b-9c5d-0bf466a0aa16: !Template
@@ -261,6 +261,6 @@ templates:
       choices_in_prompt: true
       metrics:
       - Accuracy
-      original_task: false
+      original_task: true
     name: question_option_description_id
     reference: ''


### PR DESCRIPTION
Note that cos_e is the same QA data as commonsense_QA but with additional human written explanations. We only use cos_e in training. I marked the QA prompts as original task (of commonsense_qa) while generating explanations as non-original (there is no metric/baseline anyway, and the crowdsourced explanations are not very high quality).