### PR TITLE
fix adversarial qa for test subset which doesn't contain choices.text

### DIFF
--- a/promptsource/templates/adversarial_qa/adversarialQA/templates.yaml
+++ b/promptsource/templates/adversarial_qa/adversarialQA/templates.yaml
@@ -24,11 +24,15 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: 3b2459cc-6600-443c-abf8-8f60c34cd998
-    jinja: 'I know that the answer to the question "{{question}}" is in "{{context}}".
-      Can you tell me what it is? |||
+    jinja: '{% if metadata.split != "test" %}
+
+      I know that the answer to the question "{{question}}" is in "{{context}}". Can
+      you tell me what it is? |||
 
 
-      {{answers.text | choice}}'
+      {{answers.text | choice}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
@@ -42,7 +46,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: 5bdb1815-5c6f-49a3-ad1d-367344420701
-    jinja: 'Question: "{{question}}"
+    jinja: '{% if metadata.split != "test" %}
+
+      Question: "{{question}}"
 
 
       Context: "{{context}}"
@@ -54,8 +60,7 @@ templates:
 
       {{answers.text | choice}}
 
-
-      '
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false
@@ -69,13 +74,17 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: a0872cde-2f19-4ae6-919a-868da47bfbcb
-    jinja: 'Extract the answer to the question from the following context.
+    jinja: '{% if metadata.split != "test" %}
+
+      Extract the answer to the question from the following context.
 
       Question: {{question}}
 
       Context: {{context}}|||
 
-      {{answers.text | choice}}'
+      {{answers.text | choice}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -87,7 +96,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: a64d5a15-68e2-4d1c-b30a-ca8250c860f9
-    jinja: 'Given the following passage
+    jinja: '{% if metadata.split != "test" %}
+
+      Given the following passage
 
 
       "{{context}}",
@@ -98,7 +109,9 @@ templates:
 
       Question: {{question}} |||
 
-      {{answers.text | choice}}'
+      {{answers.text | choice}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: false

--- a/promptsource/templates/adversarial_qa/dbert/templates.yaml
+++ b/promptsource/templates/adversarial_qa/dbert/templates.yaml
@@ -24,11 +24,15 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: 3b2459cc-6600-443c-abf8-8f60c34cd99a
-    jinja: 'I know that the answer to the question "{{question}}" is in "{{context}}".
-      Can you tell me what it is? |||
+    jinja: '{% if metadata.split != "test" %}
+
+      I know that the answer to the question "{{question}}" is in "{{context}}". Can
+      you tell me what it is? |||
 
 
-      {{answers.text | choice}}'
+      {{answers.text | choice}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -42,7 +46,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: 5bdb1815-5c6f-49a3-ad1d-36734442070a
-    jinja: 'Question: "{{question}}"
+    jinja: '{% if metadata.split != "test" %}
+
+      Question: "{{question}}"
 
 
       Context: "{{context}}"
@@ -54,8 +60,7 @@ templates:
 
       {{answers.text | choice}}
 
-
-      '
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -69,13 +74,17 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: a0872cde-2f19-4ae6-919a-868da47bfbca
-    jinja: 'Extract the answer to the question from the following context.
+    jinja: '{% if metadata.split != "test" %}
+
+      Extract the answer to the question from the following context.
 
       Question: {{question}}
 
       Context: {{context}}|||
 
-      {{answers.text | choice}}'
+      {{answers.text | choice}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -89,7 +98,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: a64d5a15-68e2-4d1c-b30a-ca8250c860fa
-    jinja: 'Given the following passage
+    jinja: '{% if metadata.split != "test" %}
+
+      Given the following passage
 
 
       "{{context}}",
@@ -100,7 +111,9 @@ templates:
 
       Question: {{question}} |||
 
-      {{answers.text | choice}}'
+      {{answers.text | choice}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true

--- a/promptsource/templates/adversarial_qa/dbidaf/templates.yaml
+++ b/promptsource/templates/adversarial_qa/dbidaf/templates.yaml
@@ -5,13 +5,17 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: 41f28b31-d0fc-4f20-a0a2-ff21813e298e
-    jinja: 'Extract the answer to the question from the following context.
+    jinja: '{% if metadata.split != "test" %}
+
+      Extract the answer to the question from the following context.
 
       Question: {{question}}
 
       Context: {{context}}|||
 
-      {{answers.text | choice}}'
+      {{answers.text | choice}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -25,7 +29,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: a64d5a15-68e2-4d1c-b30a-ca8250c860d9
-    jinja: 'Given the following passage
+    jinja: '{% if metadata.split != "test" %}
+
+      Given the following passage
 
 
       "{{context}}",
@@ -36,7 +42,9 @@ templates:
 
       Question: {{question}} |||
 
-      {{answers.text | choice}}'
+      {{answers.text | choice}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -69,11 +77,15 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: ce9bc00a-567b-4c4e-aad7-df6f5d5d57bb
-    jinja: 'I know that the answer to the question "{{question}}" is in "{{context}}".
-      Can you tell me what it is? |||
+    jinja: '{% if metadata.split != "test" %}
+
+      I know that the answer to the question "{{question}}" is in "{{context}}". Can
+      you tell me what it is? |||
 
 
-      {{answers.text | choice}}'
+      {{answers.text | choice}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -87,7 +99,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: fa185424-6ebe-49b8-b4ed-7632ca33c361
-    jinja: 'Question: "{{question}}"
+    jinja: '{% if metadata.split != "test" %}
+
+      Question: "{{question}}"
 
 
       Context: "{{context}}"
@@ -99,8 +113,7 @@ templates:
 
       {{answers.text | choice}}
 
-
-      '
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true

--- a/promptsource/templates/adversarial_qa/droberta/templates.yaml
+++ b/promptsource/templates/adversarial_qa/droberta/templates.yaml
@@ -24,11 +24,15 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: 3b2459cc-6600-443c-abf8-8f60c34cd993
-    jinja: 'I know that the answer to the question "{{question}}" is in "{{context}}".
-      Can you tell me what it is? |||
+    jinja: '{% if metadata.split != "test" %}
+
+      I know that the answer to the question "{{question}}" is in "{{context}}". Can
+      you tell me what it is? |||
 
 
-      {{answers.text | choice}}'
+      {{answers.text | choice}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -42,7 +46,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: 5bdb1815-5c6f-49a3-ad1d-367344420703
-    jinja: 'Question: "{{question}}"
+    jinja: '{% if metadata.split != "test" %}
+
+      Question: "{{question}}"
 
 
       Context: "{{context}}"
@@ -54,8 +60,7 @@ templates:
 
       {{answers.text | choice}}
 
-
-      '
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -69,13 +74,17 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: a0872cde-2f19-4ae6-919a-868da47bfbc3
-    jinja: 'Extract the answer to the question from the following context.
+    jinja: '{% if metadata.split != "test" %}
+
+      Extract the answer to the question from the following context.
 
       Question: {{question}}
 
       Context: {{context}}|||
 
-      {{answers.text | choice}}'
+      {{answers.text | choice}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -89,7 +98,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: a64d5a15-68e2-4d1c-b30a-ca8250c860f3
-    jinja: 'Given the following passage
+    jinja: '{% if metadata.split != "test" %}
+
+      Given the following passage
 
 
       "{{context}}",
@@ -100,7 +111,9 @@ templates:
 
       Question: {{question}} |||
 
-      {{answers.text | choice}}'
+      {{answers.text | choice}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true


### PR DESCRIPTION
Test sets don't contain target annotations, so i wrapped the original tasks under `{% if metadata.split != "test" %} ... {% endif %}` to solve the bugs that arise when trying to access the annotations for the test sets