### PR TITLE
clean wiki_hop task/dataset

### DIFF
--- a/promptsource/templates/amazon_polarity/templates.yaml
+++ b/promptsource/templates/amazon_polarity/templates.yaml
@@ -17,9 +17,10 @@ templates:
       _do_eval: false
       _do_train: true
       choices_in_prompt: true
-      metrics: []
-      original_task: null
-    name: Template 1
+      metrics:
+      - Accuracy
+      original_task: true
+    name: Is_this_review
     reference: ''
   3a48f287-6a4b-4df0-ab2d-2eaf6cb8e53d: !Template
     answer_choices:
@@ -40,9 +41,10 @@ templates:
       _do_eval: false
       _do_train: true
       choices_in_prompt: false
-      metrics: []
-      original_task: null
-    name: Template 4
+      metrics:
+      - Accuracy
+      original_task: true
+    name: User_recommend_this_product
     reference: 'Reformulation equivalent to sent analysis: would the user recommend
       this product?'
   592caf8f-f8ff-426a-a61b-b7e95ed510b6: !Template
@@ -64,9 +66,10 @@ templates:
       _do_eval: false
       _do_train: true
       choices_in_prompt: false
-      metrics: []
-      original_task: null
-    name: Template 2
+      metrics:
+      - Accuracy
+      original_task: true
+    name: Is_this_product_review_positive
     reference: ''
   745b9c05-10df-4a7e-81ad-1b88cefcb166: !Template
     answer_choices:
@@ -85,9 +88,10 @@ templates:
       _do_eval: false
       _do_train: true
       choices_in_prompt: false
-      metrics: []
-      original_task: null
-    name: Template 3
+      metrics:
+      - Accuracy
+      original_task: true
+    name: Is_this_review_negative
     reference: ''
   8abb5377-5dd3-4402-92a5-0d81adb6a325: !Template
     answer_choices:
@@ -106,9 +110,10 @@ templates:
       _do_eval: false
       _do_train: true
       choices_in_prompt: true
-      metrics: []
-      original_task: null
-    name: Template 5
+      metrics:
+      - Accuracy
+      original_task: true
+    name: convey_negative_or_positive_sentiment
     reference: ''
   9df70cdf-f8ed-4e79-8e2f-b4668058d637: !Template
     answer_choices:
@@ -131,7 +136,8 @@ templates:
       _do_eval: false
       _do_train: true
       choices_in_prompt: true
-      metrics: []
-      original_task: null
-    name: Template 6
+      metrics:
+      - Accuracy
+      original_task: true
+    name: negative_or_positive_tone
     reference: ''

--- a/promptsource/templates/wiki_hop/original/templates.yaml
+++ b/promptsource/templates/wiki_hop/original/templates.yaml
@@ -8,8 +8,8 @@ templates:
     jinja: "Information:\n{% for support in supports %}\n- {{ support }}\n{% endfor\
       \ %}\n\n{% set question_split = question.split(' ') %}\nWhat object entity has\
       \ the relation of '{{ question_split[0] | replace(\"_\", \" \")}}' with the\
-      \ subject '{{ question_split[1:] | join(\" \")}}'? \n\nChoices: {{ candidates\
-      \ | join(\" \\|\\|\\| \") }}\n\n|||\n{{answer}}"
+      \ subject '{{ question_split[1:] | join(\" \")}}'? \n\nChoices:\n{% for candidate\
+      \ in candidates %}\n- {{ candidate }}\n{% endfor %}\n\n|||\n{{answer}}"
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -135,7 +135,13 @@ templates:
       subject ''{{ question_split[1:] | join(" ")}}''.
 
 
-      Choices: {{ candidates | join(" \|\|\| ") }}
+      Choices:
+
+      {% for candidate in candidates %}
+
+      - {{ candidate }}
+
+      {% endfor %}
 
 
       |||
@@ -170,7 +176,13 @@ templates:
       choices below.
 
 
-      Choices: {{ candidates | join(" \|\|\| ") }}
+      Choices:
+
+      {% for candidate in candidates %}
+
+      - {{ candidate }}
+
+      {% endfor %}
 
 
       |||
