### PR TITLE
Experiment D4 train/eval mixtures

### DIFF
--- a/promptsource/seqio_tasks/experiment_D4.csv
+++ b/promptsource/seqio_tasks/experiment_D4.csv
@@ -1,0 +1,218 @@
+HF_name,subset,task_by_convention,format,input_length,_human_skill,comment,seed_paper,train_order,september_check,do_train,do_eval,train_size,adjusted_train_size,D3_do_train,D3_do_eval,D3_adjusted_train_size,answer_choices,metric,multiple correct answer,SOTA,GPT-3 (13B),GPT-3 (175B),T5 (11B LM Adapted),,,"T0 (3B, Exp. D2) ","T0 (11B, Exp. D3)",,"T0 (11B, Exp. D4)",,non_linguistic_knowledge,skip,Imported Task Name,imported category,Domain,Paper link,Reference
+,,,,,,,,,,,,,,,,,,,,traditional fine-tuning,"ZS, rank eval","ZS, rank eval",zero-shot prompts,few-shot prompts,fully trained prompts ,ZS,ZS,"ZS, rank eval",ZS,"ZS, rank eval",,,,,,,
+quoref,,coreference,ext,,,,,1,TRUE,TRUE,,19399,19399,TRUE,,19399,,,,,,,,,,,,,,,,,Quoref,Extractive QA,,https://aclanthology.org/D19-1606.pdf,Dasigi et al. 2019
+super_glue,wsc.fixed,coreference,cls,single sentence,knowledge-? reading comprehension,,,,,,TRUE,554,0,TRUE,TRUE,554,fixed,accuracy,,,,,,,,,,,,,,,superglue-wsc,cls/other,,,Levesque et al. 2012
+winograd_wsc,,coreference,ext,,,todo: which subset? add to hackaprompt,GPT,,,,TRUE,,0,,,0,,,,,,,,,,,,,,,,,,,,,
+winogrande,,coreference,ext,,knowledge-? reading comprehension,todo: which HF subsets map to which subsets in the paper?,GPT,,,,TRUE,,0,,,0,,accuracy,,,,,,,,,,,,,,,WinoGrande,qa/multiple-choice qa,,https://arxiv.org/pdf/1907.10641.pdf,Sakaguchi et al. 2020
+glue,cola,grammatical_acceptability,cls,single sentence,,includes semantic acceptability too; to be replaced by blimp,,,,,TRUE,8551,0,,TRUE,0,,matthews_corrcoef,,,,,,,,,,,,,,,glue-cola,cls/other,,https://arxiv.org/pdf/1805.12471.pdf,Warstadt et al. 2019
+blimp,,grammatical_acceptability,cls,,,todo: no prompts yet; collapse subsets,,,,,TRUE,,0,,,0,,,,,,,,,,,,,,,,,,,,,
+super_glue,cb,NLI,cls,sentence pair,knowledge-neutral inference,"""for multi-class F1 we compute the unweighted average of the F1 per class.""",,,,,TRUE,250,0,,TRUE,0,,mean_multiclass_f1;accuracy,,,,,,,,,,,,,,,superglue-cb,cls/nli,,https://semanticsarchive.net/Archive/Tg3ZGI2M/Marneffe.pdf,de Marneffe et al. 2019
+super_glue,rte,NLI,cls,sentence pair,knowledge modest inference,,,,,,TRUE,2490,0,,TRUE,0,,accuracy,,,,,,,,,,,,,,,superglue-rte,cls/nli,,,Dagan et al. 2005; Bar-Haim et al. 2006 Giampiccolo et al. 2007; Bentivogli et al. 2009
+anli,,NLI,cls,sentence pair,knowledge modest inference,"todo: fix split; In addition to accuracy, paper also evaluates on range of relaxed/strict and matched/unmatched settings and reports F scores for different answers",,,,,TRUE,162865,0,,TRUE,0,,accuracy,,,,,,,,,,,,,,,anli,cls/nli,,https://arxiv.org/abs/1910.14599,Nie et al. 2020
+hans,,NLI,cls,sentence pair,syntax?,,,,,,TRUE,0,0,,TRUE,0,,accuracy,,,,,,,,,,,,,,,,,,https://arxiv.org/pdf/1902.01007.pdf,McCoy et al. 2019
+glue,mrpc,paraphrase,cls,,paraphrase,semi-novel generalization,,2,,,TRUE,3668,0,TRUE,TRUE,3668,,accuracy;f1_score_with_invalid,,,,,,,,,,,,,,,glue-mrpc,cls/paraphrase,,https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/I05-50025B15D.pdf,Dolan and Brockett 2005
+glue,qqp,paraphrase,cls,,,revisit: have similar prompts to NLI,,2,,,TRUE,363846,0,TRUE,,363846,,,,,,,,,,,,,,,,,glue-qqp,cls/paraphrase,,,(link)
+paws,labeled_final,paraphrase,cls,,,revisit: have similar prompts to NLI,,2,,,,49401,0,TRUE,,49401,,,,,,,,,,,,,,,,,paws,cls/paraphrase,,,Zhang et al. 2019
+kilt_tasks,nq,QA_closed_book,gen,,trivia,revisit: to be replaced by KILT,GPT,,TRUE,,TRUE,87925,0,,TRUE,0,,accuracy,TRUE,,,,,,,,,,,,intensive,,Natural Questions (open domain),,,,
+trivia_qa,rc,QA_closed_book,gen,,,,GPT,,,,TRUE,138384,0,TRUE,,138384,,,,,,,,,,,,,,,intensive,,Trivia QA,,,,
+web_questions,,QA_closed_book,gen,,,"""supposed to be answerable by Freebase"" Check corpora deduplication with freebaseqa.",GPT,,,,TRUE,3778,0,TRUE,,3778,,,,,,,,,,,,,,,intensive,,web questions,qa/closed-book qa,,,Berant et al. 2013
+adversarial_qa,dbidaf,QA_extractive,ext,,,,,1,TRUE,TRUE,,10000,10000,TRUE,,10000,,,,,,,,,,,,,,,,,adversarialqa,qa/machine reading comprehension,,https://aclanthology.org/2020.tacl-1.43/,Bartolo et al. 2020
+adversarial_qa,dbert,QA_extractive,ext,,,,,1,TRUE,TRUE,,10000,10000,TRUE,,10000,,,,,,,,,,,,,,,,,,,,,
+adversarial_qa,droberta,QA_extractive,ext,,,,,1,TRUE,TRUE,,10000,10000,TRUE,,10000,,,,,,,,,,,,,,,,,,,,,
+ropes,,QA_extractive,ext,,cause_and_effect;nontrivial_comprehension,,,1,TRUE,TRUE,,10924,10924,TRUE,,10924,,,,,,,,,,,,,,,modest,,ropes,Extractive QA,,,Lin et al. 2019
+squad_v2,,QA_extractive,ext,,,,GPT,,,,TRUE,130319,0,TRUE,,130319,,,,,,,,,,,,,,,,,SQuAD 2.0,Extractive QA,,,Rajpurkar et al. 2018
+qa_srl,,QA_extractive,ext,,semantic role,"need non-naive metric (""If the predicted word is contained inside the annotated answer span it is considered a correct prediction.""); v2 not in HF https://aclanthology.org/P18-1191.pdf",,,,,TRUE,6414,0,TRUE,TRUE,6414,,accuracy,,,,,,,,,,,,,neutral,,qa srl,other,,https://dada.cs.washington.edu/qasrl/#page-top,He et al. 2015
+ai2_arc,ARC-Challenge,QA_multiple_choice,cls,,nontrivial_comprehension,revisit: closed-book/open-domain?,GPT,,,,TRUE,1119,0,TRUE,,1119,,,,,,,,,,,,,,,mid-intensive,,ARC (chal.),qa/multiple-choice qa,,https://www.semanticscholar.org/paper/Think-you-have-Solved-Question-Answering-Try-ARC%2C-Clark-Cowhey/88bb0a28bb58d847183ec505dda89b63771bb495,Clark et al. 2018
+ai2_arc,ARC-Easy,QA_multiple_choice,cls,,,,GPT,,,,TRUE,2251,0,TRUE,,2251,,,,,,,,,,,,,,,mid-intensive,,ARC (easy),Multiple choice,,,
+cos_e,v1.11,QA_multiple_choice,cls,,,"same as commonsense_qa but with (poorly sourced) human explanations; questionable ""commonsense"" lots of world knowledge",Vania,1,TRUE,TRUE,,9741,9741,TRUE,,9741,,,,,,,,,,,,,,,,,cos e,other/generate explanation,,,Rajani et al. 2019
+cosmos_qa,,QA_multiple_choice,cls,,,,,1,TRUE,TRUE,,25262,25262,TRUE,,25262,,,,,,,,,,,,,,,,,cosmos qa,qa/multiple-choice qa,,,Huang et al. 2019
+dream,,QA_multiple_choice,cls,,,,,1,TRUE,TRUE,,6116,6116,TRUE,,6116,,,,,,,,,,,,,,,,,dream,qa/multiple-choice qa,,,Sun et al. 2019
+openbookqa,main,QA_multiple_choice,cls,,pragmatics,interesting combo of pragmatics + scientific reasoning,GPT,,,,TRUE,4957,0,TRUE,TRUE,4957,,accuracy,,,,,,,,,,,,,modest,,openbookqa,qa/multiple-choice qa,,https://aclanthology.org/D18-1260.pdf,Mihaylov et al. 2018
+qasc,,QA_multiple_choice,cls,,,,,1,TRUE,TRUE,,8134,8134,TRUE,,8134,,,,,,,,,,,,,,,given?,,qasc,qa/multiple-choice qa,,,Khot et al. 2020
+quail,,QA_multiple_choice,cls,,,,,1,wait for PR,TRUE,,10246,10246,TRUE,,10246,,,,,,,,,,,,,,,,,quail,qa/multiple-choice qa,,,Rogers et al. 2020
+quartz,,QA_multiple_choice,cls,,,,,1,TRUE,TRUE,,2696,2696,TRUE,,2696,,,,,,,,,,,,,,,given?,,quartz-with knowledge,qa/multiple-choice qa,,https://aclanthology.org/D19-1608.pdf,Tafjord et al. 2019b
+race,high,QA_multiple_choice,cls,,knowledge-neutral reading comprehension,GPT-hard,GPT,,,,TRUE,62445,0,TRUE,TRUE,62445,,accuracy,,,,,,,,,,,,,neutral,,race-high,qa/multiple-choice qa,,,Lai et al. 2017
+race,middle,QA_multiple_choice,cls,,knowledge-neutral reading comprehension,"revisit: define as comprehension, paragraph level?",GPT,,,,TRUE,25421,0,TRUE,TRUE,25421,,accuracy,,,,,,,,,,,,,neutral,,race-middle,qa/multiple-choice qa,,,Lai et al. 2017
+sciq,,QA_multiple_choice,cls,,,,,1,https://github.com/bigscience-workshop/promptsource/pull/388,TRUE,,11679,11679,TRUE,,11679,,,,,,,,,,,,,,,,,sciq,qa/multiple-choice qa,,,Welbl et al. 2017
+social_i_qa,,QA_multiple_choice,cls,,cultural knowledge,metric differ by prompt: 4-way classification cast as binary ,,1,TRUE,TRUE,TRUE,33410,33410,TRUE,TRUE,33410,,accuracy,,,,,,,,,,,,,,,SIQA,qa/multiple-choice qa,,https://arxiv.org/pdf/1904.09728.pdf,Sap et al. 2019
+super_glue,copa,QA_multiple_choice,cls,,causal cognition,,,,,,TRUE,400,0,TRUE,TRUE,400,,accuracy,,,,,,,,,,,,,modest,,superglue-copa,qa/multiple-choice qa,,,Gordon et al. 2012
+super_glue,boolq,QA_multiple_choice,cls,,knowledge-? reading comprehension,,,,,,TRUE,9427,0,TRUE,TRUE,9427,,accuracy,,,,,,,,,,,,,neutral?,,superglue-boolq,,,,
+super_glue,multirc,QA_multiple_choice,cls,,knowledge-? reading comprehension,F1 over all answer options. See paper p. 259 for defintion,,,,,TRUE,27243,0,TRUE,TRUE,27243,,multirc_f1_over_all_answers;exact_match,,,,,,,,,,,,,neutral?,,superglue-multirc,qa/multiple-choice qa,,https://aclanthology.org/N18-1023.pdf,Khashabi et al. 2018
+wiki_hop,original,QA_multiple_choice,cls,,,,,1,TRUE,TRUE,,43738,43738,TRUE,,43738,,,,,,,,,,,,,,,,,WikiHop (Welbl et al. 2018),multi-hop QA,Wikipedia KB,https://transacl.org/ojs/index.php/tacl/article/viewFile/1325/299,
+wiqa,,QA_multiple_choice,cls,,cause_and_effect,,,1,wait for PR,TRUE,,29808,29808,TRUE,,29808,,,,,,,,,,,,,,,,,wiqa,qa/multiple-choice qa,,,Tandon et al. 2019
+super_glue,record,QA_multiple_choice,ext,,knowledge-? reading comprehension,revisit: QA or coref?,,3,,,TRUE,100730,0,TRUE,TRUE,100730,per_example,squad,,,,,,,,,,,,,,,superglue-record,qa/machine reading comprehension,,,Zhang et al. 2018
+circa,,QA_multiple_choice,cls,,pragmatics,revisit: problematic prompts,,3,,,TRUE,34268,0,,TRUE,0,,mean_multiclass_f1;accuracy,,,,,,,,,,,,,,,circa,cls/other,,https://arxiv.org/pdf/2010.03450.pdf,Louis et al. 2020
+mc_taco,,QA_multiple_choice,cls,,temporal cognition,revisit: variable number of answer_chocies; eval in paper is over set of possible candidates;,,3,,,TRUE,0,0,,TRUE,0,,accuracy,,,,,,,,,,,,,,,mc taco,qa/binary,,https://arxiv.org/pdf/1909.03065.pdf,Zhou et al. 2019
+piqa,,QA_multiple_choice,cls,,physical_cognition,revisit: not just other,GPT,3,,,TRUE,16113,0,TRUE,,16113,,,,,,,,,,,,,,,,,PIQA,Multiple choice,,,Bisk et al. 2020
+amazon_polarity,,sentiment,cls,,,,,1,TRUE,TRUE,,3600000,500000,TRUE,,500000,,,,,,,,,,,,,,,,,amazon polarity,cls/sentiment analysis,,https://cs.stanford.edu/people/jure/pubs/reviews-recsys13.pdf,McAuley and Leskovec 2013
+app_reviews,,sentiment,cls,,,,,1,TRUE,TRUE,,288065,288065,TRUE,,288065,,,,,,,,,,,,,,,,,app reviews,other/regression,,,Missing
+imdb,,sentiment,cls,,,,,1,wait for PR,TRUE,,25000,25000,TRUE,,25000,,,,,,,,,,,,,,,,,imdb,cls/sentiment analysis,,,Maas et al. 2011
+rotten_tomatoes,,sentiment,cls,,,,,1,TRUE,TRUE,,8530,8530,TRUE,,8530,,,,,,,,,,,,,,,,,rotten tomatoes,cls/sentiment analysis,,,Pang and Lee 2005
+yelp_review_full,,sentiment,cls,,,no dev set,,1,TRUE,TRUE,,650000,500000,TRUE,,500000,,,,,,,,,,,,,,,,,yelp review full,other/regression,,,Zhang et al. 2015; (link)
+lambada,,story_completion,gen,,,revisit: story or cloze or coref? trivial cloze prompt; training set is just unlabeled corpora; GPT task,GPT,2,,,TRUE,0,0,,TRUE,0,,,,,,,,,,,,,,,,,,,,,
+storycloze,,story_completion,cls,,,todo: not in HF datasets; swag like?,GPT,2,,,TRUE,,0,,TRUE,0,,,,,,,,,,,,,,,,,,,,,
+hellaswag,,story_completion,cls,,,,GPT,2,,,TRUE,39905,0,TRUE,,39905,,,,,,,,,,,,,,,,,hellaswag,qa/multiple-choice qa,,,Zellers et al. 2019
+common_gen,,structure_to_text,gen,,,,,1,TRUE,TRUE,,67389,67389,TRUE,,67389,,,,,,,,,,,,,,,,,common gen,other,,,Lin et al. 2020b
+wiki_bio,,structure_to_text,gen,,,,,1,https://github.com/bigscience-workshop/promptsource/pull/388,TRUE,,582659,500000,TRUE,,500000,,,,,,,,,,,,,,,,,wiki bio,cg/other,,,Lebret et al. 2016
+cnn_dailymail,3.0.0,summarization,gen,,,,,2,TRUE,TRUE,,287113,287113,TRUE,,287113,,,,,,,,,,,,,,,,,,,,,
+gigaword,,summarization,gen,,,,,2,TRUE,TRUE,,3803957,500000,TRUE,,500000,,,,,,,,,,,,,,,,,gigaword,cg/summarization,,,Napoles et al. 2012
+xsum,,summarization,gen,,,,,2,TRUE,TRUE,TRUE,204045,204045,TRUE,TRUE,204045,,rouge,,,,,,,,,,,,,,,xsum,cg/summarization,,https://arxiv.org/pdf/1808.08745.pdf,Narayan et al. 2018
+ag_news,,topic_classification,cls,,,,,1,TRUE,TRUE,,120000,120000,TRUE,,120000,,,,,,,,,,,,,,,,,ag news,cls/topic,,http://groups.di.unipi.it/~gulli/AG_corpus_of_news_articles.html,Gulli (link)
+dbpedia_14,,topic_classification,cls,,,,,1,TRUE,TRUE,,560000,500000,TRUE,,500000,,,,,,,,,,,,,,,,,dbpedia 14,cls/topic,,https://svn.aksw.org/papers/2013/SWJ_DBpedia/public.pdf,Lehmann et al. 2015
+trec,,topic_classification,cls,,,,,1,TRUE,TRUE,,5452,5452,TRUE,,5452,,,,,,,,,,,,,,,,,trec,cls/other,,https://trec.nist.gov/data/qa.html,Li and Roth 2002; Hovy et al. 2001
+super_glue,wic,word_sense_disambiguation,cls,,lexical_knowledge,,,,,,TRUE,5428,0,TRUE,TRUE,5428,,accuracy,,,,,,,,,,,,,,,superglue-wic,cls/other,,,Pilehvar and Camacho-Collados 2019
+Staging Area,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+quac,,,,,dialogue,,GPT,,,,,,,,,,,,,,,,,,,,,,,,,,,,,https://arxiv.org/pdf/1808.07036.pdf,
+coqa,,,,,,GPT-easy,GPT,,,,,,,,,,,,,,,,,,,,,,,,,,,,,https://arxiv.org/abs/1808.07042,
+drop,,,,,numerical,"skip for early experiments: nontrivial math; try history_690, it's pretty hard even when I knew the subject",GPT,,,,,,,,,,,,,,,,,,,,,,,,,,DROP ,multi-hop quantitative reasoning; Abstractive QA,Wikipedia crowd,https://aclanthology.org/N19-1246.pdf,Dua et al. 2019
+duorc,SelfRC,,,,,skip for early experiments: dataset contains prompt-like artifacts,,,,,,60721,,,,,,,,,,,,,,,,,,,,,DuoRC,qa/machine reading comprehension,Wikipedia/IMDB crowd,https://duorc.github.io/,Saha et al. 2018
+duorc,ParaphraseRC,,,,,skip for early experiments: dataset contains prompt-like artifacts,,,,,,69524,,,,,,,,,,,,,,,,,,,,,DuoRC,paraphrased QA,,https://arxiv.org/pdf/1804.07927.pdf,Saha et al. 2018
+definite_pronoun_resolution,,coreference,,,,todo: promptsource download error,,,,,,,,,,,,,,,,,,,,,,,,,,,deﬁnite pronoun resolution,other,,,Rahman and Ng 2012
+jigsaw_toxicity_pred,,,,,,revisit:current https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge/data ; want https://www.kaggle.com/c/jigsaw-unintended-bias-in-toxicity-classification,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+crows_pairs,,,,,,revisit: authors themselves acknowledge some problems,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+winogender,,,,,,"same as above, held-out eval-only sets are not blocking",,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+winobias,,,,,,"same as above, held-out eval-only sets are not blocking",,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+commonsense_qa,,,,,,"skip for early experiments: strange annotations and questionable ""commonsense"" lots of world knowledge",Vania,,,,,9741,,,,,,,,,,,,,,,,,,,,,Commonsense QA,qa/multiple-choice qa,,https://arxiv.org/pdf/1811.00937.pdf,Talmor et al. 2019
+Multi-Turn Dialogue Reasoning,,,,,,https://aclanthology.org/2020.acl-main.130.pdf,Vania,,,,,7088,,,,,,,,,,,,,,,,,,,,,,,,,
+Argument Reasoning Comprehension Task,,,,,,https://aclanthology.org/N18-1175.pdf,Vania,,,,,1211,,,,,,,,,,,,,,,,,,,,,,,,,
+MCScript,,,,,,https://aclanthology.org/L18-1564.pdf,Vania,,,,,14191,,,,,,,,,,,,,,,,,,,,,,,,,
+swag,,story_completion,cls,,,revisit whether this should be considered as a variant of NLI,,,,,,73546,0,TRUE,,73546,,,,,,,,,,,,,,,,,swag,qa/multiple-choice qa,,,Zellers et al. 2018
+codah,codah,story_completion,cls,,,a variant of swag revisit whether this should be considered as a variant of NLI,,,,,,2776,0,TRUE,,2776,,,,,,,,,,,,,,,,,codah,qa/multiple-choice qa,,,Chen et al. 2019
+freebase_qa,,QA_closed_book,gen,,,"need to be held out because web_questions is ""supposed to be answerable by Freebase""",,1,,,,20358,0,TRUE,,20358,,,,,,,,,,,,,,,intensive,,freebase qa,qa/closed-book qa,,,Jiang et al. 2019
+emo,,sentiment,cls,,,skip: offensive and ungrammatical text,,1,merged,,,30160,0,TRUE,TRUE,30160,,precision;recall;F1,,,,,,,,,,,,,,skip: offensive and ungrammatical text,emo,cls/emotion,,https://aclanthology.org/S19-2005.pdf,Chatterjee et al. 2019
+Skipped,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+aqua_rat,,,,,nontrivial math,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: nontrivial math,aqua rat,qa/multiple-choice qa,,https://arxiv.org/abs/1705.04146,Ling et al. 2017
+math_qa,,,,,nontrivial math,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: nontrivial math,math qa,qa/multiple-choice qa,,,Amini et al. 2019
+numer_sense,,,,,numerical knowledge,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: closed-book trivia ,numer sense,qa/closed-book qa,,,Lin et al. 2020a
+squad_adversarial,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,validation set only,,,,,
+squadshifts,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,test set only,,,,,
+kilt_tasks,fever,,,,encyclopedia,revisit whether this should be considered as a variant of NLI,,,,,,,,,,,,,,,,,,,,,,,,,,temporary skip: prompts available in non-benchmark standalone dataset,kilt fever,cls/fact checking,,,Thorne et al. 2018
+kilt_tasks,hotpotqa,,,,encyclopedia; multi-hop QA,,,,,,,,,,,,,,,,,,,,,,,,,,,temporary skip: prompts available in non-benchmark standalone dataset,kilt hotpotqa,qa/closed-book qa,,,Yang et al. 2018
+sms_spam,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: unclean corpus and likely harmful content,sms spam,cls/other,,,Almeida et al. 2011
+search_qa,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: seems like a very unclean corpus,search qa,qa/closed-book qa,,,Dunn et al. 2017
+wiki_qa,,closed-book qa,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: revisit: many unfilled templates,wiki qa,cls/other,,https://aclanthology.org/D15-1237.pdf,Yang et al. 2015
+kilt_tasks,trex,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: non-natural language,kilt trex,qa/closed-book qa,,,Elsahar et al. 2018
+kilt_tasks,structured_zeroshot,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: non-natural language,kilt zsre,qa/closed-book qa,,,Levy et al. 2017
+spider,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: non-natural language,spider,cg/other,,,Yu et al. 2018
+wikisql,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: non-natural language,wikisql,cg/other,,,Zhong et al. 2017
+climate_fever,,,,,,revisit whether this should be considered as a variant of NLI,,,,,,,,,,,,,,,,,,,,,,,,,,skip: no train set,climate fever,cls/fact checking,,,Diggelmann et al. 2020
+art,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: NLI reserved for generalization studies (although this one is not a traditionally defined NLI),art (abductive nli),other,,https://arxiv.org/pdf/1908.05739.pdf,Bhagavatula et al. 2020
+glue,mnli,classification_NLI,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: NLI reserved for generalization studies,glue-mnli,cls/nli,,,Williams et al. 2018
+glue,qnli,classification_NLI,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: NLI reserved for generalization studies,glue-qnli,cls/nli,,,Rajpurkar et al. 2016
+glue,rte,classification_NLI,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: NLI reserved for generalization studies,glue-rte,cls/nli,,,Dagan et al. 2005; Bar-Haim et al. 2006 Giampiccolo et al. 2007; Bentivogli et al. 2009
+glue,wnli,classification_NLI,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: NLI reserved for generalization studies,glue-wnli,cls/nli,,,Levesque et al. 2012
+,,classification_NLI,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: NLI reserved for generalization studies,scitail,cls/nli,,,Khot et al. 2018
+,,classification_NLI,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: NLI reserved for generalization studies,sick,cls/nli,,,Marelli et al. 2014
+,,classification_NLI,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: NLI reserved for generalization studies,SNLI (Bowman et al. 2015),NLI,misc.,,
+aeslc,,,,,generation,summarization by email subject line,,,,,,,,,,,,,,,,,,,,,,,,,,skip: niche task,aeslc,cg/summarization,,https://arxiv.org/abs/1906.03497,Zhang and Tetreault 2019
+onestop_english,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: niche task: classify curriculum diffculty,onestop english,cls/other,,https://aclanthology.org/W18-0535.pdf,Vajjala and Luˇci´c 2018
+mocha,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: model generated text,mocha,other/regression,,,Chen et al. 2020a
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: maybe harmful content from Twitter,emotion,cls/emotion,,,Saravia et al. 2018
+eli5,,,,,possibly knowledge-neutral,train_askh,,,,,,,,,,,,,,,,,,,,,,,,,,skip: HF datasets error the split field is used for subsets,eli5-askh,qa/long-form qa,,https://facebookresearch.github.io/ELI5/explore.html,Fan et al. 2019
+eli5,,,,,possibly knowledge-neutral,train_asks,,,,,,,,,,,,,,,,,,,,,,,,,,skip: HF datasets error the split field is used for subsets,eli5-asks,qa/long-form qa,,,Fan et al. 2019
+eli5,,,,,possibly knowledge-neutral,train_eli5,,,,,,,,,,,,,,,,,,,,,,,,,,skip: HF datasets error the split field is used for subsets,eli5-eli5,qa/long-form qa,,,Fan et al. 2019
+samsum,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: HF datasets error,samsum,cg/summarization,,,Gliwa et al. 2019
+,,,,,,the authors themselves seem to have renounced their own work,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,crows pairs,other,,https://github.com/nyu-mll/crows-pairs,Nangia et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,ethos-directed vs generalized,cls/hate speech detection,,,Mollas et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,ethos-disability,cls/hate speech detection,,,Mollas et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,ethos-gender,cls/hate speech detection,,,Mollas et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,ethos-national origin,cls/hate speech detection,,,Mollas et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,ethos-race,cls/hate speech detection,,,Mollas et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,ethos-religion,cls/hate speech detection,,,Mollas et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,ethos-sexual orientation,cls/hate speech detection,,,Mollas et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,hate speech offensive,cls/hate speech detection,,,Davidson et al. 2017
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,hate speech18,cls/hate speech detection,,,de Gibert et al. 2018
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,hatexplain,cls/hate speech detection,,,Mathew et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,reddit tifu-title,cg/summarization,,,Kim et al. 2019
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,reddit tifu-tldr,cg/summarization,,,Kim et al. 2019
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,tweet eval-emoji,cls/emotion,,,Barbieri et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,tweet eval-emotion,cls/emotion,,,Barbieri et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,tweet eval-hate,cls/emotion,,,Barbieri et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,tweet eval-irony,cls/emotion,,,Barbieri et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,tweet eval-offensive,cls/emotion,,,Barbieri et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,tweet eval-sentiment,cls/emotion,,,Barbieri et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,tweet eval-stance abortion,cls/emotion,,,Barbieri et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,tweet eval-stance atheism,cls/emotion,,,Barbieri et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,tweet eval-stance climate,cls/emotion,,,Barbieri et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,tweet eval-stance feminist,cls/emotion,,,Barbieri et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,tweet eval-stance hillary,cls/emotion,,,Barbieri et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,tweet qa,qa/machine reading comprehension,,,Xiong et al. 2019
+yelp_polarity,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: duplicate with yelp_review_full,yelp polarity,cls/sentiment analysis,,,Zhang et al. 2015; (link)
+quora,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: duplicate under GLUE,QQP,paraphrase identiﬁcation,social QA,https://quoradata.quora.com/First-Quora-Dataset-Release-Question-Pairs,Iyer et al. 2017
+squad,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: duplicate under Squad 2.0,SQuAD 1.1,Extractive QA,,,
+fever,v2.0,closed-book qa/fact checking,,,,also in KILT,,,,,,,,,,,,,,,,,,,,,,,,,,skip: awkward prompts as closed-book qa,FEVER,,,,
+hotpot_qa,distractor,,,,,also in KILT,,,,,,,,,,,,,,,,,,,,,,,,,,skip for experiment D3: very long input sequence,Hotpot QA,,,,
+hotpot_qa,fullwiki,,,,,also in KILT,,,,,,,,,,,,,,,,,,,,,,,,,,skip for experiment D3: very long input sequence,Hotpot QA,,,,
+narrativeqa,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for experiment D3: very long input sequence,NarQA,Abstractive QA,,,
+yahoo_answers_topics,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: unclean corpus,yahoo answers topics,cls/topic,,,(link)
+tab_fact,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: tabular data,tab fact,cls/fact checking,,,Chen et al. 2020b
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: revisit if we want to include a large number of ungrammatical sentences in our training data,blimp-anaphor gender agreement,other/linguistic phenomenon,,,Warstadt et al. 2020
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: revisit if we want to include a large number of ungrammatical sentences in our training data,blimp-anaphor number agreement,other/linguistic phenomenon,,,Warstadt et al. 2020
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: revisit if we want to include a large number of ungrammatical sentences in our training data,blimp-determiner noun agreement with adj irregular 1,other/linguistic phenomenon,,,Warstadt et al. 2020
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: revisit if we want to include a large number of ungrammatical sentences in our training data,blimp-ellipsis n bar 1,other/linguistic phenomenon,,,Warstadt et al. 2020
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: revisit if we want to include a large number of ungrammatical sentences in our training data,blimp-ellipsis n bar 2,other/linguistic phenomenon,,,Warstadt et al. 2020
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: revisit if we want to include a large number of ungrammatical sentences in our training data,blimp-existential there quantiﬁers 1,other/linguistic phenomenon,,,Warstadt et al. 2020
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: revisit if we want to include a large number of ungrammatical sentences in our training data,blimp-irregular past participle adjectives,other/linguistic phenomenon,,,Warstadt et al. 2020
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: revisit if we want to include a large number of ungrammatical sentences in our training data,blimp-sentential negation npi licensor present,other/linguistic phenomenon,,,Warstadt et al. 2020
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: revisit if we want to include a large number of ungrammatical sentences in our training data,blimp-sentential negation npi scope,other/linguistic phenomenon,,,Warstadt et al. 2020
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: revisit if we want to include a large number of ungrammatical sentences in our training data,blimp-wh questions object gap,other/linguistic phenomenon,,,Warstadt et al. 2020
+poem_sentiment,,,,,creativity,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: poetry domain,poem sentiment,cls/sentiment analysis,,,Sheng and Uthus 2020
+acronym_identification,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: niche/hard task,acronym identiﬁcation,other,,https://arxiv.org/pdf/2010.14678.pdf,Pouran Ben Veyseh et al. 2020
+google_wellformed_query,,,,,,revisit whether to exclude fine-grain regression tasks,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: niche/hard task,google wellformed query,cls/other,,,Faruqui and Das 2018
+liar,,,,,,revisit whether to exclude fine-grain regression tasks,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: niche/hard task,liar,cls/fact checking,,,Wang 2017
+,,,,,semantic representation,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: niche/hard task,break-QDMR-high-level,other,,,Wolfson et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: niche/hard task,crawl domain,other,,,Zhang et al. 2020
+discovery,discovery,,,,generative-ish,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: niche task no cannonical answer,discovery,cls/other,,,Sileo et al. 2019
+wiki_split,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: niche task,wiki split,cg/other,,,Botha et al. 2018
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: multilingual,aslg pc12,other,,,Othman and Jemni 2012
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: input token/span classification less straightforward for a generative LM,CCG (Hockenmaier and Steedman 2007),CCG supertagging,Penn Treebank,,
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: input token/span classification less straightforward for a generative LM,Chunk (Tjong Kim Sang and Buchholz 2000),syntactic chunking,Penn Treebank,,
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: input token/span classification less straightforward for a generative LM,Conj (Ficler and Goldberg 2016),conjunct identiﬁcation,Penn Treebank,,
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: input token/span classification less straightforward for a generative LM,GED (Yannakoudakis et al. 2011),grammatical error detection,misc.,,
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: input token/span classification less straightforward for a generative LM,GGParent (Liu et al. 2019a),syntactic tagging,Penn Treebank,,
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: input token/span classification less straightforward for a generative LM,GParent (Liu et al. 2019a),syntactic tagging,Penn Treebank,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: input token/span classification less straightforward for a generative LM,NER (Tjong Kim Sang and De Meulder 2003),named entity recognition,news,,
+,,,,,syntax; constituency,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: input token/span classification less straightforward for a generative LM,Parent (Liu et al. 2019a),syntactic tagging,Penn Treebank,,
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: input token/span classification less straightforward for a generative LM,POS-EWT (Silveira et al. 2014),part-of-speech tagging,Web Treebank,,
+,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: input token/span classification less straightforward for a generative LM,POS-PTB (Marcus et al. 1993),part-of-speech tagging,Penn Treebank,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: input token/span classification less straightforward for a generative LM,ST (Bjerva et al. 2016),semantic tagging,Groningen Meaning Bank,,
+financial_phrasebank,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: financial domain,ﬁnancial phrasebank,cls/sentiment analysis,,,Malo et al. 2014
+health_fact,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: biomedical domain,health fact,cls/fact checking,,,Kotonya and Toni 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: biomedical domain,ade corpus v2-classiﬁcation,cls/other,,http://www.sciencedirect.com/science/article/pii/S1532046412000615,Gurulingappa et al. 2012
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: biomedical domain,ade corpus v2-dosage,other/slot ﬁlling,,,Gurulingappa et al. 2012
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: biomedical domain,ade corpus v2-effect,other/slot ﬁlling,,,Gurulingappa et al. 2012
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: biomedical domain,biomrc,qa/machine reading comprehension,,,Pappas et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: biomedical domain,medical questions pairs,cls/paraphrase,,,McCreery et al. 2020
+scicite,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: academic domain + niche/hard task,scicite,cls/other,,,Cohan et al. 2019
+,,,,,logical form,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: abstract semantic representations,break-QDMR,other,,,Wolfson et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: abstract semantic representations,e2e nlg cleaned,other,,,Duˇsek et al. 2020 2019
+glue,sst2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,revisit: very short and often ill-formed movie reviews,glue-sst2,cls/sentiment analysis,,,Socher et al. 2013
+glue,stsb,fine-grain regression,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,revisit whether to exclude fine-grain regression tasks,glue-stsb,semantic similarity,misc.,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,promptsource ImportError,Natural Questions,,,,
+jeopardy,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,promptsource download error,jeopardy,qa/closed-book qa,,,(link)
+newsqa,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,promptsource download error,NewsQA,Extractive QA,,,Trischler et al. 2017
+com_qa,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,ComQA (Abujabal et al. 2019),factoid QA w/ paraphrases,snippets WikiAnswers,https://arxiv.org/pdf/1809.09528.pdf,
+empathetic_dialogues,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,empathetic dialogues,cg/dialogue,,https://arxiv.org/pdf/1811.00207.pdf,Rashkin et al. 2019
+kilt_tasks,aidayago2,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,kilt ay2,other/entity linking,,,Hoffart et al. 2011
+kilt_tasks,nq,,,,encyclopedia; abstractive QA,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,kilt nq,qa/closed-book qa,,,Kwiatkowski et al. 2019
+kilt_tasks,wow,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,kilt wow,cg/dialogue,,,Dinan et al. 2019
+lama,conceptnet,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,lama-conceptnet,qa/closed-book qa,,,Petroni et al. 2019 2020
+lama,google_re,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,lama-google re,qa/closed-book qa,,,Petroni et al. 2019 2020
+lama,squad,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,lama-squad,qa/closed-book qa,,,Petroni et al. 2019 2020
+lama,trex,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,lama-trex,qa/closed-book qa,,,Petroni et al. 2019 2020
+multi_news,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,multi news,cg/summarization,,,Fabbri et al. 2019
+proto_qa,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,proto qa,other,,,Boratko et al. 2020
+quarel,,,,,logical form,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,quarel,qa/multiple-choice qa,,,Tafjord et al. 2019a
+wiki_auto,,,,,text simplification,revisit: lots of duplicate simplified text,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,wiki auto,cls/other,,,Jiang et al. 2020
+limit,,physical cognition,,,physical semantic repr.,,,,,,,,,,,,,,,,,,,,,,,,,,,label errors in dataset itself? also no validation set otherwise well motivated by semantic theories,limit,other,,https://aclanthology.org/2020.findings-emnlp.88.pdf,Manotas et al. 2020
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,double check: subset missing from HF datasets,squad-no context,qa/closed-book qa,,,Rajpurkar et al. 2016
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,double check: subset missing from HF datasets,squad-with context,qa/machine reading comprehension,,,Rajpurkar et al. 2016
+,,,,,,contrast sets,,,,,,,,,,,,,,,,,,,,,,,,,,double check: missing from HF datasets,BoolQ-CS,Binary yes/no,,https://arxiv.org/pdf/2004.02709.pdf,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,double check: missing from HF datasets,CQ (Bao et al. 2016),knowledge-based QA,snippets web queries/KB,https://aclanthology.org/C16-1236.pdf,
+,,,,,,contrast sets,,,,,,,,,,,,,,,,,,,,,,,,,,double check: missing from HF datasets,DROP-CS,Abstractive QA,,https://arxiv.org/pdf/2004.02709.pdf,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,double check: missing from HF datasets,MCTest,Multiple choice,,https://aclanthology.org/D13-1020.pdf,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,double check: missing from HF datasets,MRPC (Dolan and Brockett 2005),paraphrase identiﬁcation,news,,
+,,,,,,"""naturally perturbed"" version of BoolQ",,,,,,,,,,,,,,,,,,,,,,,,,,double check: missing from HF datasets,NP-BoolQ,Binary yes/no,,https://arxiv.org/pdf/2004.04849.pdf,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,double check: missing from HF datasets,quartz-no knowledge,qa/multiple-choice qa,,https://aclanthology.org/D19-1608.pdf,Tafjord et al. 2019b
+,,,,,,contrast sets,,,,,,,,,,,,,,,,,,,,,,,,,,double check: missing from HF datasets,Quoref-CS,Extractive QA,,https://arxiv.org/pdf/2004.02709.pdf,
+,,,,,,contrast sets,,,,,,,,,,,,,,,,,,,,,,,,,,double check: missing from HF datasets,ROPES-CS,Extractive QA,,https://arxiv.org/pdf/2004.02709.pdf,

--- a/promptsource/seqio_tasks/experiment_D4.csv
+++ b/promptsource/seqio_tasks/experiment_D4.csv
@@ -5,10 +5,10 @@ super_glue,wsc.fixed,coreference,cls,single sentence,knowledge-? reading compreh
 winograd_wsc,,coreference,ext,,,todo: which subset? add to hackaprompt,GPT,,,,TRUE,,0,,,0,,,,,,,,,,,,,,,,,,,,,
 winogrande,,coreference,ext,,knowledge-? reading comprehension,todo: which HF subsets map to which subsets in the paper?,GPT,,,,TRUE,,0,,,0,,accuracy,,,,,,,,,,,,,,,WinoGrande,qa/multiple-choice qa,,https://arxiv.org/pdf/1907.10641.pdf,Sakaguchi et al. 2020
 glue,cola,grammatical_acceptability,cls,single sentence,,includes semantic acceptability too; to be replaced by blimp,,,,,TRUE,8551,0,,TRUE,0,,matthews_corrcoef,,,,,,,,,,,,,,,glue-cola,cls/other,,https://arxiv.org/pdf/1805.12471.pdf,Warstadt et al. 2019
-blimp,,grammatical_acceptability,cls,,,todo: no prompts yet; collapse subsets,,,,,TRUE,,0,,,0,,,,,,,,,,,,,,,,,,,,,
+blimp,,grammatical_acceptability,cls,,,no prompts yet; collapse subsets,,,,,TRUE,,0,,,0,,,,,,,,,,,,,,,,,,,,,
 super_glue,cb,NLI,cls,sentence pair,knowledge-neutral inference,"""for multi-class F1 we compute the unweighted average of the F1 per class.""",,,,,TRUE,250,0,,TRUE,0,,mean_multiclass_f1;accuracy,,,,,,,,,,,,,,,superglue-cb,cls/nli,,https://semanticsarchive.net/Archive/Tg3ZGI2M/Marneffe.pdf,de Marneffe et al. 2019
 super_glue,rte,NLI,cls,sentence pair,knowledge modest inference,,,,,,TRUE,2490,0,,TRUE,0,,accuracy,,,,,,,,,,,,,,,superglue-rte,cls/nli,,,Dagan et al. 2005; Bar-Haim et al. 2006 Giampiccolo et al. 2007; Bentivogli et al. 2009
-anli,,NLI,cls,sentence pair,knowledge modest inference,"todo: fix split; In addition to accuracy, paper also evaluates on range of relaxed/strict and matched/unmatched settings and reports F scores for different answers",,,,,TRUE,162865,0,,TRUE,0,,accuracy,,,,,,,,,,,,,,,anli,cls/nli,,https://arxiv.org/abs/1910.14599,Nie et al. 2020
+anli,,NLI,cls,sentence pair,knowledge modest inference,"In addition to accuracy, paper also evaluates on range of relaxed/strict and matched/unmatched settings and reports F scores for different answers",,,,,TRUE,162865,0,,TRUE,0,,accuracy,,,,,,,,,,,,,,,anli,cls/nli,,https://arxiv.org/abs/1910.14599,Nie et al. 2020
 hans,,NLI,cls,sentence pair,syntax?,,,,,,TRUE,0,0,,TRUE,0,,accuracy,,,,,,,,,,,,,,,,,,https://arxiv.org/pdf/1902.01007.pdf,McCoy et al. 2019
 glue,mrpc,paraphrase,cls,,paraphrase,semi-novel generalization,,2,,,TRUE,3668,0,TRUE,TRUE,3668,,accuracy;f1_score_with_invalid,,,,,,,,,,,,,,,glue-mrpc,cls/paraphrase,,https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/I05-50025B15D.pdf,Dolan and Brockett 2005
 glue,qqp,paraphrase,cls,,,revisit: have similar prompts to NLI,,2,,,TRUE,363846,0,TRUE,,363846,,,,,,,,,,,,,,,,,glue-qqp,cls/paraphrase,,,(link)
@@ -33,27 +33,27 @@ quail,,QA_multiple_choice,cls,,,,,1,wait for PR,TRUE,,10246,10246,TRUE,,10246,,,
 quartz,,QA_multiple_choice,cls,,,,,1,TRUE,TRUE,,2696,2696,TRUE,,2696,,,,,,,,,,,,,,,given?,,quartz-with knowledge,qa/multiple-choice qa,,https://aclanthology.org/D19-1608.pdf,Tafjord et al. 2019b
 race,high,QA_multiple_choice,cls,,knowledge-neutral reading comprehension,GPT-hard,GPT,,,,TRUE,62445,0,TRUE,TRUE,62445,,accuracy,,,,,,,,,,,,,neutral,,race-high,qa/multiple-choice qa,,,Lai et al. 2017
 race,middle,QA_multiple_choice,cls,,knowledge-neutral reading comprehension,"revisit: define as comprehension, paragraph level?",GPT,,,,TRUE,25421,0,TRUE,TRUE,25421,,accuracy,,,,,,,,,,,,,neutral,,race-middle,qa/multiple-choice qa,,,Lai et al. 2017
-sciq,,QA_multiple_choice,cls,,,,,1,https://github.com/bigscience-workshop/promptsource/pull/388,TRUE,,11679,11679,TRUE,,11679,,,,,,,,,,,,,,,,,sciq,qa/multiple-choice qa,,,Welbl et al. 2017
+sciq,,QA_multiple_choice,cls,,,,,1,TRUE,TRUE,,11679,11679,TRUE,,11679,,,,,,,,,,,,,,,,,sciq,qa/multiple-choice qa,,,Welbl et al. 2017
 social_i_qa,,QA_multiple_choice,cls,,cultural knowledge,metric differ by prompt: 4-way classification cast as binary ,,1,TRUE,TRUE,TRUE,33410,33410,TRUE,TRUE,33410,,accuracy,,,,,,,,,,,,,,,SIQA,qa/multiple-choice qa,,https://arxiv.org/pdf/1904.09728.pdf,Sap et al. 2019
 super_glue,copa,QA_multiple_choice,cls,,causal cognition,,,,,,TRUE,400,0,TRUE,TRUE,400,,accuracy,,,,,,,,,,,,,modest,,superglue-copa,qa/multiple-choice qa,,,Gordon et al. 2012
 super_glue,boolq,QA_multiple_choice,cls,,knowledge-? reading comprehension,,,,,,TRUE,9427,0,TRUE,TRUE,9427,,accuracy,,,,,,,,,,,,,neutral?,,superglue-boolq,,,,
 super_glue,multirc,QA_multiple_choice,cls,,knowledge-? reading comprehension,F1 over all answer options. See paper p. 259 for defintion,,,,,TRUE,27243,0,TRUE,TRUE,27243,,multirc_f1_over_all_answers;exact_match,,,,,,,,,,,,,neutral?,,superglue-multirc,qa/multiple-choice qa,,https://aclanthology.org/N18-1023.pdf,Khashabi et al. 2018
 wiki_hop,original,QA_multiple_choice,cls,,,,,1,TRUE,TRUE,,43738,43738,TRUE,,43738,,,,,,,,,,,,,,,,,WikiHop (Welbl et al. 2018),multi-hop QA,Wikipedia KB,https://transacl.org/ojs/index.php/tacl/article/viewFile/1325/299,
-wiqa,,QA_multiple_choice,cls,,cause_and_effect,,,1,wait for PR,TRUE,,29808,29808,TRUE,,29808,,,,,,,,,,,,,,,,,wiqa,qa/multiple-choice qa,,,Tandon et al. 2019
+wiqa,,QA_multiple_choice,cls,,cause_and_effect,,,1,TRUE,TRUE,,29808,29808,TRUE,,29808,,,,,,,,,,,,,,,,,wiqa,qa/multiple-choice qa,,,Tandon et al. 2019
 super_glue,record,QA_multiple_choice,ext,,knowledge-? reading comprehension,revisit: QA or coref?,,3,,,TRUE,100730,0,TRUE,TRUE,100730,per_example,squad,,,,,,,,,,,,,,,superglue-record,qa/machine reading comprehension,,,Zhang et al. 2018
 circa,,QA_multiple_choice,cls,,pragmatics,revisit: problematic prompts,,3,,,TRUE,34268,0,,TRUE,0,,mean_multiclass_f1;accuracy,,,,,,,,,,,,,,,circa,cls/other,,https://arxiv.org/pdf/2010.03450.pdf,Louis et al. 2020
 mc_taco,,QA_multiple_choice,cls,,temporal cognition,revisit: variable number of answer_chocies; eval in paper is over set of possible candidates;,,3,,,TRUE,0,0,,TRUE,0,,accuracy,,,,,,,,,,,,,,,mc taco,qa/binary,,https://arxiv.org/pdf/1909.03065.pdf,Zhou et al. 2019
 piqa,,QA_multiple_choice,cls,,physical_cognition,revisit: not just other,GPT,3,,,TRUE,16113,0,TRUE,,16113,,,,,,,,,,,,,,,,,PIQA,Multiple choice,,,Bisk et al. 2020
 amazon_polarity,,sentiment,cls,,,,,1,TRUE,TRUE,,3600000,500000,TRUE,,500000,,,,,,,,,,,,,,,,,amazon polarity,cls/sentiment analysis,,https://cs.stanford.edu/people/jure/pubs/reviews-recsys13.pdf,McAuley and Leskovec 2013
 app_reviews,,sentiment,cls,,,,,1,TRUE,TRUE,,288065,288065,TRUE,,288065,,,,,,,,,,,,,,,,,app reviews,other/regression,,,Missing
-imdb,,sentiment,cls,,,,,1,wait for PR,TRUE,,25000,25000,TRUE,,25000,,,,,,,,,,,,,,,,,imdb,cls/sentiment analysis,,,Maas et al. 2011
+imdb,,sentiment,cls,,no dev set,,,1,https://github.com/bigscience-workshop/promptsource/pull/409#pullrequestreview-752157471,TRUE,,25000,25000,TRUE,,25000,,,,,,,,,,,,,,,,,imdb,cls/sentiment analysis,,,Maas et al. 2011
 rotten_tomatoes,,sentiment,cls,,,,,1,TRUE,TRUE,,8530,8530,TRUE,,8530,,,,,,,,,,,,,,,,,rotten tomatoes,cls/sentiment analysis,,,Pang and Lee 2005
 yelp_review_full,,sentiment,cls,,,no dev set,,1,TRUE,TRUE,,650000,500000,TRUE,,500000,,,,,,,,,,,,,,,,,yelp review full,other/regression,,,Zhang et al. 2015; (link)
 lambada,,story_completion,gen,,,revisit: story or cloze or coref? trivial cloze prompt; training set is just unlabeled corpora; GPT task,GPT,2,,,TRUE,0,0,,TRUE,0,,,,,,,,,,,,,,,,,,,,,
-storycloze,,story_completion,cls,,,todo: not in HF datasets; swag like?,GPT,2,,,TRUE,,0,,TRUE,0,,,,,,,,,,,,,,,,,,,,,
+storycloze,,story_completion,cls,,,todo: not in HF datasets; swag like?,GPT,2,,,,,0,,TRUE,0,,,,,,,,,,,,,,,,,,,,,
 hellaswag,,story_completion,cls,,,,GPT,2,,,TRUE,39905,0,TRUE,,39905,,,,,,,,,,,,,,,,,hellaswag,qa/multiple-choice qa,,,Zellers et al. 2019
 common_gen,,structure_to_text,gen,,,,,1,TRUE,TRUE,,67389,67389,TRUE,,67389,,,,,,,,,,,,,,,,,common gen,other,,,Lin et al. 2020b
-wiki_bio,,structure_to_text,gen,,,,,1,https://github.com/bigscience-workshop/promptsource/pull/388,TRUE,,582659,500000,TRUE,,500000,,,,,,,,,,,,,,,,,wiki bio,cg/other,,,Lebret et al. 2016
+wiki_bio,,structure_to_text,gen,,,,,1,TRUE,TRUE,,582659,500000,TRUE,,500000,,,,,,,,,,,,,,,,,wiki bio,cg/other,,,Lebret et al. 2016
 cnn_dailymail,3.0.0,summarization,gen,,,,,2,TRUE,TRUE,,287113,287113,TRUE,,287113,,,,,,,,,,,,,,,,,,,,,
 gigaword,,summarization,gen,,,,,2,TRUE,TRUE,,3803957,500000,TRUE,,500000,,,,,,,,,,,,,,,,,gigaword,cg/summarization,,,Napoles et al. 2012
 xsum,,summarization,gen,,,,,2,TRUE,TRUE,TRUE,204045,204045,TRUE,TRUE,204045,,rouge,,,,,,,,,,,,,,,xsum,cg/summarization,,https://arxiv.org/pdf/1808.08745.pdf,Narayan et al. 2018
@@ -62,9 +62,9 @@ dbpedia_14,,topic_classification,cls,,,,,1,TRUE,TRUE,,560000,500000,TRUE,,500000
 trec,,topic_classification,cls,,,,,1,TRUE,TRUE,,5452,5452,TRUE,,5452,,,,,,,,,,,,,,,,,trec,cls/other,,https://trec.nist.gov/data/qa.html,Li and Roth 2002; Hovy et al. 2001
 super_glue,wic,word_sense_disambiguation,cls,,lexical_knowledge,,,,,,TRUE,5428,0,TRUE,TRUE,5428,,accuracy,,,,,,,,,,,,,,,superglue-wic,cls/other,,,Pilehvar and Camacho-Collados 2019
 Staging Area,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-quac,,,,,dialogue,,GPT,,,,,,,,,,,,,,,,,,,,,,,,,,,,,https://arxiv.org/pdf/1808.07036.pdf,
-coqa,,,,,,GPT-easy,GPT,,,,,,,,,,,,,,,,,,,,,,,,,,,,,https://arxiv.org/abs/1808.07042,
-drop,,,,,numerical,"skip for early experiments: nontrivial math; try history_690, it's pretty hard even when I knew the subject",GPT,,,,,,,,,,,,,,,,,,,,,,,,,,DROP ,multi-hop quantitative reasoning; Abstractive QA,Wikipedia crowd,https://aclanthology.org/N19-1246.pdf,Dua et al. 2019
+quac,,,,,dialogue,,GPT,,,,TRUE,,,,,,,,,,,,,,,,,,,,,,,,,https://arxiv.org/pdf/1808.07036.pdf,
+coqa,,,,,,GPT-easy,GPT,,,,TRUE,,,,,,,,,,,,,,,,,,,,,,,,,https://arxiv.org/abs/1808.07042,
+drop,,,,,numerical,"skip for early experiments: nontrivial math; try history_690, it's pretty hard even when I knew the subject",GPT,,,,TRUE,,,,,,,,,,,,,,,,,,,,,,DROP ,multi-hop quantitative reasoning; Abstractive QA,Wikipedia crowd,https://aclanthology.org/N19-1246.pdf,Dua et al. 2019
 duorc,SelfRC,,,,,skip for early experiments: dataset contains prompt-like artifacts,,,,,,60721,,,,,,,,,,,,,,,,,,,,,DuoRC,qa/machine reading comprehension,Wikipedia/IMDB crowd,https://duorc.github.io/,Saha et al. 2018
 duorc,ParaphraseRC,,,,,skip for early experiments: dataset contains prompt-like artifacts,,,,,,69524,,,,,,,,,,,,,,,,,,,,,DuoRC,paraphrased QA,,https://arxiv.org/pdf/1804.07927.pdf,Saha et al. 2018
 definite_pronoun_resolution,,coreference,,,,todo: promptsource download error,,,,,,,,,,,,,,,,,,,,,,,,,,,deﬁnite pronoun resolution,other,,,Rahman and Ng 2012
@@ -79,15 +79,37 @@ MCScript,,,,,,https://aclanthology.org/L18-1564.pdf,Vania,,,,,14191,,,,,,,,,,,,,
 swag,,story_completion,cls,,,revisit whether this should be considered as a variant of NLI,,,,,,73546,0,TRUE,,73546,,,,,,,,,,,,,,,,,swag,qa/multiple-choice qa,,,Zellers et al. 2018
 codah,codah,story_completion,cls,,,a variant of swag revisit whether this should be considered as a variant of NLI,,,,,,2776,0,TRUE,,2776,,,,,,,,,,,,,,,,,codah,qa/multiple-choice qa,,,Chen et al. 2019
 freebase_qa,,QA_closed_book,gen,,,"need to be held out because web_questions is ""supposed to be answerable by Freebase""",,1,,,,20358,0,TRUE,,20358,,,,,,,,,,,,,,,intensive,,freebase qa,qa/closed-book qa,,,Jiang et al. 2019
