### PR TITLE
Expanded answer_choices_key.

### DIFF
--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -344,7 +344,9 @@ else:
                 st.markdown("##### Answer Choices")
                 st.text(", ".join(template.answer_choices) if template.answer_choices is not None else None)
                 st.markdown("##### Answer Choices Key")
-                st.text(template.answer_choices_key.to_str() if template.get_answer_choices_key() is not None else None)
+                st.text(
+                    template.answer_choices_key.to_str() if template.get_answer_choices_key() is not None else None
+                )
                 st.markdown("##### Jinja")
                 splitted_template = template.jinja.split("|||")
                 st.markdown("###### Prompt + X")

--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -344,9 +344,7 @@ else:
                 st.markdown("##### Answer Choices")
                 st.text(", ".join(template.answer_choices) if template.answer_choices is not None else None)
                 st.markdown("##### Answer Choices Key")
-                st.text(
-                    template.answer_choices_key.to_str() if template.get_answer_choices_key() is not None else None
-                )
+                st.text(template.get_answer_choices_expr())
                 st.markdown("##### Jinja")
                 splitted_template = template.jinja.split("|||")
                 st.markdown("###### Prompt + X")
@@ -525,18 +523,11 @@ else:
                         )
 
                         # Answer choices key
-                        if template.get_answer_choices_key() is not None:
-                            current_answer_choices_key = template.get_answer_choices_key().to_str()
-                        else:
-                            current_answer_choices_key = ""
                         state.answer_choices_key = st.text_input(
                             "Answer Choices Key",
-                            value=current_answer_choices_key,
-                            help="Provide a key from the example schema containing an iterable "
-                            "of strings with choices for the correct output (or leave "
-                            "blank if not applicable). If choices are nested in dictionaries, "
-                            "each key with a semi-colon (;). If each choice is a "
-                            "different key, separate keys with a triple bar (|||).",
+                            value=template.get_answer_choices_expr(),
+                            help="A Jinja expression for computing answer choices. "
+                                 "Separate choices with a triple bar (|||).",
                         )
 
                         # Jinja
@@ -559,10 +550,10 @@ else:
                                 updated_answer_choices = [x.strip() for x in state.answer_choices.split("|||")]
                                 if len(updated_answer_choices) == 0 or len(updated_answer_choices) == 1:
                                     updated_answer_choices = None
-
-                                updated_answer_choices_key = Template.AnswerChoicesKey.from_str(
-                                    state.answer_choices_key
-                                )
+                                if state.answer_choices_key == "":
+                                    updated_answer_choices_key = None
+                                else:
+                                    updated_answer_choices_key = state.answer_choices_key
 
                                 dataset_templates.update_template(
                                     state.template_name,

--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -344,7 +344,10 @@ else:
                 st.markdown("##### Answer Choices")
                 st.text(", ".join(template.answer_choices) if template.answer_choices is not None else None)
                 st.markdown("##### Answer Choices Key")
-                show_jinja(template.get_answer_choices_expr())
+                if template.get_answer_choices_expr() is not None:
+                    show_jinja(template.get_answer_choices_expr())
+                else:
+                    st.text(None)
                 st.markdown("##### Jinja")
                 splitted_template = template.jinja.split("|||")
                 st.markdown("###### Prompt + X")

--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -344,7 +344,7 @@ else:
                 st.markdown("##### Answer Choices")
                 st.text(", ".join(template.answer_choices) if template.answer_choices is not None else None)
                 st.markdown("##### Answer Choices Key")
-                st.text(template.answer_choices_key)
+                st.text(template.answer_choices_key.to_str() if template.get_answer_choices_key() is not None else None)
                 st.markdown("##### Jinja")
                 splitted_template = template.jinja.split("|||")
                 st.markdown("###### Prompt + X")

--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -534,7 +534,7 @@ else:
                             "Answer Choices Key",
                             value=answer_choices_key,
                             help="A Jinja expression for computing answer choices. "
-                                 "Separate choices with a triple bar (|||).",
+                            "Separate choices with a triple bar (|||).",
                         )
 
                         # Jinja

