### PR TITLE
Clean glue/{{mnli|mnli-matched|mnli-mismatched}}

### DIFF
--- a/promptsource/templates/glue/mnli/templates.yaml
+++ b/promptsource/templates/glue/mnli/templates.yaml
@@ -134,3 +134,29 @@ templates:
       original_task: true
     name: imply
     reference: ''
+  d067f960-75d9-4fed-bf54-6ddaff123a43: !Template
+    answer_choices:
+      - 'yes'
+      - neutral
+      - 'no'
+    answer_choices_key: null
+    id: d067f960-75d9-4fed-bf54-6ddaff123a43
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 entail Sentence 2? {{answer_choices[0]}},
+      {{answer_choices[2]}}, or {{answer_choices[1]}} ?
+
+      |||
+
+      {{answer_choices[label]}}'
+    metadata: !TemplateMetadata
+      _do_eval: false
+      _do_train: false
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: does S1 entail S2?
+    reference: Imported from multi_nli prompts for completeness

--- a/promptsource/templates/glue/mnli/templates.yaml
+++ b/promptsource/templates/glue/mnli/templates.yaml
@@ -34,8 +34,8 @@ templates:
     id: a558db31-99e3-45ee-9e24-a4d1b64ed1df
     jinja: 'In this task, you need to determine if two passages have one of three
       relationships: {{answer_choices[0]}}, {{answer_choices[1]}}, {{answer_choices[2]}}.
-      {{answer_choices[0].upper()}} means that the first passage implies the second.
-      {{answer_choices[1].upper()}} means that their relationship is unclear. {{answer_choices[2].upper()}}
+      {{answer_choices[0].capitalize()}} means that the first passage implies the second.
+      {{answer_choices[1].capitalize()}} means that their relationship is unclear. {{answer_choices[2].capitalize()}}
       means the first passage contradicts the second. Here are the two passages:
 
       {{premise}}

--- a/promptsource/templates/glue/mnli/templates.yaml
+++ b/promptsource/templates/glue/mnli/templates.yaml
@@ -10,8 +10,8 @@ templates:
     id: 2884f60d-8069-4238-92fa-3314bbf76c3d
     jinja: '{{premise}}
 
-      Is it therefore the case that "{{hypothesis}}"? Please answer {{"yes, no, or
-      unclear"}}.
+      Is it therefore the case that "{{hypothesis}}"? Please answer {{answer_choices[0]}},
+      {{answer_choices[2]}}, or {{answer_choices[1]}}.
 
       |||
 
@@ -19,9 +19,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
     name: is it the case
     reference: ''
   a558db31-99e3-45ee-9e24-a4d1b64ed1df: !Template
@@ -32,16 +33,16 @@ templates:
     answer_choices_key: null
     id: a558db31-99e3-45ee-9e24-a4d1b64ed1df
     jinja: 'In this task, you need to determine if two passages have one of three
-      relationships: {{"entailment, neural, or contradiction"}}. {{"Entailment"}}
-      means that the first passage implies the second. {{"Neutral"}} means that their
-      relationship is unclear. {{"Contradiction"}} means the first passage contradicts
-      the second. Here are the two passages:
+      relationships: {{answer_choices[0]}}, {{answer_choices[1]}}, {{answer_choices[2]}}.
+      {{answer_choices[0].upper()}} means that the first passage implies the second.
+      {{answer_choices[1].upper()}} means that their relationship is unclear. {{answer_choices[2].upper()}}
+      means the first passage contradicts the second. Here are the two passages:
 
       {{premise}}
 
       {{hypothesis}}
 
-      Is the relationship {{"entailment, neutral, or contradiction"}}?
+      Is the relationship {{answer_choices[0]}}, {{answer_choices[1]}}, or {{answer_choices[2]}}?
 
       |||
 
@@ -49,9 +50,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
     name: entailment
     reference: ''
   a730746a-58c3-4c5d-9e93-a73dbe3661e1: !Template
@@ -63,7 +65,8 @@ templates:
     id: a730746a-58c3-4c5d-9e93-a73dbe3661e1
     jinja: '{{premise}}
 
-      Does this mean that "{{hypothesis}}"? {{"A) yes B) no or C) maybe."}}
+      Does this mean that "{{hypothesis}}"? A) {{answer_choices[0]}} B) {{answer_choices[2]}}
+      or C) {{answer_choices[1]}}.
 
       |||
 