-emo,,sentiment,cls,,,skip: offensive and ungrammatical text,,1,merged,,,30160,0,TRUE,TRUE,30160,,precision;recall;F1,,,,,,,,,,,,,,skip: offensive and ungrammatical text,emo,cls/emotion,,https://aclanthology.org/S19-2005.pdf,Chatterjee et al. 2019
+fever,v2.0,closed-book qa/fact checking,,,,also in KILT,,,,,,,,,,,,,,,,,,,,,,,,,,skip: awkward prompts as closed-book qa,FEVER,,,,
+hotpot_qa,distractor,,,,,also in KILT,,,,,,,,,,,,,,,,,,,,,,,,,,skip for experiment D3: very long input sequence,Hotpot QA,,,,
+hotpot_qa,fullwiki,,,,,also in KILT,,,,,,,,,,,,,,,,,,,,,,,,,,skip for experiment D3: very long input sequence,Hotpot QA,,,,
+narrativeqa,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for experiment D3: very long input sequence,NarQA,Abstractive QA,,,
+eli5,,,,,possibly knowledge-neutral,train_askh,,,,,,,,,,,,,,,,,,,,,,,,,,skip: HF datasets error the split field is used for subsets,eli5-askh,qa/long-form qa,,https://facebookresearch.github.io/ELI5/explore.html,Fan et al. 2019
+eli5,,,,,possibly knowledge-neutral,train_asks,,,,,,,,,,,,,,,,,,,,,,,,,,skip: HF datasets error the split field is used for subsets,eli5-asks,qa/long-form qa,,,Fan et al. 2019
+eli5,,,,,possibly knowledge-neutral,train_eli5,,,,,,,,,,,,,,,,,,,,,,,,,,skip: HF datasets error the split field is used for subsets,eli5-eli5,qa/long-form qa,,,Fan et al. 2019
+samsum,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: HF datasets error,samsum,cg/summarization,,,Gliwa et al. 2019
+jeopardy,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,promptsource download error,jeopardy,qa/closed-book qa,,,(link)
+newsqa,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,promptsource download error,NewsQA,Extractive QA,,,Trischler et al. 2017
+empathetic_dialogues,,,,,,,CrossFit,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,empathetic dialogues,cg/dialogue,,https://arxiv.org/pdf/1811.00207.pdf,Rashkin et al. 2019
+multi_news,,,,,,,CrossFit,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,multi news,cg/summarization,,,Fabbri et al. 2019
+proto_qa,,,,,,,CrossFit,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,proto qa,other,,,Boratko et al. 2020
+quarel,,,,,logical form,,CrossFit,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,quarel,qa/multiple-choice qa,,,Tafjord et al. 2019a
+wiki_auto,,,,,text simplification,revisit: lots of duplicate simplified text,CrossFit,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,wiki auto,cls/other,,,Jiang et al. 2020
+kilt_tasks,aidayago2,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,kilt ay2,other/entity linking,,,Hoffart et al. 2011
+kilt_tasks,wow,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,kilt wow,cg/dialogue,,,Dinan et al. 2019
+lama,conceptnet,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,lama-conceptnet,qa/closed-book qa,,,Petroni et al. 2019 2020
+lama,google_re,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,lama-google re,qa/closed-book qa,,,Petroni et al. 2019 2020
+lama,squad,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,lama-squad,qa/closed-book qa,,,Petroni et al. 2019 2020
+lama,trex,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,lama-trex,qa/closed-book qa,,,Petroni et al. 2019 2020
+limit,,physical cognition,,,physical semantic repr.,,,,,,,,,,,,,,,,,,,,,,,,,,,label errors in dataset itself? also no validation set otherwise well motivated by semantic theories,limit,other,,https://aclanthology.org/2020.findings-emnlp.88.pdf,Manotas et al. 2020
+kilt_tasks,fever,,,,encyclopedia,revisit whether this should be considered as a variant of NLI,,,,,,,,,,,,,,,,,,,,,,,,,,temporary skip: prompts available in non-benchmark standalone dataset,kilt fever,cls/fact checking,,,Thorne et al. 2018
+kilt_tasks,hotpotqa,,,,encyclopedia; multi-hop QA,,,,,,,,,,,,,,,,,,,,,,,,,,,temporary skip: prompts available in non-benchmark standalone dataset,kilt hotpotqa,qa/closed-book qa,,,Yang et al. 2018
 Skipped,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+emo,,sentiment,cls,,,skip: offensive and ungrammatical text,,1,merged,,,30160,0,TRUE,TRUE,30160,,precision;recall;F1,,,,,,,,,,,,,,skip: offensive and ungrammatical text,emo,cls/emotion,,https://aclanthology.org/S19-2005.pdf,Chatterjee et al. 2019
 aqua_rat,,,,,nontrivial math,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: nontrivial math,aqua rat,qa/multiple-choice qa,,https://arxiv.org/abs/1705.04146,Ling et al. 2017
 math_qa,,,,,nontrivial math,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: nontrivial math,math qa,qa/multiple-choice qa,,,Amini et al. 2019
 numer_sense,,,,,numerical knowledge,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: closed-book trivia ,numer sense,qa/closed-book qa,,,Lin et al. 2020a
 squad_adversarial,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,validation set only,,,,,
 squadshifts,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,test set only,,,,,