@@ -235,7 +247,13 @@ templates:
       ''{{ question_split[0] | replace("_", " ")}}''.
 
 
-      Choices: {{ candidates | join(" \|\|\| ") }}
+      Choices:
+
+      {% for candidate in candidates %}
+
+      - {{ candidate }}
+
+      {% endfor %}
 
 
       |||
@@ -268,7 +286,13 @@ templates:
       the relation of ''{{ question_split[0] | replace("_", " ")}}''?
 
 
-      Choices: {{ candidates | join(" \|\|\| ") }}
+      Choices:
+
+      {% for candidate in candidates %}
+
+      - {{ candidate }}
+
+      {% endfor %}
 
 
       |||

--- a/promptsource/templates/wiki_hop/original/templates.yaml
+++ b/promptsource/templates/wiki_hop/original/templates.yaml
@@ -15,7 +15,6 @@ templates:
       choices_in_prompt: true
       metrics:
       - Sequence Accuracy
-      - Accuracy
       original_task: true
     name: choose_best_object_interrogative_1
     reference: Given information and subject and relation, choose the best object
@@ -47,7 +46,7 @@ templates:
       original_task: false
     name: explain_relation
     reference: Given information, explain the relation between the subject entity
-      and the object entity in a fact triple.
+      and the object entity.
   2fadafea-f814-4ff1-a3aa-cace9067f31f: !Template
     answer_choices: null
     answer_choices_key: null
@@ -130,11 +129,11 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
-      - Accuracy
       - Sequence Accuracy
       original_task: true
     name: choose_best_object_affirmative_1
-    reference: ''
+    reference: Given information and subject and relation, choose the best object
+      entity (affirmative instruction).
   4a1b61f6-c619-4d3d-aec2-f41a8986641c: !Template
     answer_choices: null
     answer_choices_key: candidates
@@ -163,11 +162,11 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
-      - Accuracy
       - Sequence Accuracy
       original_task: true
     name: choose_best_object_affirmative_3
-    reference: ''
+    reference: Given information and subject and relation, choose the best object
+      entity (affirmative instruction).
   c4675106-0ac5-4bf0-a400-f628daae81db: !Template
     answer_choices: null
     answer_choices_key: null
@@ -222,11 +221,11 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
-      - Accuracy
       - Sequence Accuracy
       original_task: true
     name: choose_best_object_affirmative_2
-    reference: ''
+    reference: Given information and subject and relation, choose the best object
+      entity (affirmative instruction).
   f44936e1-cbde-4d41-b462-6150cce8c1c8: !Template
     answer_choices: null
     answer_choices_key: candidates
@@ -254,7 +253,7 @@ templates:
       choices_in_prompt: true
       metrics:
       - Sequence Accuracy
-      - Accuracy
       original_task: true
     name: choose_best_object_interrogative_2
-    reference: ''
+    reference: Given information and subject and relation, choose the best object
+      entity (interrogative instruction).

--- a/promptsource/templates/wiki_hop/original/templates.yaml
+++ b/promptsource/templates/wiki_hop/original/templates.yaml
@@ -5,10 +5,11 @@ templates:
     answer_choices: null
     answer_choices_key: candidates
     id: 0bb6b603-115e-4ae9-b17b-881fa72b2e81
-    jinja: "Information:\n- {{ supports | join(\"\\n- \") }}\n\n{% set question_split\
-      \ = question.split(' ') %}\nWhat object entity has the relation of '{{ question_split[0]\
-      \ | replace(\"_\", \" \")}}' with the subject '{{ question_split[1:] | join(\"\
-      \ \")}}'? \n\nChoices: {{ candidates | join(\"|||\") }}\n\n|||\n{{answer}}"
+    jinja: "Information:\n{% for support in supports %}\n- {{ support }}\n{% endfor\
+      \ %}\n\n{% set question_split = question.split(' ') %}\nWhat object entity has\
+      \ the relation of '{{ question_split[0] | replace(\"_\", \" \")}}' with the\
+      \ subject '{{ question_split[1:] | join(\" \")}}'? \n\nChoices: {{ candidates\
+      \ | join(\" \\|\\|\\| \") }}\n\n|||\n{{answer}}"
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -25,7 +26,11 @@ templates:
     id: 23e0d05a-8777-45c4-8692-13f3dc5a40bb
     jinja: 'Information:
 
