### PR TITLE
Cleaning samsum

### DIFF
--- a/templates/samsum/templates.yaml
+++ b/templates/samsum/templates.yaml
@@ -1,45 +1,114 @@
 dataset: samsum
 templates:
-  3ac01292-4a54-4546-b4e6-c225ae114213: !Template
-    id: 3ac01292-4a54-4546-b4e6-c225ae114213
-    jinja: 'Summarize: {{dialogue}}|||
-
-      {{summary}}'
-    name: 'Summarize:'
-    reference: ''
-  4891a8e7-258c-41e2-80d3-0c1a054acb07: !Template
-    id: 4891a8e7-258c-41e2-80d3-0c1a054acb07
-    jinja: 'Write a dialogue. Summary: {{summary}} |||
-
-      {{dialogue}}'
-    name: Write a dialogue given summary
-    reference: ''
-  550fa161-af4e-4430-9844-ce7dad587733: !Template
-    id: 550fa161-af4e-4430-9844-ce7dad587733
+  01faf0cd-d9d8-4245-b86f-e7e13c2972ff: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: 01faf0cd-d9d8-4245-b86f-e7e13c2972ff
     jinja: 'Summarize this dialogue: {{dialogue}} |||
 
       {{summary}}'
+    metadata: !TemplateMetadata
+      _do_eval: false
+      _do_train: false
+      choices_in_prompt: false
+      metrics:
+      - ROUGE
+      original_task: true
     name: 'Summarize this dialogue:'
     reference: ''
-  5d2404b9-63ff-406e-977d-eda6afb5c689: !Template
-    id: 5d2404b9-63ff-406e-977d-eda6afb5c689
+  182a251f-2f76-4b36-8d2e-417f8d43f729: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: 182a251f-2f76-4b36-8d2e-417f8d43f729
     jinja: '{{dialogue}}
 
-      ===
-
-      Generate a summary for this dialogue:
-
-      |||{{summary}}'
-    name: Generate a summary for this dialogue
-    reference: ''
-  a96094e1-d477-4610-b2a3-643b89a0a72a: !Template
-    id: a96094e1-d477-4610-b2a3-643b89a0a72a
-    jinja: '{{dialogue}}
-
-      ===
-
-      Given the above dialogue, write a summary. Summary: |||
+      Given the above dialogue, write a summary. |||
 
       {{summary}}'
-    name: Write a summary
+    metadata: !TemplateMetadata
+      _do_eval: false
+      _do_train: false
+      choices_in_prompt: false
+      metrics:
+      - ROUGE
+      original_task: true
+    name: Given the above dialogue write a summary
+    reference: ''
+  72eda731-894d-4260-9113-9e492822f80e: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: 72eda731-894d-4260-9113-9e492822f80e
+    jinja: 'Summarize: {{dialogue}}|||
+
+      {{summary}}'
+    metadata: !TemplateMetadata
+      _do_eval: false
+      _do_train: false
+      choices_in_prompt: false
+      metrics:
+      - ROUGE
+      original_task: true
+    name: 'Summarize:'
+    reference: ''
+  7bd51f5b-5bac-429e-b8f9-dd6782b92a59: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: 7bd51f5b-5bac-429e-b8f9-dd6782b92a59
+    jinja: '{{dialogue}}
+
+      To sum up this dialog:
+
+      |||{{summary}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - ROUGE
+      original_task: true
+    name: To sum up this dialog
+    reference: ''
+  8d829dcb-ea64-457d-b025-f16e31c2834a: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: 8d829dcb-ea64-457d-b025-f16e31c2834a
+    jinja: 'Generate a summary for this dialogue:
+
+      {{dialogue}}
+
+      |||{{summary}}'
+    metadata: !TemplateMetadata
+      _do_eval: false
+      _do_train: false
+      choices_in_prompt: false
+      metrics:
+      - ROUGE
+      original_task: true
+    name: Generate a summary for this dialogue
+    reference: ''
+  9f571a72-6813-4307-9aae-753ca0f737c5: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: 9f571a72-6813-4307-9aae-753ca0f737c5
+    jinja: 'Write a dialogue that match this summary: {{summary}} |||
+
+      {{dialogue}}'
+    metadata: !TemplateMetadata
+      _do_eval: false
+      _do_train: false
+      choices_in_prompt: false
+      metrics:
+      - ROUGE
+      original_task: false
+    name: Write a dialogue that match this summary
+    reference: ''
+  bd891653-49b6-40bb-968f-8e6632c75659: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: bd891653-49b6-40bb-968f-8e6632c75659
+    jinja: "Sum up the following dialogue: \n{{dialogue}}\n|||{{summary}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - ROUGE
+      original_task: true
+    name: Sum up the following dialogue
     reference: ''


### PR DESCRIPTION
I cleaned the samsum dataset, mostly by checking the true task checkbox, except for one prompt which was the inverse task (generate dialogue from the summary). I added two prompts so we have at least 5 true task templates.

Also added the metric: ROUGE, since it is the original paper metric.

I also flagged it as very open-ended generation, but I'm unsure of this. I think it is true for the inverse task, but just summarizing is maybe not too open-ended.