-kilt_tasks,fever,,,,encyclopedia,revisit whether this should be considered as a variant of NLI,,,,,,,,,,,,,,,,,,,,,,,,,,temporary skip: prompts available in non-benchmark standalone dataset,kilt fever,cls/fact checking,,,Thorne et al. 2018
-kilt_tasks,hotpotqa,,,,encyclopedia; multi-hop QA,,,,,,,,,,,,,,,,,,,,,,,,,,,temporary skip: prompts available in non-benchmark standalone dataset,kilt hotpotqa,qa/closed-book qa,,,Yang et al. 2018
 sms_spam,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: unclean corpus and likely harmful content,sms spam,cls/other,,,Almeida et al. 2011
 search_qa,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: seems like a very unclean corpus,search qa,qa/closed-book qa,,,Dunn et al. 2017
 wiki_qa,,closed-book qa,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: revisit: many unfilled templates,wiki qa,cls/other,,https://aclanthology.org/D15-1237.pdf,Yang et al. 2015
@@ -95,6 +117,7 @@ kilt_tasks,trex,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: non-natural lang
 kilt_tasks,structured_zeroshot,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: non-natural language,kilt zsre,qa/closed-book qa,,,Levy et al. 2017
 spider,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: non-natural language,spider,cg/other,,,Yu et al. 2018
 wikisql,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: non-natural language,wikisql,cg/other,,,Zhong et al. 2017