--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -344,7 +344,7 @@ else:
                 st.markdown("##### Answer Choices")
                 st.text(", ".join(template.answer_choices) if template.answer_choices is not None else None)
                 st.markdown("##### Answer Choices Key")
-                st.text(template.get_answer_choices_expr())
+                show_jinja(template.get_answer_choices_expr())
                 st.markdown("##### Jinja")
                 splitted_template = template.jinja.split("|||")
                 st.markdown("###### Prompt + X")
@@ -523,9 +523,13 @@ else:
                         )
 
                         # Answer choices key
+                        if template.get_answer_choices_expr() is not None:
+                            answer_choices_key = template.get_answer_choices_expr()
+                        else:
+                            answer_choices_key = ""
                         state.answer_choices_key = st.text_input(
                             "Answer Choices Key",
-                            value=template.get_answer_choices_expr(),
+                            value=answer_choices_key,
                             help="A Jinja expression for computing answer choices. "
                                  "Separate choices with a triple bar (|||).",
                         )

--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -469,6 +469,8 @@ else:
                             help="Short description of the template and/or paper reference for the template.",
                             value=template.reference,
                         )
+
+                        # Metadata
                         state.metadata = template.metadata
                         state.metadata.original_task = st.checkbox(
                             "Original Task?",
@@ -480,6 +482,7 @@ else:
                             value=template.metadata.choices_in_prompt,
                             help="Template explicitly lists choices in the prompt for the output.",
                         )
+
                         # Metrics from here:
                         # https://github.com/google-research/text-to-text-transfer-transformer/blob/4b580f23968c2139be7fb1cd53b22c7a7f686cdf/t5/evaluation/metrics.py
                         metrics_choices = [
@@ -510,28 +513,34 @@ else:
                             help="Select all metrics that are commonly used (or should "
                             "be used if a new task) to evaluate this template.",
                         )
+
+                        # Answer choices
                         state.answer_choices = st.text_input(
                             "Answer Choices",
                             value=" ||| ".join(template.answer_choices) if template.answer_choices is not None else "",
                             help="A ||| separated list of possible outputs (or leave blank). "
                             + "Value is available in Jinja in a list called answer_choices.",
                         )
-                        answer_choices_key_options = list(rendered_features.keys())
-                        answer_choices_key_options.insert(0, "")
-                        if template.answer_choices_key is None:
-                            answer_choices_key_index = 0
+
+                        # Answer choices key
+                        if template.get_answer_choices_key() is not None:
+                            current_answer_choices_key = template.get_answer_choices_key().to_str()
                         else:
