### PR TITLE
fix ropes for test split which doesn't contain answers.text

### DIFF
--- a/promptsource/templates/ropes/templates.yaml
+++ b/promptsource/templates/ropes/templates.yaml
@@ -4,9 +4,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: 0791ec30-6361-4e62-8dce-ca9cbf997acc
-    jinja: "Please answer correctly the following question related to the paragraph\
-      \ below. \n\n{{ question }}\n\n{{ situation }}\n\nHint: {{ background }}\n|||\n\
-      {{ answers.text | choice }}"
+    jinja: "{% if answers.text %}\nPlease answer correctly the following question\
+      \ related to the paragraph below. \n\n{{ question }}\n\n{{ situation }}\n\n\
+      Hint: {{ background }}\n|||\n{{ answers.text | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -20,9 +20,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: 0909d72d-50c7-4cbb-bec4-1f891123717c
-    jinja: "{{ situation }}\n\nGiven the paragraph above, please answer correctly\
-      \ the following question: \n\n{{ question }}\n|||\n{{ answers.text | choice\
-      \ }}"
+    jinja: "{% if answers.text %}\n{{ situation }}\n\nGiven the paragraph above, please\
+      \ answer correctly the following question: \n\n{{ question }}\n|||\n{{ answers.text\
+      \ | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -36,7 +36,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: 1e4944e7-4d5b-475c-8b04-4b523e96bc51
-    jinja: 'Background: {{ background }}
+    jinja: '{% if answers.text %}
+
+      Background: {{ background }}
 
 
       Paragraph: {{ situation }}
@@ -47,7 +49,9 @@ templates:
 
       |||
 
-      {{ answers.text | choice }}'
+      {{ answers.text | choice }}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -61,7 +65,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: 27fb16c6-a563-46ef-af73-42e15183824e
-    jinja: 'Given the background: {{background}}
+    jinja: '{% if answers.text %}
+
+      Given the background: {{background}}
 
 
       and the situation: {{situation}}
@@ -71,7 +77,7 @@ templates:
 
       {{ answers.text | choice }}
 
-      '
+      {% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -83,7 +89,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: 31faf808-80ff-47af-ac49-d2cd7a7abcaf
-    jinja: '{{ situation }}
+    jinja: '{% if answers.text %}
+
+      {{ situation }}
 
 
       {{ question }}
@@ -91,7 +99,9 @@ templates:
 
       |||
 
-      {{ answers.text | choice }}'
+      {{ answers.text | choice }}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -105,7 +115,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: 473f2c9c-9731-443c-a641-5e43770f7df6
-    jinja: '{{ situation }}
+    jinja: '{% if answers.text %}
+
+      {{ situation }}
 
 
       {{ question }}
@@ -115,7 +127,9 @@ templates:
 
       |||
 
-      {{ answers.text | choice}}'
+      {{ answers.text | choice}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -129,7 +143,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: a04f69ac-8122-4618-8426-185fc043feca
-    jinja: '{{ background }}
+    jinja: '{% if answers.text %}
+
+      {{ background }}
 
 
       {{ situation }}
@@ -139,7 +155,9 @@ templates:
 
       |||
 
-      {{ answers.text | choice }}'
+      {{ answers.text | choice }}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -153,7 +171,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: a17aefbb-c571-4127-8170-379e2ec83774
-    jinja: 'I can use this background: {{background}}
+    jinja: '{% if answers.text %}
+
+      I can use this background: {{background}}
 
 
       Now, I have a new situation: {{situation}}
@@ -163,7 +183,7 @@ templates:
 
       {{ answers.text | choice }}
 
-      '
+      {% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -175,7 +195,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: b6da4f12-5384-46f5-a74e-c703c19d1698
-    jinja: 'You are given a new situation: {{situation}}
+    jinja: '{% if answers.text %}
+
+      You are given a new situation: {{situation}}
 
 
       and a hint : {{background}}
@@ -185,7 +207,7 @@ templates:
 
       {{ answers.text | choice }}
 
-      '
+      {% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -197,7 +219,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: cc747655-6472-4023-95e4-03cb85d5a1c5
-    jinja: 'I have a new situation: {{situation}}
+    jinja: '{% if answers.text %}
+
+      I have a new situation: {{situation}}
 
 
       But I can use this background: {{background}}
@@ -207,7 +231,7 @@ templates:
 
       {{ answers.text | choice }}
 
-      '
+      {% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -219,9 +243,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: cc8f3c6b-b800-4b47-b6ec-e8febfdaad6f
-    jinja: "{{ situation }}\n\nGiven the paragraph above, please answer correctly\
-      \ the following question: \n\n{{ question }}\n\nHint: {{ background }}\n|||\n\
-      {{ answers.text | choice }}"
+    jinja: "{% if answers.text %}\n{{ situation }}\n\nGiven the paragraph above, please\
+      \ answer correctly the following question: \n\n{{ question }}\n\nHint: {{ background\
+      \ }}\n|||\n{{ answers.text | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true
@@ -235,7 +259,9 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: f62e0adb-ca74-4280-8ed3-8b53411d87ce
-    jinja: 'I read this background article the other day: {{background}}
+    jinja: '{% if answers.text %}
+
+      I read this background article the other day: {{background}}
 
 
       I am facing a new situation today: {{situation}}
@@ -246,7 +272,7 @@ templates:
 
       {{ answers.text | choice }}
 
-      '
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: false
       _do_train: true


### PR DESCRIPTION
Test sets don't contain target annotations, so i wrapped the original tasks under {% if answers.text %} ... {% endif %} to solve the bugs that arise when trying to access the annotations for the test sets.
Same as #427