### PR TITLE
Prompt multi_news.

### DIFF
--- a/promptsource/templates/multi_news/templates.yaml
+++ b/promptsource/templates/multi_news/templates.yaml
@@ -117,7 +117,7 @@ templates:
 
       Write an expanded news article with plausible details from the following summary:
 
-      {{summary[2:]}}'
+      {{summary[2:]}}
 
       |||
 

--- a/promptsource/templates/multi_news/templates.yaml
+++ b/promptsource/templates/multi_news/templates.yaml
@@ -85,7 +85,8 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: b15485f5-2bd9-4ed4-98ce-4b241a341f99
-    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") %}
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
+      "") | list %}
 
       Write a summary of the following articles:
 

--- a/promptsource/templates/multi_news/templates.yaml
+++ b/promptsource/templates/multi_news/templates.yaml
@@ -112,7 +112,7 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: bc910e51-c0a9-473c-aa85-adcab21b9ba9
-    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") reject("equalto",
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
       "") | list%}
 
       Write an expanded news article with plausible details from the following summary:

--- a/promptsource/templates/multi_news/templates.yaml
+++ b/promptsource/templates/multi_news/templates.yaml
@@ -43,7 +43,7 @@ templates:
 
       |||
 
-      {{summary}}'
+      {{summary[2:]}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:

--- a/promptsource/templates/multi_news/templates.yaml
+++ b/promptsource/templates/multi_news/templates.yaml
@@ -95,7 +95,7 @@ templates:
 
       |||
 
-      {{summary}}'
+      {{summary[2:]}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:

--- a/promptsource/templates/multi_news/templates.yaml
+++ b/promptsource/templates/multi_news/templates.yaml
@@ -112,7 +112,8 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: bc910e51-c0a9-473c-aa85-adcab21b9ba9
-    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") %}
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") reject("equalto",
+      "") | list%}
 
       Write an expanded news article with plausible details from the following summary:
 

--- a/promptsource/templates/multi_news/templates.yaml
+++ b/promptsource/templates/multi_news/templates.yaml
@@ -69,7 +69,7 @@ templates:
 
       |||
 
-      {{summary}}'
+      {{summary[2:]}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:

--- a/promptsource/templates/multi_news/templates.yaml
+++ b/promptsource/templates/multi_news/templates.yaml
@@ -4,7 +4,8 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: 12269bd1-1c3a-4865-9702-892782b593d9
-    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") %}
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
+      "") | list %}
 
       What are the key points across these news articles:
 

--- a/promptsource/templates/multi_news/templates.yaml
+++ b/promptsource/templates/multi_news/templates.yaml
@@ -143,7 +143,7 @@ templates:
 
       |||
 
-      {{summary}}'
+      {{summary[2:]}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:

--- a/promptsource/templates/multi_news/templates.yaml
+++ b/promptsource/templates/multi_news/templates.yaml
@@ -17,7 +17,7 @@ templates:
 
       |||
 
-      {{summary}}'
+      {{summary[2:]}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:

--- a/promptsource/templates/multi_news/templates.yaml
+++ b/promptsource/templates/multi_news/templates.yaml
@@ -58,7 +58,8 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: 9ab370ad-2b89-4d2a-bb40-ccc31accefad
-    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") %}
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
+      "") | list %}
 
       I want to edit the following articles into a more concise summary:
 

--- a/promptsource/templates/multi_news/templates.yaml
+++ b/promptsource/templates/multi_news/templates.yaml
@@ -1,0 +1,153 @@
+dataset: multi_news
+templates:
+  12269bd1-1c3a-4865-9702-892782b593d9: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: 12269bd1-1c3a-4865-9702-892782b593d9
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") %}
+
+      What are the key points across these news articles:
+
+      {% for doc in docs %}
+
+
+      Article: {{doc}}
+
+      {% endfor %}
+
+      |||
+
+      {{summary}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: true
+    name: what are the key points
+    reference: ''
+  940d0ce4-c1ef-4453-a47b-1abaaf811160: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: 940d0ce4-c1ef-4453-a47b-1abaaf811160
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") %}
+
+      Synthesize these documents into a single one:
+
+      {% for doc in docs %}
+
+
+      - {{doc}}
+
+      {% endfor %}
+
+      |||
+
+      {{summary}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: true
+    name: synthesize
+    reference: ''
+  9ab370ad-2b89-4d2a-bb40-ccc31accefad: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: 9ab370ad-2b89-4d2a-bb40-ccc31accefad
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") %}
+
+      I want to edit the following articles into a more concise summary:
+
+      {% for doc in docs %}
+
+
+      Article: {{doc}}
+
+      {% endfor %}
+
+      |||
+
+      {{summary}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: true
+    name: summary scenario
+    reference: ''
+  b15485f5-2bd9-4ed4-98ce-4b241a341f99: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: b15485f5-2bd9-4ed4-98ce-4b241a341f99
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") %}
+
+      Write a summary of the following articles:
+
+      {% for doc in docs %}
+
+
+      Document: {{doc}}
+
+      {% endfor %}
+
+      |||
+
+      {{summary}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: true
+    name: summarize
+    reference: ''
+  bc910e51-c0a9-473c-aa85-adcab21b9ba9: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: bc910e51-c0a9-473c-aa85-adcab21b9ba9
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") %}
+
+      Write an expanded news article with plausible details from the following summary:
+
+      {{summary}}
+
+      |||
+
+      {{docs | choice}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
+    name: expand (reverse task)
+    reference: ''
+  d5a4bb2a-634a-4e9a-9f1f-b0803894ca0f: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: d5a4bb2a-634a-4e9a-9f1f-b0803894ca0f
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") %}
+
+      I''m trying to distill these articles down into one:
+
+      {% for doc in docs %}
+
+
+      Article: {{doc}}
+
+      {% endfor %}
+
+      |||
+
+      {{summary}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: true
+    name: distill
+    reference: ''

--- a/promptsource/templates/multi_news/templates.yaml
+++ b/promptsource/templates/multi_news/templates.yaml
@@ -31,7 +31,8 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: 940d0ce4-c1ef-4453-a47b-1abaaf811160
-    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") %}
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
+      "") | list %}
 
       Synthesize these documents into a single one:
 

--- a/promptsource/templates/multi_news/templates.yaml
+++ b/promptsource/templates/multi_news/templates.yaml
@@ -133,7 +133,8 @@ templates:
     answer_choices: null
     answer_choices_key: null
     id: d5a4bb2a-634a-4e9a-9f1f-b0803894ca0f
-    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") %}
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
+      "") | list %}
 
       I''m trying to distill these articles down into one:
 

--- a/promptsource/templates/multi_news/templates.yaml
+++ b/promptsource/templates/multi_news/templates.yaml
@@ -112,7 +112,7 @@ templates:
 
       Write an expanded news article with plausible details from the following summary:
 
-      {{summary}}
+      {{summary[2:]}}'
 
       |||
 


### PR DESCRIPTION
So of course the last dataset we need for training requires parsing `|||||` from the examples. So you'll see that we're using our pipe protector hash in the templates. Not sure a better way to do this, and didn't want to hold up training.