+com_qa,,,,,,,CrossFit,,,,,,,,,,,,,,,,,,,,,,,,,skip: non-human language: URL,ComQA (Abujabal et al. 2019),factoid QA w/ paraphrases,snippets WikiAnswers,https://arxiv.org/pdf/1809.09528.pdf,
 climate_fever,,,,,,revisit whether this should be considered as a variant of NLI,,,,,,,,,,,,,,,,,,,,,,,,,,skip: no train set,climate fever,cls/fact checking,,,Diggelmann et al. 2020
 art,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: NLI reserved for generalization studies (although this one is not a traditionally defined NLI),art (abductive nli),other,,https://arxiv.org/pdf/1908.05739.pdf,Bhagavatula et al. 2020
 glue,mnli,classification_NLI,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: NLI reserved for generalization studies,glue-mnli,cls/nli,,,Williams et al. 2018
@@ -108,10 +131,6 @@ aeslc,,,,,generation,summarization by email subject line,,,,,,,,,,,,,,,,,,,,,,,,
 onestop_english,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: niche task: classify curriculum diffculty,onestop english,cls/other,,https://aclanthology.org/W18-0535.pdf,Vajjala and Luˇci´c 2018
 mocha,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: model generated text,mocha,other/regression,,,Chen et al. 2020a
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: maybe harmful content from Twitter,emotion,cls/emotion,,,Saravia et al. 2018
-eli5,,,,,possibly knowledge-neutral,train_askh,,,,,,,,,,,,,,,,,,,,,,,,,,skip: HF datasets error the split field is used for subsets,eli5-askh,qa/long-form qa,,https://facebookresearch.github.io/ELI5/explore.html,Fan et al. 2019
-eli5,,,,,possibly knowledge-neutral,train_asks,,,,,,,,,,,,,,,,,,,,,,,,,,skip: HF datasets error the split field is used for subsets,eli5-asks,qa/long-form qa,,,Fan et al. 2019
-eli5,,,,,possibly knowledge-neutral,train_eli5,,,,,,,,,,,,,,,,,,,,,,,,,,skip: HF datasets error the split field is used for subsets,eli5-eli5,qa/long-form qa,,,Fan et al. 2019
-samsum,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: HF datasets error,samsum,cg/summarization,,,Gliwa et al. 2019
 ,,,,,,the authors themselves seem to have renounced their own work,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,crows pairs,other,,https://github.com/nyu-mll/crows-pairs,Nangia et al. 2020
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,ethos-directed vs generalized,cls/hate speech detection,,,Mollas et al. 2020
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: harmful content,ethos-disability,cls/hate speech detection,,,Mollas et al. 2020
@@ -140,10 +159,6 @@ samsum,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: HF datasets error,samsum,cg/summariz
 yelp_polarity,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: duplicate with yelp_review_full,yelp polarity,cls/sentiment analysis,,,Zhang et al. 2015; (link)
 quora,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: duplicate under GLUE,QQP,paraphrase identiﬁcation,social QA,https://quoradata.quora.com/First-Quora-Dataset-Release-Question-Pairs,Iyer et al. 2017
 squad,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip: duplicate under Squad 2.0,SQuAD 1.1,Extractive QA,,,