@@ -71,9 +74,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
     name: does this mean
     reference: ''
   ab25652e-20a7-4a1e-a530-916b2adc64a0: !Template
@@ -91,7 +95,8 @@ templates:
 
       {{hypothesis}}
 
-      Does the hypothesis follow from the premise? {{"A) yes B) no C) maybe"}}
+      Does the hypothesis follow from the premise? A) {{answer_choices[0]}} B) {{answer_choices[2]}}
+      C) {{answer_choices[1]}}
 
       |||
 
@@ -99,9 +104,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
     name: premise hypothesis
     reference: ''
   ac71489b-c5e9-4c60-8eae-35eb14cb5545: !Template
@@ -113,7 +119,8 @@ templates:
     id: ac71489b-c5e9-4c60-8eae-35eb14cb5545
     jinja: '{{premise}}
 
-      Does this imply that "{{hypothesis}}"? Please answer {{"yes, no, or maybe"}}.
+      Does this imply that "{{hypothesis}}"? Please answer {{answer_choices[0]}},
+      {{answer_choices[2]}} or {{answer_choices[1]}}.
 
       |||
 
@@ -121,8 +128,9 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
     name: imply
     reference: ''

--- a/promptsource/templates/glue/mnli_matched/templates.yaml
+++ b/promptsource/templates/glue/mnli_matched/templates.yaml
@@ -134,3 +134,29 @@ templates:
       original_task: true
     name: is it the case
     reference: ''
+  d067f960-75d9-4fed-bf54-6ddaff123a44: !Template
+    answer_choices:
+      - 'yes'
+      - neutral
+      - 'no'
+    answer_choices_key: null
+    id: d067f960-75d9-4fed-bf54-6ddaff123a44
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 entail Sentence 2? {{answer_choices[0]}},
+      {{answer_choices[2]}}, or {{answer_choices[1]}} ?
+
+      |||
+
+      {{answer_choices[label]}}'
+    metadata: !TemplateMetadata
+      _do_eval: false
+      _do_train: false
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: does S1 entail S2?
+    reference: Imported from multi_nli prompts for completeness

--- a/promptsource/templates/glue/mnli_matched/templates.yaml
+++ b/promptsource/templates/glue/mnli_matched/templates.yaml
@@ -10,7 +10,8 @@ templates:
     id: 53f051c9-a456-4af7-ac35-aee1c139406d
     jinja: '{{premise}}
 
-      Does this imply that "{{hypothesis}}"? Please answer {{"yes, no, or maybe"}}.
+      Does this imply that "{{hypothesis}}"? Please answer {{answer_choices[0]}},
+      {{answer_choices[2]}} or {{answer_choices[1]}}.
 
       |||
 
@@ -18,9 +19,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+        - Accuracy
+      original_task: true
     name: imply
     reference: ''
   736510c1-f3a2-4f77-b7c2-5b303240ae73: !Template
@@ -31,16 +33,16 @@ templates:
     answer_choices_key: null
     id: 736510c1-f3a2-4f77-b7c2-5b303240ae73
     jinja: 'In this task, you need to determine if two passages have one of three
-      relationships: {{"entailment, neural, or contradiction"}}. {{"Entailment"}}
-      means that the first passage implies the second. {{"Neutral"}} means that their
-      relationship is unclear. {{"Contradiction"}} means the first passage contradicts
-      the second. Here are the two passages:
+      relationships: {{answer_choices[0]}}, {{answer_choices[1]}}, {{answer_choices[2]}}.
+      {{answer_choices[0].upper()}} means that the first passage implies the second.
+      {{answer_choices[1].upper()}} means that their relationship is unclear. {{answer_choices[2].upper()}}
+      means the first passage contradicts the second. Here are the two passages:
 
       {{premise}}
 
       {{hypothesis}}
 
-      Is the relationship {{"entailment, neutral, or contradiction"}}?
+      Is the relationship {{answer_choices[0]}}, {{answer_choices[1]}}, or {{answer_choices[2]}}?
 
       |||
 
@@ -48,9 +50,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+        - Accuracy
+      original_task: true
     name: entailment
     reference: ''
   75badf58-7401-43e9-9950-adb3fd61864e: !Template
@@ -62,7 +65,8 @@ templates:
     id: 75badf58-7401-43e9-9950-adb3fd61864e
     jinja: '{{premise}}
 