-      - {{ supports | join("\n- ") }}
+      {% for support in supports %}
+
+      - {{ support }}
+
+      {% endfor %}
 
 
       {% set question_split = question.split('' '') %}
@@ -53,7 +58,11 @@ templates:
     id: 2fadafea-f814-4ff1-a3aa-cace9067f31f
     jinja: 'Information:
 
-      - {{ supports | join("\n- ") }}
+      {% for support in supports %}
+
+      - {{ support }}
+
+      {% endfor %}
 
 
       {% set question_split = question.split('' '') %}
@@ -81,7 +90,11 @@ templates:
     id: 40bdb0e7-def9-4829-9a37-a05d354ef7cd
     jinja: 'Information:
 
-      - {{ supports | join("\n- ") }}
+      {% for support in supports %}
+
+      - {{ support }}
+
+      {% endfor %}
 
 
       {% set question_split = question.split('' '') %}
@@ -108,7 +121,11 @@ templates:
     id: 4836e754-b2c9-4697-b386-6770494dc5f5
     jinja: 'Information:
 
-      - {{ supports | join("\n- ") }}
+      {% for support in supports %}
+
+      - {{ support }}
+
+      {% endfor %}
 
 
       {% set question_split = question.split('' '') %}
@@ -118,7 +135,7 @@ templates:
       subject ''{{ question_split[1:] | join(" ")}}''.
 
 
-      Choices: {{ candidates | join("|||") }}
+      Choices: {{ candidates | join(" \|\|\| ") }}
 
 
       |||
@@ -138,7 +155,11 @@ templates:
     id: 4a1b61f6-c619-4d3d-aec2-f41a8986641c
     jinja: 'Information:
 
-      - {{ supports | join("\n- ") }}
+      {% for support in supports %}
+
+      - {{ support }}
+
+      {% endfor %}
 
 
       {% set question_split = question.split('' '') %}
@@ -149,7 +170,7 @@ templates:
       choices below.
 
 
-      Choices: {{ candidates | join("|||") }}
+      Choices: {{ candidates | join(" \|\|\| ") }}
 
 
       |||
@@ -169,7 +190,11 @@ templates:
     id: c4675106-0ac5-4bf0-a400-f628daae81db
     jinja: 'Information:
 
-      - {{ supports | join("\n- ") }}
+      {% for support in supports %}
+
+      - {{ support }}
+
+      {% endfor %}
 
 
       {% set question_split = question.split('' '') %}
@@ -196,7 +221,11 @@ templates:
     id: e4dc7abf-d56a-4217-ba7f-7470cd959e8e
     jinja: 'Information:
 
-      - {{ supports | join("\n- ") }}
+      {% for support in supports %}
+
+      - {{ support }}
+
+      {% endfor %}
 
 
       {% set question_split = question.split('' '') %}
@@ -206,7 +235,7 @@ templates:
       ''{{ question_split[0] | replace("_", " ")}}''.
 
 
-      Choices: {{ candidates | join("|||") }}
+      Choices: {{ candidates | join(" \|\|\| ") }}
 
 
       |||
@@ -226,7 +255,11 @@ templates:
     id: f44936e1-cbde-4d41-b462-6150cce8c1c8
     jinja: 'Information:
 
-      - {{ supports | join("\n- ") }}
+      {% for support in supports %}
+
+      - {{ support }}
+
+      {% endfor %}
 
 
       {% set question_split = question.split('' '') %}
@@ -235,7 +268,7 @@ templates:
       the relation of ''{{ question_split[0] | replace("_", " ")}}''?
 
 
-      Choices: {{ candidates | join("|||") }}
+      Choices: {{ candidates | join(" \|\|\| ") }}
 
 
       |||