-fever,v2.0,closed-book qa/fact checking,,,,also in KILT,,,,,,,,,,,,,,,,,,,,,,,,,,skip: awkward prompts as closed-book qa,FEVER,,,,
-hotpot_qa,distractor,,,,,also in KILT,,,,,,,,,,,,,,,,,,,,,,,,,,skip for experiment D3: very long input sequence,Hotpot QA,,,,
-hotpot_qa,fullwiki,,,,,also in KILT,,,,,,,,,,,,,,,,,,,,,,,,,,skip for experiment D3: very long input sequence,Hotpot QA,,,,
-narrativeqa,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for experiment D3: very long input sequence,NarQA,Abstractive QA,,,
 yahoo_answers_topics,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: unclean corpus,yahoo answers topics,cls/topic,,,(link)
 tab_fact,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: tabular data,tab fact,cls/fact checking,,,Chen et al. 2020b
 ,,,,,syntax,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: revisit if we want to include a large number of ungrammatical sentences in our training data,blimp-anaphor gender agreement,other/linguistic phenomenon,,,Warstadt et al. 2020
@@ -188,23 +203,6 @@ scicite,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: academic doma
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,skip for early experiments: abstract semantic representations,e2e nlg cleaned,other,,,Duˇsek et al. 2020 2019
 glue,sst2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,revisit: very short and often ill-formed movie reviews,glue-sst2,cls/sentiment analysis,,,Socher et al. 2013
 glue,stsb,fine-grain regression,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,revisit whether to exclude fine-grain regression tasks,glue-stsb,semantic similarity,misc.,,