-      Does this mean that "{{hypothesis}}"? {{"A) yes B) no or C) maybe."}}
+      Does this mean that "{{hypothesis}}"? A) {{answer_choices[0]}} B) {{answer_choices[2]}}
+      or C) {{answer_choices[1]}}.
 
       |||
 
@@ -70,9 +74,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+        - Accuracy
+      original_task: true
     name: does this mean
     reference: ''
   8cd9b255-865b-4217-b1ff-4a027158fba8: !Template
@@ -90,7 +95,8 @@ templates:
 
       {{hypothesis}}
 
-      Does the hypothesis follow from the premise? {{"A) yes B) no C) maybe"}}
+      Does the hypothesis follow from the premise? A) {{answer_choices[0]}} B) {{answer_choices[2]}}
+      C) {{answer_choices[1]}}
 
       |||
 
@@ -98,9 +104,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+        - Accuracy
+      original_task: true
     name: premise hypothesis
     reference: ''
   cef02970-9c3e-4089-befa-2d01de2eaa12: !Template
@@ -112,8 +119,8 @@ templates:
     id: cef02970-9c3e-4089-befa-2d01de2eaa12
     jinja: '{{premise}}
 
-      Is it therefore the case that "{{hypothesis}}"? Please answer {{"yes, no, or
-      unclear"}}.
+      Is it therefore the case that "{{hypothesis}}"? Please answer {{answer_choices[0]}},
+      {{answer_choices[2]}}, or {{answer_choices[1]}}.
 
       |||
 
@@ -121,8 +128,9 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
     name: is it the case
     reference: ''

--- a/promptsource/templates/glue/mnli_matched/templates.yaml
+++ b/promptsource/templates/glue/mnli_matched/templates.yaml
@@ -34,8 +34,8 @@ templates:
     id: 736510c1-f3a2-4f77-b7c2-5b303240ae73
     jinja: 'In this task, you need to determine if two passages have one of three
       relationships: {{answer_choices[0]}}, {{answer_choices[1]}}, {{answer_choices[2]}}.
-      {{answer_choices[0].upper()}} means that the first passage implies the second.
-      {{answer_choices[1].upper()}} means that their relationship is unclear. {{answer_choices[2].upper()}}
+      {{answer_choices[0].capitalize()}} means that the first passage implies the second.
+      {{answer_choices[1].capitalize()}} means that their relationship is unclear. {{answer_choices[2].capitalize()}}
       means the first passage contradicts the second. Here are the two passages:
 
       {{premise}}

--- a/promptsource/templates/glue/mnli_mismatched/templates.yaml
+++ b/promptsource/templates/glue/mnli_mismatched/templates.yaml
@@ -112,8 +112,8 @@ templates:
     id: b249978b-b1ee-440b-ae67-280e6631286b
     jinja: 'In this task, you need to determine if two passages have one of three
       relationships: {{answer_choices[0]}}, {{answer_choices[1]}}, {{answer_choices[2]}}.
-      {{answer_choices[0].upper()}} means that the first passage implies the second.
-      {{answer_choices[1].upper()}} means that their relationship is unclear. {{answer_choices[2].upper()}}
+      {{answer_choices[0].capitalize()}} means that the first passage implies the second.
+      {{answer_choices[1].capitalize()}} means that their relationship is unclear. {{answer_choices[2].capitalize()}}
       means the first passage contradicts the second. Here are the two passages:
 
       {{premise}}

--- a/promptsource/templates/glue/mnli_mismatched/templates.yaml
+++ b/promptsource/templates/glue/mnli_mismatched/templates.yaml
@@ -132,8 +132,5 @@ templates:
       metrics:
         - Accuracy
       original_task: true
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
     name: entailment
     reference: ''

--- a/promptsource/templates/glue/mnli_mismatched/templates.yaml
+++ b/promptsource/templates/glue/mnli_mismatched/templates.yaml
@@ -134,3 +134,29 @@ templates:
       original_task: true
     name: entailment
     reference: ''
+  d067f960-75d9-4fed-bf54-6ddaff123a45: !Template
+    answer_choices:
+      - 'yes'
+      - neutral
+      - 'no'
+    answer_choices_key: null
+    id: d067f960-75d9-4fed-bf54-6ddaff123a45
+    jinja: 'Sentence 1: {{premise}}
+
+      Sentence 2: {{hypothesis}}
+
+      Question: Does Sentence 1 entail Sentence 2? {{answer_choices[0]}},
+      {{answer_choices[2]}}, or {{answer_choices[1]}} ?
+
+      |||
+
+      {{answer_choices[label]}}'
+    metadata: !TemplateMetadata
+      _do_eval: false
+      _do_train: false
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: does S1 entail S2?
+    reference: Imported from multi_nli prompts for completeness

--- a/promptsource/templates/glue/mnli_mismatched/templates.yaml
+++ b/promptsource/templates/glue/mnli_mismatched/templates.yaml
@@ -10,8 +10,8 @@ templates:
     id: 6e6ffb0a-6981-4fd9-a188-15fe2c07d7f0
     jinja: '{{premise}}
 
-      Is it therefore the case that "{{hypothesis}}"? Please answer {{"yes, no, or
-      unclear"}}.
+      Is it therefore the case that "{{hypothesis}}"? Please answer {{answer_choices[0]}},
+      {{answer_choices[2]}}, or {{answer_choices[1]}}.
 
       |||
 
@@ -19,9 +19,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+        - Accuracy
+      original_task: true
     name: is it the case
     reference: ''
   704397f4-c16e-4737-ad6d-2f282517810f: !Template
@@ -33,7 +34,8 @@ templates:
     id: 704397f4-c16e-4737-ad6d-2f282517810f
     jinja: '{{premise}}
 
-      Does this imply that "{{hypothesis}}"? Please answer {{"yes, no, or maybe"}}.
+      Does this imply that "{{hypothesis}}"? Please answer {{answer_choices[0]}},
+      {{answer_choices[2]}} or {{answer_choices[1]}}.
 
       |||
 
@@ -41,9 +43,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+        - Accuracy
+      original_task: true
     name: imply
     reference: ''
   709efd1d-3911-4db7-969b-7fc8600b796c: !Template
@@ -61,7 +64,8 @@ templates:
 
       {{hypothesis}}
 
-      Does the hypothesis follow from the premise? {{"A) yes B) no C) maybe"}}
+      Does the hypothesis follow from the premise? A) {{answer_choices[0]}} B) {{answer_choices[2]}}
+      C) {{answer_choices[1]}}
 
       |||
 
@@ -69,9 +73,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+        - Accuracy
+      original_task: true
     name: premise hypothesis
     reference: ''
   873607a6-cf11-4fb4-a038-0fe3a843315d: !Template
@@ -83,7 +88,8 @@ templates:
     id: 873607a6-cf11-4fb4-a038-0fe3a843315d
     jinja: '{{premise}}
 
-      Does this mean that "{{hypothesis}}"? {{"A) yes B) no or C) maybe."}}
+      Does this mean that "{{hypothesis}}"? A) {{answer_choices[0]}} B) {{answer_choices[2]}}
+      or C) {{answer_choices[1]}}.
 
       |||
 