-                            answer_choices_key_index = answer_choices_key_options.index(template.answer_choices_key)
-                        state.answer_choices_key = st.selectbox(
+                            current_answer_choices_key = ""
+                        state.answer_choices_key = st.text_input(
                             "Answer Choices Key",
-                            answer_choices_key_options,
-                            index=answer_choices_key_index,
-                            help="Select a key from the example schema containing an iterable "
+                            value=current_answer_choices_key,
+                            help="Provide a key from the example schema containing an iterable "
                             "of strings with choices for the correct output (or leave "
-                            "blank if not applicable).",
+                            "blank if not applicable). If choices are nested in dictionaries, "
+                            "each key with a semi-colon (;). If each choice is a "
+                            "different key, separate keys with a triple bar (|||).",
                         )
+
+                        # Jinja
                         state.jinja = st.text_area("Template", height=40, value=template.jinja)
 
+                        # Submit form
                         if st.form_submit_button("Save"):
                             if (
                                 updated_template_name in dataset_templates.all_template_names
@@ -548,10 +557,10 @@ else:
                                 updated_answer_choices = [x.strip() for x in state.answer_choices.split("|||")]
                                 if len(updated_answer_choices) == 0 or len(updated_answer_choices) == 1:
                                     updated_answer_choices = None
-                                if state.answer_choices_key != "":
-                                    updated_answer_choices_key = state.answer_choices_key
-                                else:
-                                    updated_answer_choices_key = None
+
+                                updated_answer_choices_key = Template.AnswerChoicesKey.from_str(
+                                    state.answer_choices_key
+                                )
 
                                 dataset_templates.update_template(
                                     state.template_name,

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -134,8 +134,11 @@ class Template(yaml.YAMLObject):
         """
         Returns a list of answer choices for a given example
 
-        :return: list of strings
+        :return: list of strings, or None if get_answer_choices_expr is None
         """
+        if self.get_answer_choices_expr() is None:
+            return None
+
         jinja = self.answer_choices_key
         rtemplate = env.from_string(jinja)
         protected_example = self._escape_pipe(example)

--- a/promptsource/templates/cos_e/v1.0/templates.yaml
+++ b/promptsource/templates/cos_e/v1.0/templates.yaml
@@ -3,10 +3,7 @@ subset: v1.0
 templates:
   1040d9f9-4ba6-44a5-9d44-aa907ef35d49: !Template
     answer_choices: null
-    answer_choices_key: !TemplateAnswerChoicesKey
-      keys:
-      - choices
-      separate_keys: false
+    answer_choices_key: '{ choices | join("|||") }'
     id: 1040d9f9-4ba6-44a5-9d44-aa907ef35d49
     jinja: '{{ question }}
 
@@ -50,10 +47,7 @@ templates:
     reference: ''
   836b1643-b0c7-4c21-b33f-1a0aacae6562: !Template
     answer_choices: null
-    answer_choices_key: !TemplateAnswerChoicesKey
-      keys:
-      - choices
-      separate_keys: false
+    answer_choices_key: '{ choices | join("|||") }'
     id: 836b1643-b0c7-4c21-b33f-1a0aacae6562
     jinja: '{{ question }}
 
@@ -170,10 +164,7 @@ templates:
     reference: ''
   e57e45eb-9d02-4e15-9a95-ba4ef68245c1: !Template
     answer_choices: null
-    answer_choices_key: !TemplateAnswerChoicesKey
-      keys:
-      - choices
-      separate_keys: false
+    answer_choices_key: '{ choices | join("|||") }'
     id: e57e45eb-9d02-4e15-9a95-ba4ef68245c1
     jinja: 'Pick the option in line with common sense to answer the question.
 

--- a/promptsource/templates/cos_e/v1.0/templates.yaml
+++ b/promptsource/templates/cos_e/v1.0/templates.yaml
@@ -3,7 +3,10 @@ subset: v1.0
 templates:
   1040d9f9-4ba6-44a5-9d44-aa907ef35d49: !Template
     answer_choices: null
-    answer_choices_key: choices
+    answer_choices_key: !TemplateAnswerChoicesKey
+      keys:
+      - choices
+      separate_keys: false
     id: 1040d9f9-4ba6-44a5-9d44-aa907ef35d49
     jinja: '{{ question }}
 
@@ -47,7 +50,10 @@ templates:
     reference: ''
   836b1643-b0c7-4c21-b33f-1a0aacae6562: !Template
     answer_choices: null
-    answer_choices_key: choices
+    answer_choices_key: !TemplateAnswerChoicesKey
+      keys:
+      - choices
+      separate_keys: false
     id: 836b1643-b0c7-4c21-b33f-1a0aacae6562
     jinja: '{{ question }}
 
@@ -164,7 +170,10 @@ templates:
     reference: ''
   e57e45eb-9d02-4e15-9a95-ba4ef68245c1: !Template
     answer_choices: null
-    answer_choices_key: choices
+    answer_choices_key: !TemplateAnswerChoicesKey
+      keys:
+      - choices
+      separate_keys: false
     id: e57e45eb-9d02-4e15-9a95-ba4ef68245c1
     jinja: 'Pick the option in line with common sense to answer the question.
 

--- a/promptsource/templates/cos_e/v1.0/templates.yaml
+++ b/promptsource/templates/cos_e/v1.0/templates.yaml
@@ -3,7 +3,7 @@ subset: v1.0
 templates:
   1040d9f9-4ba6-44a5-9d44-aa907ef35d49: !Template
     answer_choices: null
-    answer_choices_key: '{ choices | join("|||") }'
+    answer_choices_key: '{{ choices | join("|||") }}'
     id: 1040d9f9-4ba6-44a5-9d44-aa907ef35d49
     jinja: '{{ question }}
 
@@ -11,7 +11,7 @@ templates:
 
       Options:
 
-      - {{ choices | join("\n- ") }}
+      - {{ answer_choices | join("\n- ") }}
 
       |||
 
@@ -47,11 +47,11 @@ templates:
     reference: ''
   836b1643-b0c7-4c21-b33f-1a0aacae6562: !Template
     answer_choices: null
-    answer_choices_key: '{ choices | join("|||") }'
+    answer_choices_key: '{{ choices | join("|||") }}'
     id: 836b1643-b0c7-4c21-b33f-1a0aacae6562
     jinja: '{{ question }}
 
-      - {{ choices | join("\n- ") }}
+      - {{ answer_choices | join("\n- ") }}
 
 
       The best answer is
@@ -164,7 +164,7 @@ templates:
     reference: ''
   e57e45eb-9d02-4e15-9a95-ba4ef68245c1: !Template
     answer_choices: null
-    answer_choices_key: '{ choices | join("|||") }'
+    answer_choices_key: '{{ choices | join("|||") }}'
     id: e57e45eb-9d02-4e15-9a95-ba4ef68245c1
     jinja: 'Pick the option in line with common sense to answer the question.
 
@@ -172,7 +172,7 @@ templates:
 
       Options:
 
-      - {{ choices | join("\n- ") }}
+      - {{ answer_choices | join("\n- ") }}
 
       |||
 

--- a/promptsource/templates/cos_e/v1.11/templates.yaml
+++ b/promptsource/templates/cos_e/v1.11/templates.yaml
@@ -3,10 +3,7 @@ subset: v1.11
 templates:
   02a87cd3-6595-44bd-a384-95bdc8b3dd0c: !Template
     answer_choices: null
-    answer_choices_key: !TemplateAnswerChoicesKey
-      keys:
-      - choices
-      separate_keys: false
+    answer_choices_key: '{ choices | join("|||") }'
     id: 02a87cd3-6595-44bd-a384-95bdc8b3dd0c
     jinja: '{{ question }}
 
@@ -66,10 +63,7 @@ templates:
     reference: ''
   4b946a87-b39c-4f01-9041-832d82da48af: !Template
     answer_choices: null
-    answer_choices_key: !TemplateAnswerChoicesKey
-      keys:
-      - choices
-      separate_keys: false
+    answer_choices_key: '{ choices | join("|||") }'
     id: 4b946a87-b39c-4f01-9041-832d82da48af
     jinja: '{{ question }}
 

--- a/promptsource/templates/cos_e/v1.11/templates.yaml
+++ b/promptsource/templates/cos_e/v1.11/templates.yaml
@@ -3,7 +3,7 @@ subset: v1.11
 templates:
   02a87cd3-6595-44bd-a384-95bdc8b3dd0c: !Template
     answer_choices: null
-    answer_choices_key: '{ choices | join("|||") }'
+    answer_choices_key: '{{ choices | join("|||") }}'
     id: 02a87cd3-6595-44bd-a384-95bdc8b3dd0c
     jinja: '{{ question }}
 
@@ -11,7 +11,7 @@ templates:
 
       Options:
 
-      - {{ choices | join("\n- ") }}
+      - {{ answer_choices | join("\n- ") }}
 
       |||
 
@@ -63,11 +63,11 @@ templates:
     reference: ''
   4b946a87-b39c-4f01-9041-832d82da48af: !Template
     answer_choices: null
-    answer_choices_key: '{ choices | join("|||") }'
+    answer_choices_key: '{{ choices | join("|||") }}'
     id: 4b946a87-b39c-4f01-9041-832d82da48af
     jinja: '{{ question }}
 
-      - {{ choices | join("\n- ") }}
+      - {{ answer_choices | join("\n- ") }}
 
 
       The best answer is
@@ -186,7 +186,7 @@ templates:
     reference: ''
   a8036e94-ad4a-4f26-9765-cf7223800138: !Template
     answer_choices: null
-    answer_choices_key: null
+    answer_choices_key: '{{ choices | join("|||") }}'
     id: a8036e94-ad4a-4f26-9765-cf7223800138
     jinja: 'Pick the option in line with common sense to answer the question.
 
@@ -194,7 +194,7 @@ templates:
 
       Options:
 
-      - {{ choices | join("\n- ") }}
+      - {{ answer_choices | join("\n- ") }}
 
       |||
 

--- a/promptsource/templates/cos_e/v1.11/templates.yaml
+++ b/promptsource/templates/cos_e/v1.11/templates.yaml
@@ -3,7 +3,10 @@ subset: v1.11
 templates:
   02a87cd3-6595-44bd-a384-95bdc8b3dd0c: !Template
     answer_choices: null
-    answer_choices_key: choices
+    answer_choices_key: !TemplateAnswerChoicesKey
+      keys:
+      - choices
+      separate_keys: false
     id: 02a87cd3-6595-44bd-a384-95bdc8b3dd0c
     jinja: '{{ question }}
 
@@ -63,7 +66,10 @@ templates:
     reference: ''
   4b946a87-b39c-4f01-9041-832d82da48af: !Template
     answer_choices: null
-    answer_choices_key: choices
+    answer_choices_key: !TemplateAnswerChoicesKey
+      keys:
+      - choices
+      separate_keys: false
     id: 4b946a87-b39c-4f01-9041-832d82da48af
     jinja: '{{ question }}
 

--- a/promptsource/templates/race/all/templates.yaml
+++ b/promptsource/templates/race/all/templates.yaml
@@ -54,10 +54,7 @@ templates:
     reference: ''
   59b5c4e3-9539-449f-ac60-04e681c705b5: !Template
     answer_choices: null
-    answer_choices_key: !TemplateAnswerChoicesKey
-      keys:
-      - options
-      separate_keys: false
+    answer_choices_key: '{ options | join("|||") }'
     id: 59b5c4e3-9539-449f-ac60-04e681c705b5
     jinja: 'Read the following article and answer the question.
 
@@ -82,10 +79,7 @@ templates:
     reference: ''
   81368f4b-817f-4c81-9db5-b86905bb975e: !Template
     answer_choices: null
-    answer_choices_key: !TemplateAnswerChoicesKey
-      keys:
-      - options
-      separate_keys: false
+    answer_choices_key: '{ options | join("|||") }'
     id: 81368f4b-817f-4c81-9db5-b86905bb975e
     jinja: 'Read the following article and select the best answer.
 

--- a/promptsource/templates/race/all/templates.yaml
+++ b/promptsource/templates/race/all/templates.yaml
@@ -54,7 +54,10 @@ templates:
     reference: ''
   59b5c4e3-9539-449f-ac60-04e681c705b5: !Template
     answer_choices: null
-    answer_choices_key: options
+    answer_choices_key: !TemplateAnswerChoicesKey
+      keys:
+      - options
+      separate_keys: false
     id: 59b5c4e3-9539-449f-ac60-04e681c705b5
     jinja: 'Read the following article and answer the question.
 
@@ -79,7 +82,10 @@ templates:
     reference: ''
   81368f4b-817f-4c81-9db5-b86905bb975e: !Template
     answer_choices: null
-    answer_choices_key: options
+    answer_choices_key: !TemplateAnswerChoicesKey
+      keys:
+      - options
+      separate_keys: false
     id: 81368f4b-817f-4c81-9db5-b86905bb975e
     jinja: 'Read the following article and select the best answer.
 

--- a/promptsource/templates/race/all/templates.yaml
+++ b/promptsource/templates/race/all/templates.yaml
@@ -54,7 +54,7 @@ templates:
     reference: ''
   59b5c4e3-9539-449f-ac60-04e681c705b5: !Template
     answer_choices: null
-    answer_choices_key: '{ options | join("|||") }'
+    answer_choices_key: '{{ options | join("|||") }}'
     id: 59b5c4e3-9539-449f-ac60-04e681c705b5
     jinja: 'Read the following article and answer the question.
 
@@ -66,8 +66,7 @@ templates:
 
       |||
 
-      {{ [options.0,options.1,options.2,options.3][{"A":0,"B":1,"C":2,"D":3}[answer]]
-      }}'
+      {{ answer_choices[{"A":0,"B":1,"C":2,"D":3}[answer]] }}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
@@ -79,7 +78,7 @@ templates:
     reference: ''
   81368f4b-817f-4c81-9db5-b86905bb975e: !Template
     answer_choices: null
-    answer_choices_key: '{ options | join("|||") }'
+    answer_choices_key: '{{ options | join("|||") }}'
     id: 81368f4b-817f-4c81-9db5-b86905bb975e
     jinja: 'Read the following article and select the best answer.
 
@@ -87,17 +86,11 @@ templates:
 
       Question: {{question}}
 
-      - {{options.0}}
-
-      - {{options.1}}
-
-      - {{options.2}}
-
-      - {{options.3}}
+      - {{answer_choices | join("\n- ")}}
 
       |||
 
-      {{[options.0,options.1,options.2,options.3][{"A":0,"B":1,"C":2,"D":3}[answer]]}}'
+      {{answer_choices[{"A":0,"B":1,"C":2,"D":3}[answer]]}}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
@@ -187,7 +180,7 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: true

--- a/promptsource/templates/race/high/templates.yaml
+++ b/promptsource/templates/race/high/templates.yaml
@@ -140,7 +140,7 @@ templates:
     reference: ''
   ab253338-5b02-46e8-9959-b66d1009c34a: !Template
     answer_choices: null
-    answer_choices_key: '{ options | join("|||") }'
+    answer_choices_key: '{{ options | join("|||") }}'
     id: ab253338-5b02-46e8-9959-b66d1009c34a
     jinja: 'Read the following article and select the best answer.
 
@@ -148,17 +148,11 @@ templates:
 
       Question: {{question}}
 
-      - {{options.0}}
-
-      - {{options.1}}
-
-      - {{options.2}}
-
-      - {{options.3}}
+      - {{answer_choices | join("\n- ")}}
 
       |||
 
-      {{[options.0,options.1,options.2,options.3][{"A":0,"B":1,"C":2,"D":3}[answer]]}}'
+      {{answer_choices[{"A":0,"B":1,"C":2,"D":3}[answer]]}}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
@@ -202,7 +196,7 @@ templates:
     reference: ''
   e1b9d073-e18e-4940-9868-5b4a35617c35: !Template
     answer_choices: null
-    answer_choices_key: '{ options | join("|||") }'
+    answer_choices_key: '{{ options | join("|||") }}'
     id: e1b9d073-e18e-4940-9868-5b4a35617c35
     jinja: 'Read the following article and answer the question.
 
@@ -214,8 +208,7 @@ templates:
 
       |||
 
-      {{ [options.0,options.1,options.2,options.3][{"A":0,"B":1,"C":2,"D":3}[answer]]
-      }}'
+      {{ answer_choices[{"A":0,"B":1,"C":2,"D":3}[answer]] }}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true

--- a/promptsource/templates/race/high/templates.yaml
+++ b/promptsource/templates/race/high/templates.yaml
@@ -140,7 +140,10 @@ templates:
     reference: ''
   ab253338-5b02-46e8-9959-b66d1009c34a: !Template
     answer_choices: null
-    answer_choices_key: options
+    answer_choices_key: !TemplateAnswerChoicesKey
+      keys:
+      - options
+      separate_keys: false
     id: ab253338-5b02-46e8-9959-b66d1009c34a
     jinja: 'Read the following article and select the best answer.
 
@@ -202,7 +205,10 @@ templates:
     reference: ''
   e1b9d073-e18e-4940-9868-5b4a35617c35: !Template
     answer_choices: null
-    answer_choices_key: options
+    answer_choices_key: !TemplateAnswerChoicesKey
+      keys:
+      - options
+      separate_keys: false
     id: e1b9d073-e18e-4940-9868-5b4a35617c35
     jinja: 'Read the following article and answer the question.
 

--- a/promptsource/templates/race/high/templates.yaml
+++ b/promptsource/templates/race/high/templates.yaml
@@ -140,10 +140,7 @@ templates:
     reference: ''
   ab253338-5b02-46e8-9959-b66d1009c34a: !Template
     answer_choices: null
-    answer_choices_key: !TemplateAnswerChoicesKey
-      keys:
-      - options
-      separate_keys: false
+    answer_choices_key: '{ options | join("|||") }'
     id: ab253338-5b02-46e8-9959-b66d1009c34a
     jinja: 'Read the following article and select the best answer.
 
@@ -205,10 +202,7 @@ templates:
     reference: ''
   e1b9d073-e18e-4940-9868-5b4a35617c35: !Template
     answer_choices: null
-    answer_choices_key: !TemplateAnswerChoicesKey
-      keys:
-      - options
-      separate_keys: false
+    answer_choices_key: '{ options | join("|||") }'
     id: e1b9d073-e18e-4940-9868-5b4a35617c35
     jinja: 'Read the following article and answer the question.
 

--- a/promptsource/templates/race/middle/templates.yaml
+++ b/promptsource/templates/race/middle/templates.yaml
@@ -37,10 +37,7 @@ templates:
     reference: ''
   1a68b62e-404c-4037-baec-7e20cb4c3f6b: !Template
     answer_choices: null
-    answer_choices_key: !TemplateAnswerChoicesKey
-      keys:
-      - options
-      separate_keys: false
+    answer_choices_key: '{ options | join("|||") }'
     id: 1a68b62e-404c-4037-baec-7e20cb4c3f6b
     jinja: 'Read the following article and answer the question.
 
@@ -130,10 +127,7 @@ templates:
     reference: ''
   9aacc46d-8863-4e02-9783-9ec931425759: !Template
     answer_choices: null
-    answer_choices_key: !TemplateAnswerChoicesKey
-      keys:
-      - options
-      separate_keys: false
+    answer_choices_key: '{ options | join("|||") }'
     id: 9aacc46d-8863-4e02-9783-9ec931425759
     jinja: 'Read the following article and select the best answer.
 

--- a/promptsource/templates/race/middle/templates.yaml
+++ b/promptsource/templates/race/middle/templates.yaml
@@ -37,7 +37,7 @@ templates:
     reference: ''
   1a68b62e-404c-4037-baec-7e20cb4c3f6b: !Template
     answer_choices: null
-    answer_choices_key: '{ options | join("|||") }'
+    answer_choices_key: '{{ options | join("|||") }}'
     id: 1a68b62e-404c-4037-baec-7e20cb4c3f6b
     jinja: 'Read the following article and answer the question.
 
@@ -49,8 +49,7 @@ templates:
 
       |||
 
-      {{ [options.0,options.1,options.2,options.3][{"A":0,"B":1,"C":2,"D":3}[answer]]
-      }}'
+      {{ answer_choices[{"A":0,"B":1,"C":2,"D":3}[answer]] }}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -127,7 +126,7 @@ templates:
     reference: ''
   9aacc46d-8863-4e02-9783-9ec931425759: !Template
     answer_choices: null
-    answer_choices_key: '{ options | join("|||") }'
+    answer_choices_key: '{{ options | join("|||") }}'
     id: 9aacc46d-8863-4e02-9783-9ec931425759
     jinja: 'Read the following article and select the best answer.
 
@@ -135,17 +134,11 @@ templates:
 
       Question: {{question}}
 
-      - {{options.0}}
-
-      - {{options.1}}
-
-      - {{options.2}}
-
-      - {{options.3}}
+      - {{answer_choices | join("\n- ")}}
 
       |||
 
-      {{[options.0,options.1,options.2,options.3][{"A":0,"B":1,"C":2,"D":3}[answer]]}}'
+      {{answer_choices[{"A":0,"B":1,"C":2,"D":3}[answer]]}}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false

--- a/promptsource/templates/race/middle/templates.yaml
+++ b/promptsource/templates/race/middle/templates.yaml
@@ -37,7 +37,10 @@ templates:
     reference: ''
   1a68b62e-404c-4037-baec-7e20cb4c3f6b: !Template
     answer_choices: null
-    answer_choices_key: options
+    answer_choices_key: !TemplateAnswerChoicesKey
+      keys:
+      - options
+      separate_keys: false
     id: 1a68b62e-404c-4037-baec-7e20cb4c3f6b
     jinja: 'Read the following article and answer the question.
 
@@ -127,7 +130,10 @@ templates:
     reference: ''
   9aacc46d-8863-4e02-9783-9ec931425759: !Template
     answer_choices: null
-    answer_choices_key: options
+    answer_choices_key: !TemplateAnswerChoicesKey
+      keys:
+      - options
+      separate_keys: false
     id: 9aacc46d-8863-4e02-9783-9ec931425759
     jinja: 'Read the following article and select the best answer.
 


### PR DESCRIPTION
**Note:** Once this PR is merged, open PRs that set `answer_choices_key` should merge `main` and then open and resave such templates.

This expands the format of answer_choices_key to cover more cases, and provides a way to enter them in the UI.

(Note that the dropdown list of features is removed because that doesn't cover all these cases. A more complex UI in the future is possible, but I wanted to get this done quickly since these are mostly corner cases.)

Examples:

If the answer choices are in an iterable in the example, just enter the key name:
For example, given a dataset with format like
```python
{
  "abstractive_explanation": "a house is the only place that is not likely to sell things",
  "answer": "house",
  "choices": [
    "antique shop",
    "house",
    "dark place"
  ],
  "extractive_explanation": "not for sale",
  "id": "d3b479933e716fb388dfb297e881054c",
  "question": "If a lantern is not for sale, where is it likely to be?"
}
```
just enter `choices`.

For nested keys like
```python
{
  "answerKey": "A",
  "choices": {
    "label": [
      "A",
      "B"
    ],
    "text": [
      "scarce",
      "plentiful"
    ]
  },
  "id": "QRQA-10385-4",
  "para": "Many of the worlds people live with water scarcity, and that percentage will increase as populations increase and climate changes."
}
```
enter `choices ; text`.

For choices with separate keys like
```python
{
  "choice1": "The sun was rising.",
  "choice2": "The grass was cut.",
  "idx": 0,
  "label": 0,
  "premise": "My body cast a shadow over the grass.",
  "question": "cause"
}
```
enter `choice1 ||| choice2`.

This also includes code for applying this logic to examples. To get the choices for an example `example` prompted with a template `template`,
```python
if template.get_answer_choices_key() is not None:
    answer_choices = template.get_answer_choices_key().get_answer_choices(example)
else:
    answer_choices = template.get_answer_choices()
```