--- a/promptsource/templates/wiki_hop/original/templates.yaml
+++ b/promptsource/templates/wiki_hop/original/templates.yaml
@@ -3,21 +3,23 @@ subset: original
 templates:
   0bb6b603-115e-4ae9-b17b-881fa72b2e81: !Template
     answer_choices: null
-    answer_choices_key: null
+    answer_choices_key: candidates
     id: 0bb6b603-115e-4ae9-b17b-881fa72b2e81
     jinja: "Information:\n- {{ supports | join(\"\\n- \") }}\n\n{% set question_split\
-      \ = question.split(' ') %}\nQuestion: ({{ question_split[1:] | join(\" \")}},\
-      \ {{ question_split[0] | replace(\"_\", \" \") }}, ?)\n\nCandidate Answers:\
-      \ \n- {{ candidates | join(\"\\n- \") }}\n|||\n{{answer}}"
+      \ = question.split(' ') %}\nWhat object entity has the relation of '{{ question_split[0]\
+      \ | replace(\"_\", \" \")}}' with the subject '{{ question_split[1:] | join(\"\
+      \ \")}}'? \n\nChoices:\n- {{ candidates | join(\"\\n- \") }}\n\n|||\n{{answer}}"
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Sequence Accuracy
+      - Accuracy
       original_task: true
-    name: Choose Best Object Candidate
-    reference: Given information and possible object candidates, choose the best object
-      for the fact triple.
+    name: choose_best_object_interrogative_1
+    reference: Given information and subject and relation, choose the best object
+      entity (interrogative instruction).
   23e0d05a-8777-45c4-8692-13f3dc5a40bb: !Template
     answer_choices: null
     answer_choices_key: null
@@ -29,7 +31,8 @@ templates:
 
       {% set question_split = question.split('' '') %}
 
-      What is the relationship between "{{ question_split[1:] | join(" ")}}" and "{{answer}}"?
+      What is the relationship between ''{{ question_split[1:] | join(" ")}}'' and
+      ''{{answer}}''?
 
 
       |||
@@ -39,9 +42,10 @@ templates:
       _do_eval: false
       _do_train: true
       choices_in_prompt: false
-      metrics: []
+      metrics:
+      - Sequence Accuracy
       original_task: false
-    name: Explain Relation
+    name: explain_relation
     reference: Given information, explain the relation between the subject entity
       and the object entity in a fact triple.
   2fadafea-f814-4ff1-a3aa-cace9067f31f: !Template
@@ -55,8 +59,8 @@ templates:
 
       {% set question_split = question.split('' '') %}
 
-      Question: ({{ question_split[1:] | join(" ")}}, {{ question_split[0] | replace("_",
-      " ") }}, ?)
+      What entity does ''{{ question_split[1:] | join(" ")}}'' has the relation ''{{
+      question_split[0] | replace("_", " ") }}'' with?
 
 
       |||
@@ -65,11 +69,13 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Sequence Accuracy
       original_task: false
-    name: Generate Object Answer
-    reference: Given information, generate the best object entity for the fact triple.
+    name: generate_object
+    reference: Given information, generate the best object entity (without answer
+      choices in prompt).
   40bdb0e7-def9-4829-9a37-a05d354ef7cd: !Template
     answer_choices: null
     answer_choices_key: null
@@ -81,7 +87,8 @@ templates:
 
       {% set question_split = question.split('' '') %}
 
-      Question: (?, {{ question_split[0] | replace("_", " ") }}, {{answer}})
+      Given the paragraphs above, decide what entity has the relation ''{{ question_split[0]
+      | replace("_", " ") }}'' with ''{{answer}}''.
 
 
       |||
@@ -90,70 +97,77 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Sequence Accuracy
       original_task: false
-    name: Generate Subject Answer
+    name: generate_subject
     reference: Given information, generate the best subject entity for the fact triple.
-  61018021-393f-4d4f-8fba-cda7df7ce240: !Template
+  4836e754-b2c9-4697-b386-6770494dc5f5: !Template
     answer_choices: null
-    answer_choices_key: null
-    id: 61018021-393f-4d4f-8fba-cda7df7ce240
-    jinja: '{% set question_split = question.split('' '') %}
-
-      {% if question_split[0]=="place_of_birth" %}
-
-      Information:
+    answer_choices_key: candidates
+    id: 4836e754-b2c9-4697-b386-6770494dc5f5
+    jinja: 'Information:
 
       - {{ supports | join("\n- ") }}
 
 
-      Where was {{ question_split[1:] | join(" ")}} born? Choose from the following:
+      {% set question_split = question.split('' '') %}
+
+      Given the information above, choose from the list below the object entity that
+      exhibits the relation ''{{ question_split[0] | replace("_", " ")}}'' with the
+      subject ''{{ question_split[1:] | join(" ")}}''.
+
+
+      Choices:
 
       - {{ candidates | join("\n- ") }}
 
-      {% elif question_split[0]=="country_of_citizenship" %}
-
-      Information:
-
-      - {{ supports | join("\n- ") }}
-
-
-      What country is {{ question_split[1:] | join(" ")}} a citizen of? Choose from
-      the following:
-
-      - {{ candidates | join("\n- ") }}
-
-      {% elif question_split[0]=="place_of_death" %}
-
-      Information:
-
-      - {{ supports | join("\n- ") }}
-
-
-      Where did {{ question_split[1:] | join(" ")}} die? Choose from the following:
-
-      - {{ candidates | join("\n- ") }}
-
-      {% endif %}
 
       |||
 
-      {% if question_split[0] in ["place_of_birth", "country_of_citizenship", "place_of_death"]
-      %}
-
-      {{answer}}
-
-      {% endif %}'
+      {{answer}}'
     metadata: !TemplateMetadata
-      _do_eval: false
-      _do_train: true
-      choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: Indirect Question about Birthplace / Citizenship / Place of Death
-    reference: Ask about place of birth, citizenship, or place of death for the subject
-      entity.
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      - Sequence Accuracy
+      original_task: true
+    name: choose_best_object_affirmative_1
+    reference: ''
+  4a1b61f6-c619-4d3d-aec2-f41a8986641c: !Template
+    answer_choices: null
+    answer_choices_key: candidates
+    id: 4a1b61f6-c619-4d3d-aec2-f41a8986641c
+    jinja: 'Information:
+
+      - {{ supports | join("\n- ") }}
+
+
+      {% set question_split = question.split('' '') %}
+
+      After reading the paragraphs above, we are interested in knowing the entity
+      with which ''{{ question_split[1:] | join(" ")}}'' exhibits the relationship
+      of ''{{ question_split[0] | replace("_", " ")}}''. Find the answer from the
+      choices below.
+
+
+      Choices:
+
+      - {{ candidates | join("\n- ") }}
+
+
+      |||
+
+      {{answer}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      - Sequence Accuracy
+      original_task: true
+    name: choose_best_object_affirmative_3
+    reference: ''
   c4675106-0ac5-4bf0-a400-f628daae81db: !Template
     answer_choices: null
     answer_choices_key: null
@@ -165,18 +179,82 @@ templates:
 
       {% set question_split = question.split('' '') %}
 
-      Generate a fact triple for the information above.
+      Given the information, choose the subject and object entities that have the
+      relation of ''{{ question_split[0] | replace("_", " ") }}''.
 
 
       |||
 
-      ({{ question_split[1:] | join(" ") }}, {{ question_split[0] | replace("_", "
-      ") }}, {{answer}})'
+      {{ question_split[1:] | join(" ") }} , {{answer}}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Sequence Accuracy
       original_task: false
-    name: Generate Fact Triple
-    reference: Given information, generate a fact triple.
+    name: generate_subject_and_object
+    reference: Given information and relation, generate the subject and object.
+  e4dc7abf-d56a-4217-ba7f-7470cd959e8e: !Template
+    answer_choices: null
+    answer_choices_key: candidates
+    id: e4dc7abf-d56a-4217-ba7f-7470cd959e8e
+    jinja: 'Information:
+
+      - {{ supports | join("\n- ") }}
+
+
+      {% set question_split = question.split('' '') %}
+
+      After reading the paragraphs above, choose the best answer for the entity that
+      related to ''{{ question_split[1:] | join(" ")}}'' with the relationship of
+      ''{{ question_split[0] | replace("_", " ")}}''.
+
+
+      Choices:
+
+      - {{ candidates | join("\n- ") }}
+
+
+      |||
+
+      {{answer}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      - Sequence Accuracy
+      original_task: true
+    name: choose_best_object_affirmative_2
+    reference: ''
+  f44936e1-cbde-4d41-b462-6150cce8c1c8: !Template
+    answer_choices: null
+    answer_choices_key: candidates
+    id: f44936e1-cbde-4d41-b462-6150cce8c1c8
+    jinja: 'Information:
+
+      - {{ supports | join("\n- ") }}
+
+
+      {% set question_split = question.split('' '') %}
+
+      ''{{ question_split[1:] | join(" ")}}'' is related to which object entity through
+      the relation of ''{{ question_split[0] | replace("_", " ")}}''?
+
+
+      Choices:
+
+      - {{ candidates | join("\n- ") }}
+
+
+      |||
+
+      {{answer}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Sequence Accuracy
+      - Accuracy
+      original_task: true
+    name: choose_best_object_interrogative_2
+    reference: ''

--- a/promptsource/templates/wiki_hop/original/templates.yaml
+++ b/promptsource/templates/wiki_hop/original/templates.yaml
@@ -8,7 +8,7 @@ templates:
     jinja: "Information:\n- {{ supports | join(\"\\n- \") }}\n\n{% set question_split\
       \ = question.split(' ') %}\nWhat object entity has the relation of '{{ question_split[0]\
       \ | replace(\"_\", \" \")}}' with the subject '{{ question_split[1:] | join(\"\
-      \ \")}}'? \n\nChoices:\n- {{ candidates | join(\"\\n- \") }}\n\n|||\n{{answer}}"
+      \ \")}}'? \n\nChoices: {{ candidates | join(\"|||\") }}\n\n|||\n{{answer}}"
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -118,9 +118,7 @@ templates:
       subject ''{{ question_split[1:] | join(" ")}}''.
 
 
-      Choices:
-
-      - {{ candidates | join("\n- ") }}
+      Choices: {{ candidates | join("|||") }}
 
 
       |||
@@ -151,9 +149,7 @@ templates:
       choices below.
 
 
-      Choices:
-
-      - {{ candidates | join("\n- ") }}
+      Choices: {{ candidates | join("|||") }}
 
 
       |||
@@ -210,9 +206,7 @@ templates:
       ''{{ question_split[0] | replace("_", " ")}}''.
 
 
-      Choices:
-
-      - {{ candidates | join("\n- ") }}
+      Choices: {{ candidates | join("|||") }}
 
 
       |||
@@ -241,9 +235,7 @@ templates:
       the relation of ''{{ question_split[0] | replace("_", " ")}}''?
 
 
-      Choices:
-
-      - {{ candidates | join("\n- ") }}
+      Choices: {{ candidates | join("|||") }}
 
 
       |||


### PR DESCRIPTION
What I have done:
- [X] fix existing issues
- [X] add 4 more original task templates
- [X] set metrics
- [X] fill out answer_choices
- [X] indicate Choices in Prompt

**Existing issues:**
The existing templates `Choose_Best_Object_Candidate`, `Generate_Fact_Triple`, `Generate_Object_Answer`, `Generate_Subject_Answer` are not in natural form. I have fixed them and rename all the templates to lower case and underscores. I include numbers in template names such as `choose_best_object_interrogative_1` to indicate the variants of the interrogative and affirmative forms. 

As for `Indirect_Question_about_Birthplace_Citizenship_Place_of_Death`, the spreadsheet says template bug. I believe the template bug comes from the template being unable to apply to examples that are not asking about birthplaces and citizenship. Therefore, I have removed the template.

**Potential Issues**
The input sequences are long so we might risk getting the prompt instruction truncated. See [slack thread](https://huggingface.slack.com/archives/C023Z96L7B4/p1631125687080900).