@@ -91,9 +97,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+        - Accuracy
+      original_task: true
     name: does this mean
     reference: ''
   b249978b-b1ee-440b-ae67-280e6631286b: !Template
@@ -104,16 +111,16 @@ templates:
     answer_choices_key: null
     id: b249978b-b1ee-440b-ae67-280e6631286b
     jinja: 'In this task, you need to determine if two passages have one of three
-      relationships: {{"entailment, neural, or contradiction"}}. {{"Entailment"}}
-      means that the first passage implies the second. {{"Neutral"}} means that their
-      relationship is unclear. {{"Contradiction"}} means the first passage contradicts
-      the second. Here are the two passages:
+      relationships: {{answer_choices[0]}}, {{answer_choices[1]}}, {{answer_choices[2]}}.
+      {{answer_choices[0].upper()}} means that the first passage implies the second.
+      {{answer_choices[1].upper()}} means that their relationship is unclear. {{answer_choices[2].upper()}}
+      means the first passage contradicts the second. Here are the two passages:
 
       {{premise}}
 
       {{hypothesis}}
 
-      Is the relationship {{"entailment, neutral, or contradiction"}}?
+      Is the relationship {{answer_choices[0]}}, {{answer_choices[1]}}, or {{answer_choices[2]}}?
 
       |||
 
@@ -121,6 +128,10 @@ templates:
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
+      choices_in_prompt: true
+      metrics:
+        - Accuracy
+      original_task: true
       choices_in_prompt: null
       metrics: []
       original_task: null


### PR DESCRIPTION
Straightforward cleaning following the cleaning instructions, mostly replacing written labels with answer_choices[x].

I also looked at the templates on `multi_nli` (same task, but P4 probably because not in Glue) and imported one from there.