-,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,promptsource ImportError,Natural Questions,,,,
-jeopardy,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,promptsource download error,jeopardy,qa/closed-book qa,,,(link)
-newsqa,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,promptsource download error,NewsQA,Extractive QA,,,Trischler et al. 2017
-com_qa,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,ComQA (Abujabal et al. 2019),factoid QA w/ paraphrases,snippets WikiAnswers,https://arxiv.org/pdf/1809.09528.pdf,
-empathetic_dialogues,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,empathetic dialogues,cg/dialogue,,https://arxiv.org/pdf/1811.00207.pdf,Rashkin et al. 2019
-kilt_tasks,aidayago2,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,kilt ay2,other/entity linking,,,Hoffart et al. 2011
-kilt_tasks,nq,,,,encyclopedia; abstractive QA,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,kilt nq,qa/closed-book qa,,,Kwiatkowski et al. 2019
-kilt_tasks,wow,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,kilt wow,cg/dialogue,,,Dinan et al. 2019
-lama,conceptnet,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,lama-conceptnet,qa/closed-book qa,,,Petroni et al. 2019 2020
-lama,google_re,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,lama-google re,qa/closed-book qa,,,Petroni et al. 2019 2020
-lama,squad,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,lama-squad,qa/closed-book qa,,,Petroni et al. 2019 2020
-lama,trex,,,,encyclopedia,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,lama-trex,qa/closed-book qa,,,Petroni et al. 2019 2020
-multi_news,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,multi news,cg/summarization,,,Fabbri et al. 2019
-proto_qa,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,proto qa,other,,,Boratko et al. 2020
-quarel,,,,,logical form,,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,quarel,qa/multiple-choice qa,,,Tafjord et al. 2019a
-wiki_auto,,,,,text simplification,revisit: lots of duplicate simplified text,,,,,,,,,,,,,,,,,,,,,,,,,,no prompt yet,wiki auto,cls/other,,,Jiang et al. 2020
-limit,,physical cognition,,,physical semantic repr.,,,,,,,,,,,,,,,,,,,,,,,,,,,label errors in dataset itself? also no validation set otherwise well motivated by semantic theories,limit,other,,https://aclanthology.org/2020.findings-emnlp.88.pdf,Manotas et al. 2020
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,double check: subset missing from HF datasets,squad-no context,qa/closed-book qa,,,Rajpurkar et al. 2016
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,double check: subset missing from HF datasets,squad-with context,qa/machine reading comprehension,,,Rajpurkar et al. 2016
 ,,,,,,contrast sets,,,,,,,,,,,,,,,,,,,,,,,,,,double check: missing from HF datasets,BoolQ-CS,Binary yes/no,,https://arxiv.org/pdf/2004.02709.pdf,

