### PR TITLE
fix: dark mode's unreadable syntax highlight #352

### DIFF
--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -48,7 +48,9 @@ st.sidebar.title(f"Prompt sourcing 🌸 - {mode}")
 #
 # Adds pygments styles to the page.
 #
-st.markdown("<style>" + HtmlFormatter().get_style_defs(".highlight") + "</style>", unsafe_allow_html=True)
+st.markdown(
+    "<style>" + HtmlFormatter(style="friendly").get_style_defs(".highlight") + "</style>", unsafe_allow_html=True
+)
 
 WIDTH = 80
 


### PR DESCRIPTION
close: #352

There seems no way (yet) to get `theme.base` option without config.toml.
In other words, no API to know the UI setting.
Hence applying a style that may work for both light and dark modes.