--- a/promptsource/seqio_tasks/preview_annotated_prompts.py
+++ b/promptsource/seqio_tasks/preview_annotated_prompts.py
@@ -48,7 +48,7 @@ def exclude_bad_prompts(prompt: Dict) -> bool:
 
 
 def load_annotated_prompts() -> List[Dict]:
-    annotated_csv_path = pkg_resources.resource_filename(__name__, "dataset_subset_template.csv")
+    annotated_csv_path = pkg_resources.resource_filename(__name__, "experiment_D3.csv")
     with open(annotated_csv_path) as in_file:
         reader = csv.DictReader(in_file)
         all_tasks = [row for row in reader]

--- a/promptsource/seqio_tasks/preview_promptsource.py
+++ b/promptsource/seqio_tasks/preview_promptsource.py
@@ -1,0 +1,78 @@
+import csv
+from typing import Dict, List
+import pkg_resources
+
+from rich import inspect
+from rich.pretty import pprint
+# from t5.data.glue_utils import get_glue_metric, get_super_glue_metric
+# from t5.evaluation.metrics import accuracy, mean_multiclass_f1, rouge
+
+from promptsource.templates import TemplateCollection
+
+
+# NON_GLUE_METRICS = {  # for those with do_eval = True
+#     "anli": [accuracy],
+#     "hans": [accuracy],
+#     "circa_goldstandard1_judgement": [mean_multiclass_f1(num_classes=8), accuracy],
+#     "circa_goldstandard2_judgement": [mean_multiclass_f1(num_classes=5), accuracy],
+#     "mc_taco": [accuracy],
+#     "nq_open": [accuracy],
+#     "qa_srl": [accuracy],
+#     "openbookqa": [accuracy],
+#     "race": [accuracy],
+#     "social_i_qa": [accuracy],
+#     "emo": [mean_multiclass_f1(num_classes=4)],
+#     "xsum": [rouge],
+# }
+
+
+def preview() -> None:
+    experiment_path = pkg_resources.resource_filename(__name__, "experiment_D4.csv")
+
+    train_sets = []
+    eval_sets = []
+    train_set_names = []
+    eval_set_names = []
+    with open(experiment_path) as exp_file:
+        reader = csv.DictReader(exp_file)
+        for row in reader:
+            if row['skip']:
+                continue
+            if row['subset'] == '':
+                row['subset'] = None  # to match promptsource.Template object
+            if row['do_train'] == 'TRUE':
+                train_sets.append(row)
+                train_set_names.append((row['HF_name'], row['subset']))
+            if row['do_eval'] == 'TRUE':
+                eval_sets.append(row)
+                eval_set_names.append((row['HF_name'], row['subset']))
+
+        # print(f'Number of non-desk-rejected datasets = {len(all_datasets)}')
+
+    D4_names = train_set_names + eval_set_names
+    print(f'Number of training sets = {len(train_sets)}')
+    print(f'Number of evaluation sets = {len(eval_sets)}')
+
+    template_collection = TemplateCollection()
+    for dataset_name, subset in template_collection.keys:
+        if (dataset_name, subset) not in train_set_names:  # D4_names:
+            continue
+        OG = 0
+        non_OG = 0
+        dataset = template_collection.get_dataset(dataset_name, subset)
+        for template_name in dataset.all_template_names:
+            template = dataset[template_name]
+            # if dataset_name == 'ropes':
+            #     inspect(template.metadata)
+            if template.metadata.original_task is True:
+                OG += 1
+            elif template.metadata.original_task is False:
+                non_OG += 1
+            elif template.metadata.original_task is None:
+                print(dataset_name, 'has not flagged original tasks')
+                continue
+        print(dataset_name, subset, OG, non_OG)
+
+
+if __name__ == "__main__":
+    preview()

--- a/promptsource/seqio_tasks/preview_promptsource.py
+++ b/promptsource/seqio_tasks/preview_promptsource.py
@@ -1,8 +1,8 @@
 import csv
 from re import template
 from typing import Dict, List
-import pkg_resources
 
+import pkg_resources
 from rich import inspect
 from rich.pretty import pprint
 from t5.data.glue_utils import get_glue_metric, get_super_glue_metric

--- a/promptsource/seqio_tasks/preview_promptsource.py
+++ b/promptsource/seqio_tasks/preview_promptsource.py
@@ -1,29 +1,30 @@
 import csv
+from re import template
 from typing import Dict, List
 import pkg_resources
 
 from rich import inspect
 from rich.pretty import pprint
-# from t5.data.glue_utils import get_glue_metric, get_super_glue_metric
-# from t5.evaluation.metrics import accuracy, mean_multiclass_f1, rouge
+from t5.data.glue_utils import get_glue_metric, get_super_glue_metric
+from t5.evaluation.metrics import accuracy, mean_multiclass_f1, rouge
 
 from promptsource.templates import TemplateCollection
 
 
-# NON_GLUE_METRICS = {  # for those with do_eval = True
-#     "anli": [accuracy],
-#     "hans": [accuracy],
-#     "circa_goldstandard1_judgement": [mean_multiclass_f1(num_classes=8), accuracy],
-#     "circa_goldstandard2_judgement": [mean_multiclass_f1(num_classes=5), accuracy],
-#     "mc_taco": [accuracy],
-#     "nq_open": [accuracy],
-#     "qa_srl": [accuracy],
-#     "openbookqa": [accuracy],
-#     "race": [accuracy],
-#     "social_i_qa": [accuracy],
-#     "emo": [mean_multiclass_f1(num_classes=4)],
-#     "xsum": [rouge],
-# }
+NON_GLUE_METRICS = {  # for those with do_eval = True
+    "anli": [accuracy],
+    "hans": [accuracy],
+    "circa_goldstandard1_judgement": [mean_multiclass_f1(num_classes=8), accuracy],
+    "circa_goldstandard2_judgement": [mean_multiclass_f1(num_classes=5), accuracy],
+    "mc_taco": [accuracy],
+    "nq_open": [accuracy],
+    "qa_srl": [accuracy],
+    "openbookqa": [accuracy],
+    "race": [accuracy],
+    "social_i_qa": [accuracy],
+    "emo": [mean_multiclass_f1(num_classes=4)],
+    "xsum": [rouge],
+}
 
 
 def preview() -> None:
@@ -54,24 +55,27 @@ def preview() -> None:
     print(f'Number of evaluation sets = {len(eval_sets)}')
 
     template_collection = TemplateCollection()
-    for dataset_name, subset in template_collection.keys:
-        if (dataset_name, subset) not in train_set_names:  # D4_names:
+    print(type(template_collection))
+    for dataset_name, subset_name in template_collection.keys:
+        if (dataset_name, subset_name) not in train_set_names:  # D4_names:
+            template_collection.remove(dataset_name, subset_name)
             continue
         OG = 0
         non_OG = 0
-        dataset = template_collection.get_dataset(dataset_name, subset)
+        dataset = template_collection.get_dataset(dataset_name, subset_name)
         for template_name in dataset.all_template_names:
             template = dataset[template_name]
             # if dataset_name == 'ropes':
             #     inspect(template.metadata)
-            if template.metadata.original_task is True:
-                OG += 1
-            elif template.metadata.original_task is False:
-                non_OG += 1
-            elif template.metadata.original_task is None:
-                print(dataset_name, 'has not flagged original tasks')
-                continue
-        print(dataset_name, subset, OG, non_OG)
+        #     if template.metadata.original_task is True:
+        #         OG += 1
+        #     elif template.metadata.original_task is False:
+        #         non_OG += 1
+        #     elif template.metadata.original_task is None:
+        #         print(dataset_name, 'has not flagged original tasks')
+        #         continue
+        # print(dataset_name, subset_name, OG, non_OG)
+    print(len(template_collection))
 
 
 if __name__ == "__main__":

--- a/promptsource/seqio_tasks/preview_promptsource.py
+++ b/promptsource/seqio_tasks/preview_promptsource.py
@@ -1,39 +1,22 @@
 import csv
-from re import template
-from typing import Dict, List
+from typing import List, Tuple, Optional
 
 import pkg_resources
-from rich import inspect
-from rich.pretty import pprint
-from t5.data.glue_utils import get_glue_metric, get_super_glue_metric
-from t5.evaluation.metrics import accuracy, mean_multiclass_f1, rouge
 
 from promptsource.templates import TemplateCollection
 
 
-NON_GLUE_METRICS = {  # for those with do_eval = True
-    "anli": [accuracy],
-    "hans": [accuracy],
-    "circa_goldstandard1_judgement": [mean_multiclass_f1(num_classes=8), accuracy],
-    "circa_goldstandard2_judgement": [mean_multiclass_f1(num_classes=5), accuracy],
-    "mc_taco": [accuracy],
-    "nq_open": [accuracy],
-    "qa_srl": [accuracy],
-    "openbookqa": [accuracy],
-    "race": [accuracy],
-    "social_i_qa": [accuracy],
-    "emo": [mean_multiclass_f1(num_classes=4)],
-    "xsum": [rouge],
-}
+# from rich import inspect
+from rich.pretty import pprint
 
 
 def preview() -> None:
     experiment_path = pkg_resources.resource_filename(__name__, "experiment_D4.csv")
-
-    train_sets = []
-    eval_sets = []
-    train_set_names = []
-    eval_set_names = []
+    d4_train: List[Tuple[str, Optional[str]]] = []
+    d4_eval: List[Tuple[str, Optional[str]]] = []
+    d3_train_gpt: List[Tuple[str, Optional[str]]] = []
+    d3_train_sglue: List[Tuple[str, Optional[str]]] = []
+    experiment_path = pkg_resources.resource_filename(__name__, "experiment_D4.csv")
     with open(experiment_path) as exp_file:
         reader = csv.DictReader(exp_file)
         for row in reader:
@@ -41,23 +24,25 @@ def preview() -> None:
                 continue
             if row["subset"] == "":
                 row["subset"] = None  # to match promptsource.Template object
+            dataset_subset = (row["HF_name"], row["subset"])
             if row["do_train"] == "TRUE":
-                train_sets.append(row)
-                train_set_names.append((row["HF_name"], row["subset"]))
+                d4_train.append(dataset_subset)
             if row["do_eval"] == "TRUE":
-                eval_sets.append(row)
-                eval_set_names.append((row["HF_name"], row["subset"]))
+                d4_eval.append(dataset_subset)
+            if row["D3_do_train"] == "TRUE" and 'GPT' in row["seed_paper"]:
+                d3_train_gpt.append(dataset_subset)
+            if row["D3_do_train"] == "TRUE" and row["HF_name"] == 'super_glue':
+                d3_train_sglue.append(dataset_subset)
+    all_datasets = d4_train + d4_eval + d3_train_gpt + d3_train_sglue
+    print(f'Number of non-desk-rejected datasets = {len(all_datasets)}')
 
-        # print(f'Number of non-desk-rejected datasets = {len(all_datasets)}')
-
-    D4_names = train_set_names + eval_set_names
-    print(f"Number of training sets = {len(train_sets)}")
-    print(f"Number of evaluation sets = {len(eval_sets)}")
+    # print(f"Number of training sets = {len(train_sets)}")
+    # print(f"Number of evaluation sets = {len(eval_sets)}")
 
     template_collection = TemplateCollection()
-    print(type(template_collection))
+    missing_og_flags = []
     for dataset_name, subset_name in template_collection.keys:
-        if (dataset_name, subset_name) not in train_set_names:  # D4_names:
+        if (dataset_name, subset_name) not in d4_train:
             template_collection.remove(dataset_name, subset_name)
             continue
         OG = 0
@@ -67,15 +52,28 @@ def preview() -> None:
             template = dataset[template_name]
             # if dataset_name == 'ropes':
             #     inspect(template.metadata)
-        #     if template.metadata.original_task is True:
-        #         OG += 1
-        #     elif template.metadata.original_task is False:
-        #         non_OG += 1
-        #     elif template.metadata.original_task is None:
-        #         print(dataset_name, 'has not flagged original tasks')
-        #         continue
-        # print(dataset_name, subset_name, OG, non_OG)
+            if template.metadata.original_task is True:
+                OG += 1
+            elif template.metadata.original_task is False:
+                non_OG += 1
+            elif template.metadata.original_task is None:
+                missing_og_flags.append(dataset_name + subset_name + template_name)
+                continue
+        print(dataset_name, subset_name, OG, non_OG, sep='\t\t')
     print(len(template_collection))
+
+    print('Missing original task flags:')
+    pprint(missing_og_flags)
+
+
+    # # print(d4_train_mixture)
+    # print(f"Number of training templates = {len(d4_train_mixture)}")
+    # # print(d4_eval_mixture)
+    # print(f"Number of evaluation templates = {len(d4_eval_mixture)}")
+    # # for i in seqio.TaskRegistry.names():
+    # #     print(i)
+    # print(f"Number of SeqIO registered templates = {len(seqio.TaskRegistry.names())}")
+    # print("^ includes non-original task templates which are excluded from the eval mixture")
 
 
 if __name__ == "__main__":

--- a/promptsource/seqio_tasks/preview_promptsource.py
+++ b/promptsource/seqio_tasks/preview_promptsource.py
@@ -37,22 +37,22 @@ def preview() -> None:
     with open(experiment_path) as exp_file:
         reader = csv.DictReader(exp_file)
         for row in reader:
-            if row['skip']:
+            if row["skip"]:
                 continue
-            if row['subset'] == '':
-                row['subset'] = None  # to match promptsource.Template object
-            if row['do_train'] == 'TRUE':
+            if row["subset"] == "":
+                row["subset"] = None  # to match promptsource.Template object
+            if row["do_train"] == "TRUE":
                 train_sets.append(row)
-                train_set_names.append((row['HF_name'], row['subset']))
-            if row['do_eval'] == 'TRUE':
+                train_set_names.append((row["HF_name"], row["subset"]))
+            if row["do_eval"] == "TRUE":
                 eval_sets.append(row)
-                eval_set_names.append((row['HF_name'], row['subset']))
+                eval_set_names.append((row["HF_name"], row["subset"]))
 
         # print(f'Number of non-desk-rejected datasets = {len(all_datasets)}')
 
     D4_names = train_set_names + eval_set_names
-    print(f'Number of training sets = {len(train_sets)}')
-    print(f'Number of evaluation sets = {len(eval_sets)}')
+    print(f"Number of training sets = {len(train_sets)}")
+    print(f"Number of evaluation sets = {len(eval_sets)}")
 
     template_collection = TemplateCollection()
     print(type(template_collection))

--- a/promptsource/seqio_tasks/tasks.py
+++ b/promptsource/seqio_tasks/tasks.py
@@ -29,7 +29,7 @@ GET_METRICS = {
     "COQA F1": mt.coqa_f1,
     "Edit Distance": mt.edit_distance,
     # "Mean Reciprocal Rank": mt.accuracy,  # NOTE not in T5?
-    'Other': mt.accuracy,
+    "Other": mt.accuracy,
     # Missing support for mean_multiclass_f1 etc. which need a num_classes parameter
 }
 
@@ -147,30 +147,30 @@ def add_task(dataset_name, subset_name, template_name, task_name=None, split_map
 
 
 train_sets: List[Dict] = []
-eval_sets:List[Dict] = []
+eval_sets: List[Dict] = []
 do_train: List[Tuple[str, Optional[str]]] = []
 do_eval: List[Tuple[str, Optional[str]]] = []
 experiment_path = pkg_resources.resource_filename(__name__, "experiment_D4.csv")
 with open(experiment_path) as exp_file:
     reader = csv.DictReader(exp_file)
     for row in reader:
-        if row['skip']:
+        if row["skip"]:
             continue
-        if row['subset'] == '':
-            row['subset'] = None  # to match promptsource.Template object
-        if row['do_train'] == 'TRUE':
+        if row["subset"] == "":
+            row["subset"] = None  # to match promptsource.Template object
+        if row["do_train"] == "TRUE":
             train_sets.append(row)
-            do_train.append((row['HF_name'], row['subset']))
-        if row['do_eval'] == 'TRUE':
+            do_train.append((row["HF_name"], row["subset"]))
+        if row["do_eval"] == "TRUE":
             eval_sets.append(row)
-            do_eval.append((row['HF_name'], row['subset']))
+            do_eval.append((row["HF_name"], row["subset"]))
 
 train_or_eval = do_train + do_eval
-print(f'Number of training datasets = {len(train_sets)}')
-print(f'Number of evaluation datasets = {len(eval_sets)}')
+print(f"Number of training datasets = {len(train_sets)}")
+print(f"Number of evaluation datasets = {len(eval_sets)}")
 
 all_templates = promptsource.templates.TemplateCollection()
-all_templates.remove('anli')  # Need to special-case ANLI due to weird split conventions
+all_templates.remove("anli")  # Need to special-case ANLI due to weird split conventions
 train_mixture: List[str] = []  # dataset_subset_template
 eval_mixture: List[str] = []
 for dataset_name, subset_name in all_templates.keys:
@@ -206,13 +206,13 @@ for anli_round in ("r1", "r2", "r3"):
         eval_mixture.append(task_name)
 
 # print(train_mixture)
-print(f'Number of training templates = {len(train_mixture)}')
+print(f"Number of training templates = {len(train_mixture)}")
 # print(eval_mixture)
-print(f'Number of evaluation templates = {len(eval_mixture)}')
+print(f"Number of evaluation templates = {len(eval_mixture)}")
 # for i in seqio.TaskRegistry.names():
 #     print(i)
-print(f'Number of SeqIO registered templates = {len(seqio.TaskRegistry.names())}')
-print('^ includes non-original task templates which are excluded from the eval mixture')
+print(f"Number of SeqIO registered templates = {len(seqio.TaskRegistry.names())}")
+print("^ includes non-original task templates which are excluded from the eval mixture")
 # raise SystemExit
 
 

--- a/promptsource/seqio_tasks/tasks.py
+++ b/promptsource/seqio_tasks/tasks.py
@@ -281,21 +281,9 @@ seqio.MixtureRegistry.add(
     default_rate=functools.partial(seqio.mixing_rate_num_examples, maximum=500_000),
 )  # eval mixture does not need to be capped
 
-# TODO mixtures below need to be updated after new rank eval implementation
-seqio.MixtureRegistry.add(
-    "anli_eval_tasks",
-    [task for task in d4_eval_mixture if task.startswith("anli")],
-    default_rate=functools.partial(seqio.mixing_rate_num_examples, maximum=500_000),
-)
 
 seqio.MixtureRegistry.add(
-    "score_eval_tasks",
-    [task for task in seqio.TaskRegistry.names() if task.endswith("_score_eval")],
-    default_rate=functools.partial(seqio.mixing_rate_num_examples, maximum=500_000),
-)
-
-seqio.MixtureRegistry.add(
-    "clean_score_eval_tasks",
+    "d4_score_eval",
     [
         task
         for task in seqio.TaskRegistry.names()

--- a/promptsource/seqio_tasks/tasks.py
+++ b/promptsource/seqio_tasks/tasks.py
@@ -10,7 +10,7 @@ import tensorflow as tf
 
 import promptsource.templates
 
-import utils
+from . import utils
 
 
 # Tasks deemed as clean/useful

--- a/promptsource/seqio_tasks/tasks.py
+++ b/promptsource/seqio_tasks/tasks.py
@@ -197,8 +197,10 @@ for dataset_name, subset_name in all_templates.keys:
         train_size = 0
     else:
         train_size = int(train_size)
-    train_size = min(train_size, MAX_EXAMPLES_PER_DATASET)
-    cap = train_size // num_templates
+    if train_size > MAX_EXAMPLES_PER_DATASET:
+        cap = MAX_EXAMPLES_PER_DATASET // num_templates
+    else:
+        cap = train_size
     for template_name in dataset.all_template_names:
         add_task(dataset_name, subset_name, template_name)
 

--- a/promptsource/seqio_tasks/tasks.py
+++ b/promptsource/seqio_tasks/tasks.py
@@ -1,6 +1,5 @@
 import csv
 import functools
-import re
 from typing import Dict, List, Optional, Tuple
 
 import datasets

--- a/promptsource/seqio_tasks/tasks.py
+++ b/promptsource/seqio_tasks/tasks.py
@@ -1,15 +1,16 @@
+import csv
 import functools
 import re
-import csv
-import pkg_resources
-from typing import Tuple, List, Dict, Optional
+from typing import Dict, List, Optional, Tuple
 
 import datasets
+import pkg_resources
 import seqio
 import t5
 import tensorflow as tf
 from t5.data.glue_utils import get_glue_metric, get_super_glue_metric
 from t5.evaluation import metrics as mt
+
 import promptsource.templates
 from promptsource.seqio_tasks import utils
 

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -252,6 +252,12 @@ class TemplateCollection:
     def keys(self):
         return list(self.datasets_templates.keys())
 
+    def __len__(self) -> int:
+        return len(self.datasets_templates)
+
+    def remove(self, dataset_name: str, subset_name: str) -> None:
+        del self.datasets_templates[dataset_name, subset_name]
+
     def _collect_dataset(self) -> Dict[Tuple[str, str], "DatasetTemplates"]:
         """
         Initialize a DatasetTemplates object for each templates.yaml detected in the templates folder

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -255,7 +255,7 @@ class TemplateCollection:
     def __len__(self) -> int:
         return len(self.datasets_templates)
 
-    def remove(self, dataset_name: str, subset_name: str) -> None:
+    def remove(self, dataset_name: str, subset_name: Optional[str] = None) -> None:
         del self.datasets_templates[dataset_name, subset_name]
 
     def _collect_dataset(self) -> Dict[Tuple[str, str], "DatasetTemplates"]:

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     package_data={"": [
         "templates/*/*.yaml",
         "templates/*/*/*.yaml",
-        "seqio_tasks/dataset_subset_template.csv",
+        "seqio_tasks/experiment_D3.csv",  # Experiment D3
+        "seqio_tasks/experiment_D4.csv",
     ]}
 )


### PR DESCRIPTION
`seqio_tasks/tasks.py` will now read from:

1. Our master datasets [google sheet](https://docs.google.com/spreadsheets/d/1ELEM-BY5E-5Tqy34jguT91ChwAguoWfyDEN0OzOhjSk/edit#gid=1315886539) downloaded as a CSV, which marks which datasets are train or eval sets.
2. Per-template metadata from promptsource, which marks each template's metric and whether it's an original task template. To-do for @craffel: This will also enable rank eval by using either `answer_choices` or `answer_choice_keys` in template.metadata.

@VictorSanh technically this is ready to be cached:
```
seqio.MixtureRegistry.add(
    "clean_tasks",  # rename as train_mixture?
    [task for task in train_mixture if task not in TASK_BLACKLIST],
    default_rate=functools.partial(seqio.mixing_rate_num_examples, maximum=500_000),
)
```
Victor and I talked about it [on Slack](https://huggingface.slack.com/archives/C020GCD4YTV/p1631313745099900) although double checking with @craffel: Am I allowed to rename the mixture name passed to  seqio.MixtureRegistry? I'm afraid that might mess up your job commands or something. Although I might make more mixtures to allow the ablation study we discussed: Train on D4 sets, checkpoint, and then train on GPT-3 sets, checkpoint, and then finally train on SuperGLUE sets.