### PR TITLE
New prompts for some superglue subsets

### DIFF
--- a/promptsource/seqio_tasks/preview_promptsource.py
+++ b/promptsource/seqio_tasks/preview_promptsource.py
@@ -56,7 +56,7 @@ def preview() -> None:
             # if dataset_name == 'ropes':
             #     inspect(template.metadata)
             if not template.metadata.metrics:
-                missing_metrics.append(f'{dataset_name}/{subset_name}/{template_name}')
+                missing_metrics.append(f"{dataset_name}/{subset_name}/{template_name}")
 
             if template.metadata.original_task is True:
                 OG += 1
@@ -65,7 +65,6 @@ def preview() -> None:
             elif template.metadata.original_task is None:
                 missing_og_flags.append(dataset_name + "/" + template_name)
                 continue
-
 
         train_size = gsheet[ds_name]["train_size"]
         if train_size == "":

--- a/promptsource/seqio_tasks/preview_promptsource.py
+++ b/promptsource/seqio_tasks/preview_promptsource.py
@@ -42,9 +42,10 @@ def preview() -> None:
     template_collection = TemplateCollection()
     output = []
     missing_og_flags = []
+    missing_metrics = []
     for dataset_name, subset_name in template_collection.keys:
         ds_name = (dataset_name, subset_name)
-        if ds_name not in d4_train:
+        if ds_name not in d4_eval:
             template_collection.remove(dataset_name, subset_name)
             continue
         OG = 0
@@ -54,6 +55,9 @@ def preview() -> None:
             template = dataset[template_name]
             # if dataset_name == 'ropes':
             #     inspect(template.metadata)
+            if not template.metadata.metrics:
+                missing_metrics.append(f'{dataset_name}/{subset_name}/{template_name}')
+
             if template.metadata.original_task is True:
                 OG += 1
             elif template.metadata.original_task is False:
@@ -61,6 +65,7 @@ def preview() -> None:
             elif template.metadata.original_task is None:
                 missing_og_flags.append(dataset_name + "/" + template_name)
                 continue
+
 
         train_size = gsheet[ds_name]["train_size"]
         if train_size == "":
@@ -80,6 +85,9 @@ def preview() -> None:
 
     pprint(output)
     print(len(template_collection))
+
+    print("Missing metrics:")
+    pprint(missing_metrics)
 
     print("Missing original task flags:")
     pprint(missing_og_flags)

--- a/promptsource/templates/anli/templates.yaml
+++ b/promptsource/templates/anli/templates.yaml
@@ -20,7 +20,7 @@ templates:
   179eb863-3ece-4e6f-af0f-fcb46d997306: !Template
     answer_choices:
     - 'Yes'
-    - 'Maybe'
+    - Maybe
     - 'No'
     answer_choices_key: null
     id: 179eb863-3ece-4e6f-af0f-fcb46d997306
@@ -36,7 +36,7 @@ templates:
   5459237b-97de-4340-bf7b-2939c3f7ca19: !Template
     answer_choices:
     - 'Yes'
-    - 'Maybe'
+    - Maybe
     - 'No'
     answer_choices_key: null
     id: 5459237b-97de-4340-bf7b-2939c3f7ca19
@@ -54,7 +54,7 @@ templates:
   620aa3fc-d5eb-46f5-a1ee-4c754527aa97: !Template
     answer_choices:
     - 'True'
-    - 'Neither'
+    - Neither
     - 'False'
     answer_choices_key: null
     id: 620aa3fc-d5eb-46f5-a1ee-4c754527aa97
@@ -66,7 +66,8 @@ templates:
       _do_eval: true
       _do_train: false
       choices_in_prompt: true
-      metrics: []
+      metrics:
+      - Accuracy
       original_task: true
     name: GPT-3 style
     reference: 'Same as reported in Figure G7 of the GPT-3 paper, except that there
@@ -74,7 +75,7 @@ templates:
   9b613182-c6ab-4427-9221-3d68f6d62765: !Template
     answer_choices:
     - 'Yes'
-    - 'Maybe'
+    - Maybe
     - 'No'
     answer_choices_key: null
     id: 9b613182-c6ab-4427-9221-3d68f6d62765
@@ -92,7 +93,7 @@ templates:
   a850110d-f1a3-49b4-949a-d3bfe9f81344: !Template
     answer_choices:
     - 'Yes'
-    - 'Maybe'
+    - Maybe
     - 'No'
     answer_choices_key: null
     id: a850110d-f1a3-49b4-949a-d3bfe9f81344
@@ -108,7 +109,7 @@ templates:
   bab86d5a-4f9c-40db-b619-a7b7d5cae681: !Template
     answer_choices:
     - 'True'
-    - 'Inconclusive'
+    - Inconclusive
     - 'False'
     answer_choices_key: null
     id: bab86d5a-4f9c-40db-b619-a7b7d5cae681
@@ -118,14 +119,15 @@ templates:
       or {{"false"}}? ||| {{ answer_choices[label] }}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
-      metrics: []
+      metrics:
+      - Accuracy
       original_task: true
     name: take the following as truth
     reference: Bers et al.
   bcd90047-3a2b-426b-b065-8a418f1317b8: !Template
     answer_choices:
     - 'Yes'
-    - 'Maybe'
+    - Maybe
     - 'No'
     answer_choices_key: null
     id: bcd90047-3a2b-426b-b065-8a418f1317b8
@@ -141,7 +143,7 @@ templates:
   c4ed37ae-d7d7-4197-a725-ef2152fa3b1f: !Template
     answer_choices:
     - 'Yes'
-    - 'Maybe'
+    - Maybe
     - 'No'
     answer_choices_key: null
     id: c4ed37ae-d7d7-4197-a725-ef2152fa3b1f
@@ -190,7 +192,7 @@ templates:
   e5b7fdd7-fdff-4630-889b-3c7a052e5da0: !Template
     answer_choices:
     - 'Yes'
-    - 'Maybe'
+    - Maybe
     - 'No'
     answer_choices_key: null
     id: e5b7fdd7-fdff-4630-889b-3c7a052e5da0
@@ -223,7 +225,7 @@ templates:
   ec249357-e672-4e7d-b8b6-d97ed7d090c5: !Template
     answer_choices:
     - 'True'
-    - 'Inconclusive'
+    - Inconclusive
     - 'False'
     answer_choices_key: null
     id: ec249357-e672-4e7d-b8b6-d97ed7d090c5
@@ -240,7 +242,7 @@ templates:
   ffa0a6f0-7186-4ccb-bb35-8b1affb747a0: !Template
     answer_choices:
     - 'Yes'
-    - 'Maybe'
+    - Maybe
     - 'No'
     answer_choices_key: null
     id: ffa0a6f0-7186-4ccb-bb35-8b1affb747a0

--- a/promptsource/templates/anli/templates.yaml
+++ b/promptsource/templates/anli/templates.yaml
@@ -2,9 +2,9 @@ dataset: anli
 templates:
   0cc3ae39-3997-4686-8c93-5d51457efa1f: !Template
     answer_choices:
-    - correct
-    - inconclusive
-    - incorrect
+    - Correct
+    - Inconclusive
+    - Incorrect
     answer_choices_key: null
     id: 0cc3ae39-3997-4686-8c93-5d51457efa1f
     jinja: '{{premise}} Using only the above description and what you know about the
@@ -19,9 +19,9 @@ templates:
     reference: Adapted from Williams et al. 2018's instructions to crowdsourcing workers.
   179eb863-3ece-4e6f-af0f-fcb46d997306: !Template
     answer_choices:
-    - 'yes'
-    - maybe
-    - 'no'
+    - 'Yes'
+    - 'Maybe'
+    - 'No'
     answer_choices_key: null
     id: 179eb863-3ece-4e6f-af0f-fcb46d997306
     jinja: 'Given {{premise}} Should we assume that "{{hypothesis}}" is true? Yes,
@@ -36,7 +36,7 @@ templates:
   5459237b-97de-4340-bf7b-2939c3f7ca19: !Template
     answer_choices:
     - 'Yes'
-    - Maybe
+    - 'Maybe'
     - 'No'
     answer_choices_key: null
     id: 5459237b-97de-4340-bf7b-2939c3f7ca19
@@ -54,7 +54,7 @@ templates:
   620aa3fc-d5eb-46f5-a1ee-4c754527aa97: !Template
     answer_choices:
     - 'True'
-    - Neither
+    - 'Neither'
     - 'False'
     answer_choices_key: null
     id: 620aa3fc-d5eb-46f5-a1ee-4c754527aa97
@@ -74,7 +74,7 @@ templates:
   9b613182-c6ab-4427-9221-3d68f6d62765: !Template
     answer_choices:
     - 'Yes'
-    - Maybe
+    - 'Maybe'
     - 'No'
     answer_choices_key: null
     id: 9b613182-c6ab-4427-9221-3d68f6d62765
@@ -91,9 +91,9 @@ templates:
     reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
   a850110d-f1a3-49b4-949a-d3bfe9f81344: !Template
     answer_choices:
-    - 'yes'
-    - maybe
-    - 'no'
+    - 'Yes'
+    - 'Maybe'
+    - 'No'
     answer_choices_key: null
     id: a850110d-f1a3-49b4-949a-d3bfe9f81344
     jinja: '{{premise}} Are we justified in saying that "{{hypothesis}}"? Yes, no,
@@ -107,15 +107,15 @@ templates:
     reference: Webson & Pavlick 2021
   bab86d5a-4f9c-40db-b619-a7b7d5cae681: !Template
     answer_choices:
-    - 'true'
-    - inconclusive
-    - 'false'
+    - 'True'
+    - 'Inconclusive'
+    - 'False'
     answer_choices_key: null
     id: bab86d5a-4f9c-40db-b619-a7b7d5cae681
     jinja: 'Take the following as truth: {{premise}}
 
       Then the following statement: "{{hypothesis}}" is {{"true"}}, {{"inconclusive"}},
-      or  {{"false"}}? ||| {{ answer_choices[label] }}'
+      or {{"false"}}? ||| {{ answer_choices[label] }}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics: []
@@ -124,9 +124,9 @@ templates:
     reference: Bers et al.
   bcd90047-3a2b-426b-b065-8a418f1317b8: !Template
     answer_choices:
-    - 'yes'
-    - maybe
-    - 'no'
+    - 'Yes'
+    - 'Maybe'
+    - 'No'
     answer_choices_key: null
     id: bcd90047-3a2b-426b-b065-8a418f1317b8
     jinja: 'Given that {{premise}} Therefore, it must be true that "{{hypothesis}}"?
@@ -140,9 +140,9 @@ templates:
     reference: v0.1
   c4ed37ae-d7d7-4197-a725-ef2152fa3b1f: !Template
     answer_choices:
-    - 'yes'
-    - maybe
-    - 'no'
+    - 'Yes'
+    - 'Maybe'
+    - 'No'
     answer_choices_key: null
     id: c4ed37ae-d7d7-4197-a725-ef2152fa3b1f
     jinja: 'Suppose {{premise}} Can we infer that "{{hypothesis}}"? Yes, no, or maybe?
@@ -156,9 +156,9 @@ templates:
     reference: Webson & Pavlick 2021
   ca24b93a-6265-462f-b140-e329c03d94fa: !Template
     answer_choices:
-    - guaranteed
-    - possible
-    - impossible
+    - Guaranteed
+    - Possible
+    - Impossible
     answer_choices_key: null
     id: ca24b93a-6265-462f-b140-e329c03d94fa
     jinja: "Assume it is true that {{premise}} \n\nTherefore, \"{{hypothesis}}\" is\
@@ -173,9 +173,9 @@ templates:
     reference: Bers et al.
   dbc68425-5c42-43ae-9748-70ce8c5a167e: !Template
     answer_choices:
-    - always
-    - sometimes
-    - never
+    - Always
+    - Sometimes
+    - Never
     answer_choices_key: null
     id: dbc68425-5c42-43ae-9748-70ce8c5a167e
     jinja: Suppose it's true that {{premise}} Then, is "{{hypothesis}}" {{"always"}},
@@ -189,9 +189,9 @@ templates:
     reference: Bers et al.
   e5b7fdd7-fdff-4630-889b-3c7a052e5da0: !Template
     answer_choices:
-    - 'yes'
-    - maybe
-    - 'no'
+    - 'Yes'
+    - 'Maybe'
+    - 'No'
     answer_choices_key: null
     id: e5b7fdd7-fdff-4630-889b-3c7a052e5da0
     jinja: "{{premise}} \n\nQuestion: Does this imply that \"{{hypothesis}}\"? Yes,\
@@ -205,9 +205,9 @@ templates:
     reference: v0.1
   e6f32b9c-7e0b-474a-a0d2-e84d20c22aba: !Template
     answer_choices:
-    - always
-    - sometimes
-    - never
+    - Always
+    - Sometimes
+    - Never
     answer_choices_key: null
     id: e6f32b9c-7e0b-474a-a0d2-e84d20c22aba
     jinja: "{{premise}} \n\nKeeping in mind the above text, consider: {{hypothesis}}\
@@ -222,9 +222,9 @@ templates:
     reference: Bers et al.
   ec249357-e672-4e7d-b8b6-d97ed7d090c5: !Template
     answer_choices:
-    - 'true'
-    - inconclusive
-    - 'false'
+    - 'True'
+    - 'Inconclusive'
+    - 'False'
     answer_choices_key: null
     id: ec249357-e672-4e7d-b8b6-d97ed7d090c5
     jinja: '{{premise}} Based on that information, is the claim: "{{hypothesis}}"
@@ -240,7 +240,7 @@ templates:
   ffa0a6f0-7186-4ccb-bb35-8b1affb747a0: !Template
     answer_choices:
     - 'Yes'
-    - Maybe
+    - 'Maybe'
     - 'No'
     answer_choices_key: null
     id: ffa0a6f0-7186-4ccb-bb35-8b1affb747a0

--- a/promptsource/templates/anli/templates.yaml
+++ b/promptsource/templates/anli/templates.yaml
@@ -115,8 +115,8 @@ templates:
     id: bab86d5a-4f9c-40db-b619-a7b7d5cae681
     jinja: 'Take the following as truth: {{premise}}
 
-      Then the following statement: "{{hypothesis}}" is {{"true"}}, {{"inconclusive"}},
-      or {{"false"}}? ||| {{ answer_choices[label] }}'
+      Then the following statement: "{{hypothesis}}" is {{"true"}}, {{"false"}}, or
+      {{"inconclusive"}}? ||| {{ answer_choices[label] }}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -230,7 +230,7 @@ templates:
     answer_choices_key: null
     id: ec249357-e672-4e7d-b8b6-d97ed7d090c5
     jinja: '{{premise}} Based on that information, is the claim: "{{hypothesis}}"
-      {{"true"}}, {{"inconclusive"}}, or {{"false"}}? ||| {{ answer_choices[label]
+      {{"true"}}, {{"false"}}, or {{"inconclusive"}}? ||| {{ answer_choices[label]
       }}'
     metadata: !TemplateMetadata
       choices_in_prompt: true

--- a/promptsource/templates/anli/templates.yaml
+++ b/promptsource/templates/anli/templates.yaml
@@ -1,27 +1,38 @@
 dataset: anli
 templates:
-  391acb43-732a-4c09-8c10-e02d226d8854: !Template
+  0cc3ae39-3997-4686-8c93-5d51457efa1f: !Template
     answer_choices:
-    - 'No'
-    - Neutral
-    - 'Yes'
+    - correct
+    - inconclusive
+    - incorrect
     answer_choices_key: null
-    id: 391acb43-732a-4c09-8c10-e02d226d8854
-    jinja: 'Sentence 1: {{premise}}
-
-      Sentence 2: {{hypothesis}}
-
-      Question: Does Sentence 1 contradict Sentence 2? Yes, No, or Neutral? |||
-
-      {{answer_choices[label]}}'
+    id: 0cc3ae39-3997-4686-8c93-5d51457efa1f
+    jinja: '{{premise}} Using only the above description and what you know about the
+      world, "{{hypothesis}}" is definitely correct, incorrect, or inconclusive? |||
+      {{ answer_choices[label] }}'
     metadata: !TemplateMetadata
-      _do_eval: true
-      _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: does S1 contradict S2?
-    reference: Copied from Victor's prompts for XNLI.
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: MNLI crowdsource
+    reference: Adapted from Williams et al. 2018's instructions to crowdsourcing workers.
+  179eb863-3ece-4e6f-af0f-fcb46d997306: !Template
+    answer_choices:
+    - 'yes'
+    - maybe
+    - 'no'
+    answer_choices_key: null
+    id: 179eb863-3ece-4e6f-af0f-fcb46d997306
+    jinja: 'Given {{premise}} Should we assume that "{{hypothesis}}" is true? Yes,
+      no, or maybe? ||| {{ ["yes", "maybe", "no"][label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: should assume
+    reference: Webson & Pavlick 2021
   5459237b-97de-4340-bf7b-2939c3f7ca19: !Template
     answer_choices:
     - 'Yes'
@@ -35,13 +46,11 @@ templates:
       _do_eval: true
       _do_train: false
       choices_in_prompt: true
-      metrics: []
+      metrics:
+      - Accuracy
       original_task: true
-    name: "given\u2026 does it follow that\u2026 "
-    reference: "\"Does it follow that\" could be replaced with \"can we infer that\u2026\
-      \ \", \"is it guaranteed that\u2026\", etc. Ideally there should be a question\
-      \ mark after \"does it follow that {hypothesis}?\", but the hypothesis string\
-      \ often comes with ending punctuations of its own."
+    name: does it follow that
+    reference: v0.1
   620aa3fc-d5eb-46f5-a1ee-4c754527aa97: !Template
     answer_choices:
     - 'True'
@@ -69,55 +78,178 @@ templates:
     - 'No'
     answer_choices_key: null
     id: 9b613182-c6ab-4427-9221-3d68f6d62765
-    jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
+    jinja: '{{premise}} Based on the previous passage, is it true that "{{hypothesis}}"?
       Yes, no, or maybe? ||| {{ answer_choices[label] }}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: false
       choices_in_prompt: true
-      metrics: []
+      metrics:
+      - Accuracy
       original_task: true
     name: based on the previous passage
     reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
-  cf55f09b-bc68-439d-a9b2-781263509f99: !Template
+  a850110d-f1a3-49b4-949a-d3bfe9f81344: !Template
+    answer_choices:
+    - 'yes'
+    - maybe
+    - 'no'
+    answer_choices_key: null
+    id: a850110d-f1a3-49b4-949a-d3bfe9f81344
+    jinja: '{{premise}} Are we justified in saying that "{{hypothesis}}"? Yes, no,
+      or maybe? ||| {{ ["yes", "maybe", "no"][label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: justified in saying
+    reference: Webson & Pavlick 2021
+  bab86d5a-4f9c-40db-b619-a7b7d5cae681: !Template
+    answer_choices:
+    - 'true'
+    - inconclusive
+    - 'false'
+    answer_choices_key: null
+    id: bab86d5a-4f9c-40db-b619-a7b7d5cae681
+    jinja: 'Take the following as truth: {{premise}}
+
+      Then the following statement: "{{hypothesis}}" is {{"true"}}, {{"inconclusive"}},
+      or  {{"false"}}? ||| {{ answer_choices[label] }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics: []
+      original_task: true
+    name: take the following as truth
+    reference: Bers et al.
+  bcd90047-3a2b-426b-b065-8a418f1317b8: !Template
+    answer_choices:
+    - 'yes'
+    - maybe
+    - 'no'
+    answer_choices_key: null
+    id: bcd90047-3a2b-426b-b065-8a418f1317b8
+    jinja: 'Given that {{premise}} Therefore, it must be true that "{{hypothesis}}"?
+      Yes, no, or maybe? ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: must be true
+    reference: v0.1
+  c4ed37ae-d7d7-4197-a725-ef2152fa3b1f: !Template
+    answer_choices:
+    - 'yes'
+    - maybe
+    - 'no'
+    answer_choices_key: null
+    id: c4ed37ae-d7d7-4197-a725-ef2152fa3b1f
+    jinja: 'Suppose {{premise}} Can we infer that "{{hypothesis}}"? Yes, no, or maybe?
+      ||| {{ ["yes", "maybe", "no"][label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: can we infer
+    reference: Webson & Pavlick 2021
+  ca24b93a-6265-462f-b140-e329c03d94fa: !Template
+    answer_choices:
+    - guaranteed
+    - possible
+    - impossible
+    answer_choices_key: null
+    id: ca24b93a-6265-462f-b140-e329c03d94fa
+    jinja: "Assume it is true that {{premise}} \n\nTherefore, \"{{hypothesis}}\" is\
+      \ {{\"guaranteed\"}}, {{\"possible\"}}, or {{\"impossible\"}}? ||| {{ answer_choices[label]\
+      \ }}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: guaranteed/possible/impossible
+    reference: Bers et al.
+  dbc68425-5c42-43ae-9748-70ce8c5a167e: !Template
+    answer_choices:
+    - always
+    - sometimes
+    - never
+    answer_choices_key: null
+    id: dbc68425-5c42-43ae-9748-70ce8c5a167e
+    jinja: Suppose it's true that {{premise}} Then, is "{{hypothesis}}" {{"always"}},
+      {{"sometimes"}}, or {{"never"}} true? ||| {{ answer_choices[label] }}
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: always/sometimes/never
+    reference: Bers et al.
+  e5b7fdd7-fdff-4630-889b-3c7a052e5da0: !Template
+    answer_choices:
+    - 'yes'
+    - maybe
+    - 'no'
+    answer_choices_key: null
+    id: e5b7fdd7-fdff-4630-889b-3c7a052e5da0
+    jinja: "{{premise}} \n\nQuestion: Does this imply that \"{{hypothesis}}\"? Yes,\
+      \ no, or maybe? ||| {{answer_choices[label]}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: does this imply
+    reference: v0.1
+  e6f32b9c-7e0b-474a-a0d2-e84d20c22aba: !Template
+    answer_choices:
+    - always
+    - sometimes
+    - never
+    answer_choices_key: null
+    id: e6f32b9c-7e0b-474a-a0d2-e84d20c22aba
+    jinja: "{{premise}} \n\nKeeping in mind the above text, consider: {{hypothesis}}\
+      \ Is this {{\"always\"}}, {{\"sometimes\"}}, or {{\"never\"}} correct? ||| {{\
+      \ answer_choices[label] }}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: consider always/sometimes/never
+    reference: Bers et al.
+  ec249357-e672-4e7d-b8b6-d97ed7d090c5: !Template
+    answer_choices:
+    - 'true'
+    - inconclusive
+    - 'false'
+    answer_choices_key: null
+    id: ec249357-e672-4e7d-b8b6-d97ed7d090c5
+    jinja: '{{premise}} Based on that information, is the claim: "{{hypothesis}}"
+      {{"true"}}, {{"inconclusive"}}, or {{"false"}}? ||| {{ answer_choices[label]
+      }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: claim true/false/inconclusive
+    reference: Bers et al.
+  ffa0a6f0-7186-4ccb-bb35-8b1affb747a0: !Template
     answer_choices:
     - 'Yes'
-    - Neutral
+    - Maybe
     - 'No'
     answer_choices_key: null
-    id: cf55f09b-bc68-439d-a9b2-781263509f99
-    jinja: 'Sentence 1: {{premise}}
-
-      Sentence 2: {{hypothesis}}
-
-      Question: Does Sentence 1 entail Sentence 2? Yes, No, or Neutral? |||
-
-      {{answer_choices[label]}}'
+    id: ffa0a6f0-7186-4ccb-bb35-8b1affb747a0
+    jinja: 'Given {{premise}} Is it guaranteed true that "{{hypothesis}}"? Yes, no,
+      or maybe? ||| {{ answer_choices[label] }} '
     metadata: !TemplateMetadata
-      _do_eval: true
-      _do_train: false
       choices_in_prompt: true
-      metrics: []
+      metrics:
+      - Accuracy
       original_task: true
-    name: does S1 entail S2?
-    reference: Copied from Victor's prompts for XNLI.
-  e0e8b914-c32c-4c85-8b8f-0f61ae79e2b3: !Template
-    answer_choices:
-    - must be true
-    - might be true
-    - must be false
-    answer_choices_key: null
-    id: e0e8b914-c32c-4c85-8b8f-0f61ae79e2b3
-    jinja: Given that {{premise}}, it {{"must be true, might be true, or must be false"}}
-      that {{hypothesis}}? ||| It {{ answer_choices[label] }}.
-    metadata: !TemplateMetadata
-      _do_eval: true
-      _do_train: false
-      choices_in_prompt: true
-      metrics: []
-      original_task: true
-    name: "given\u2026 it must be true that\u2026"
-    reference: 'Maybe a little verbose for a generative model, but anecdotally this
-      is the most natural way of how I say an NLI sentence pair out loud to humans.
-      Caveat: NLI annotations are not meant to be strictly truth-conditional entailment,
-      so "must" is not ideal.'
+    name: guaranteed true
+    reference: Webson & Pavlick 2021

--- a/promptsource/templates/anli/templates.yaml
+++ b/promptsource/templates/anli/templates.yaml
@@ -25,7 +25,7 @@ templates:
     answer_choices_key: null
     id: 179eb863-3ece-4e6f-af0f-fcb46d997306
     jinja: 'Given {{premise}} Should we assume that "{{hypothesis}}" is true? Yes,
-      no, or maybe? ||| {{ ["yes", "maybe", "no"][label] }} '
+      no, or maybe? ||| {{ answer_choices[label] }} '
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -97,7 +97,7 @@ templates:
     answer_choices_key: null
     id: a850110d-f1a3-49b4-949a-d3bfe9f81344
     jinja: '{{premise}} Are we justified in saying that "{{hypothesis}}"? Yes, no,
-      or maybe? ||| {{ ["yes", "maybe", "no"][label] }} '
+      or maybe? ||| {{ answer_choices[label] }} '
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -146,7 +146,7 @@ templates:
     answer_choices_key: null
     id: c4ed37ae-d7d7-4197-a725-ef2152fa3b1f
     jinja: 'Suppose {{premise}} Can we infer that "{{hypothesis}}"? Yes, no, or maybe?
-      ||| {{ ["yes", "maybe", "no"][label] }} '
+      ||| {{ answer_choices[label] }} '
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:

--- a/promptsource/templates/hans/templates.yaml
+++ b/promptsource/templates/hans/templates.yaml
@@ -1,80 +1,137 @@
 dataset: hans
 templates:
-  1b2386f7-4b2b-436b-a0cc-7092a90964f7: !Template
+  03fc899d-aa53-4bbd-8808-d390b2a30f86: !Template
     answer_choices:
     - 'Yes'
+    - Maybe
     - 'No'
     answer_choices_key: null
-    id: 1b2386f7-4b2b-436b-a0cc-7092a90964f7
-    jinja: '{{premise}} Does the previous passage support the claim that {{hypothesis}}?
-      ||| {{ answer_choices[label] }}'
+    id: 03fc899d-aa53-4bbd-8808-d390b2a30f86
+    jinja: "{{premise}} \n\nQuestion: Does this imply that \"{{hypothesis}}\"? Yes,\
+      \ no, or maybe? ||| {{answer_choices[label]}}"
     metadata: !TemplateMetadata
-      _do_eval: true
-      _do_train: false
-      choices_in_prompt: false
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: true
-    name: "\u2026does the previous passage support the claim that"
-    reference: ''
-  213f6f71-0987-4cba-8e16-85ed08b6d237: !Template
+    name: does this imply
+    reference: v0.1
+  2084c370-6052-4840-89b6-b35ad70fdf31: !Template
     answer_choices:
     - 'Yes'
     - 'No'
     answer_choices_key: null
-    id: 213f6f71-0987-4cba-8e16-85ed08b6d237
-    jinja: Suppose {{premise}} Can we infer that {{hypothesis}}? ||| {{ answer_choices[label]
-      }}
+    id: 2084c370-6052-4840-89b6-b35ad70fdf31
+    jinja: 'Given {{premise}} Should we assume that "{{hypothesis}}" is true? Yes
+      or no? ||| {{ answer_choices[label] }} '
     metadata: !TemplateMetadata
-      _do_eval: true
-      _do_train: false
-      choices_in_prompt: false
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: true
-    name: "Suppose\u2026 Can we infer that\u2026"
-    reference: ''
-  930dbf9e-be95-458c-bf63-0358e36b8f8f: !Template
+    name: should assume
+    reference: Webson & Pavlick 2021
+  559dec8c-5ecc-4ff6-9765-7358e5b675d3: !Template
     answer_choices:
     - 'Yes'
     - 'No'
     answer_choices_key: null
-    id: 930dbf9e-be95-458c-bf63-0358e36b8f8f
-    jinja: 'Sentence 1: {{premise}}
-
-      Sentence 2: {{hypothesis}}
-
-      Question: Does Sentence 1 entail Sentence 2? Yes or no? |||
-
-      {{answer_choices[label]}}'
+    id: 559dec8c-5ecc-4ff6-9765-7358e5b675d3
+    jinja: '{{premise}} Based on the previous passage, is it true that "{{hypothesis}}"?
+      Yes or no? ||| {{ answer_choices[label] }}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: false
       choices_in_prompt: true
-      metrics: []
+      metrics:
+      - Accuracy
       original_task: true
-    name: does S1 entail S2?
-    reference: Adapted from Victor's prompts for XNLI.
-  9666d06a-63eb-4992-a1f5-3e582ffe39a6: !Template
+    name: based on the previous passage
+    reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+  591a436a-588d-4356-9c3c-7f2ddbb3ba55: !Template
     answer_choices:
     - 'Yes'
     - 'No'
     answer_choices_key: null
-    id: 9666d06a-63eb-4992-a1f5-3e582ffe39a6
+    id: 591a436a-588d-4356-9c3c-7f2ddbb3ba55
     jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes or no? |||
       {{ answer_choices[label] }}
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: false
       choices_in_prompt: true
-      metrics: []
+      metrics:
+      - Accuracy
       original_task: true
-    name: "given\u2026 does it follow that\u2026 "
-    reference: ''
-  9be63780-a784-4a8e-9440-4453c14f8a0e: !Template
+    name: does it follow that
+    reference: v0.1
+  6ed3823e-5ebb-4398-8366-273047d970f0: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: 6ed3823e-5ebb-4398-8366-273047d970f0
+    jinja: 'Given {{premise}} Is it guaranteed true that "{{hypothesis}}"? Yes or
+      no? ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: guaranteed true
+    reference: Webson & Pavlick 2021
+  b12b3a20-3cc2-42a8-899e-4ef71a72e484: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: b12b3a20-3cc2-42a8-899e-4ef71a72e484
+    jinja: 'Given that {{premise}} Therefore, it must be true that "{{hypothesis}}"?
+      Yes or no? ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: must be true
+    reference: v0.1
+  c5508a95-1f23-47b9-aed4-0eca8380f71b: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: c5508a95-1f23-47b9-aed4-0eca8380f71b
+    jinja: '{{premise}} Using only the above description and what you know about the
+      world, is "{{hypothesis}}" definitely correct? Yes or no? ||| {{ answer_choices[label]
+      }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: MNLI crowdsource
+    reference: Adapted from Williams et al. 2018's instructions to crowdsourcing workers.
+  d6fad9e1-d882-4d06-8f7f-ce400268df5f: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: d6fad9e1-d882-4d06-8f7f-ce400268df5f
+    jinja: '{{premise}} Are we justified in saying that "{{hypothesis}}"? Yes or no?
+      ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: justified in saying
+    reference: Webson & Pavlick 2021
+  e86994a7-2649-4535-acce-57e5aed8d390: !Template
     answer_choices:
     - 'True'
     - 'False'
     answer_choices_key: null
-    id: 9be63780-a784-4a8e-9440-4453c14f8a0e
+    id: e86994a7-2649-4535-acce-57e5aed8d390
     jinja: '{{premise}}
 
       Question: {{hypothesis}} True or False? ||| {{ answer_choices[label] }}'
@@ -82,25 +139,23 @@ templates:
       _do_eval: true
       _do_train: false
       choices_in_prompt: true
-      metrics: []
+      metrics:
+      - Accuracy
       original_task: true
     name: GPT-3 style
-    reference: Same as reported in Figure G31 of the GPT-3 paper, although I'm not
-      sure about phrasing the not_entailment label (could be either neutral and contradiction)
-      simply as "False".
-  b7676330-5e75-4f3d-96bd-2ab7aa10fbcd: !Template
+    reference: Same as reported in Figure G31 of the GPT-3 paper.
+  ffbc8068-e791-4277-b342-1d7e0e80f825: !Template
     answer_choices:
     - 'Yes'
     - 'No'
     answer_choices_key: null
-    id: b7676330-5e75-4f3d-96bd-2ab7aa10fbcd
-    jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}?
-      ||| {{ answer_choices[label] }}'
+    id: ffbc8068-e791-4277-b342-1d7e0e80f825
+    jinja: 'Suppose {{premise}} Can we infer that "{{hypothesis}}"? Yes or no? |||
+      {{ answer_choices[label] }} '
     metadata: !TemplateMetadata
-      _do_eval: true
-      _do_train: false
-      choices_in_prompt: false
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: true
-    name: based on the previous passage
-    reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+    name: can we infer
+    reference: Webson & Pavlick 2021

--- a/promptsource/templates/hans/templates.yaml
+++ b/promptsource/templates/hans/templates.yaml
@@ -3,12 +3,11 @@ templates:
   03fc899d-aa53-4bbd-8808-d390b2a30f86: !Template
     answer_choices:
     - 'Yes'
-    - Maybe
     - 'No'
     answer_choices_key: null
     id: 03fc899d-aa53-4bbd-8808-d390b2a30f86
-    jinja: "{{premise}} \n\nQuestion: Does this imply that \"{{hypothesis}}\"? Yes,\
-      \ no, or maybe? ||| {{answer_choices[label]}}"
+    jinja: "{{premise}} \n\nQuestion: Does this imply that \"{{hypothesis}}\"? Yes\
+      \ or no? ||| {{answer_choices[label]}}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:

--- a/promptsource/templates/super_glue/axb/templates.yaml
+++ b/promptsource/templates/super_glue/axb/templates.yaml
@@ -1,0 +1,162 @@
+dataset: super_glue
+subset: axb
+templates:
+  1ae41916-7b4d-4ef3-b414-bfadd95d67e2: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: 1ae41916-7b4d-4ef3-b414-bfadd95d67e2
+    jinja: 'Given {{sentence1}} Should we assume that "{{sentence2}}" is true? Yes
+      or no? ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: should assume
+    reference: Webson & Pavlick 2021
+  1b2d6e85-a5a9-4d1b-9e3b-630b490c6a34: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: 1b2d6e85-a5a9-4d1b-9e3b-630b490c6a34
+    jinja: '{{sentence1}} Are we justified in saying that "{{sentence2}}"? Yes or no?
+      ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: justified in saying
+    reference: Webson & Pavlick 2021
+  23651f68-93cc-441f-b826-30dd2c6d6a93: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: 23651f68-93cc-441f-b826-30dd2c6d6a93
+    jinja: Given that {{sentence1}} Does it follow that {{sentence2}} Yes or no? |||
+      {{ answer_choices[label] }}
+    metadata: !TemplateMetadata
+      _do_eval: true
+      _do_train: false
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: does it follow that
+    reference: v0.1
+  552d6c20-ab5b-462f-b5fb-3c7b80c78dcc: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: 552d6c20-ab5b-462f-b5fb-3c7b80c78dcc
+    jinja: '{{sentence1}} Using only the above description and what you know about the
+      world, is "{{sentence2}}" definitely correct? Yes or no? ||| {{ answer_choices[label]
+      }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: MNLI crowdsource
+    reference: Adapted from Williams et al. 2018's instructions to crowdsourcing workers.
+  908be561-caf4-4416-9fe9-9919c3998681: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: 908be561-caf4-4416-9fe9-9919c3998681
+    jinja: 'Given {{sentence1}} Is it guaranteed true that "{{sentence2}}"? Yes or
+      no? ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: guaranteed true
+    reference: Webson & Pavlick 2021
+  bae54ef5-c3be-4862-bdd4-a559ed04eb31: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: bae54ef5-c3be-4862-bdd4-a559ed04eb31
+    jinja: 'Suppose {{sentence1}} Can we infer that "{{sentence2}}"? Yes or no? |||
+      {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: can we infer
+    reference: Webson & Pavlick 2021
+  c92d765f-83b1-4684-a0a3-580929b5e46b: !Template
+    answer_choices:
+    - 'Yes'
+    - Maybe
+    - 'No'
+    answer_choices_key: null
+    id: c92d765f-83b1-4684-a0a3-580929b5e46b
+    jinja: "{{sentence1}} \n\nQuestion: Does this imply that \"{{sentence2}}\"? Yes,\
+      \ no, or maybe? ||| {{answer_choices[label]}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: does this imply
+    reference: v0.1
+  cb68ee27-c0a3-440b-b595-e90fe89539c3: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: cb68ee27-c0a3-440b-b595-e90fe89539c3
+    jinja: 'Given that {{sentence1}} Therefore, it must be true that "{{sentence2}}"?
+      Yes or no? ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: must be true
+    reference: v0.1
+  d57550ef-2f67-46eb-98cb-432dd135be16: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: d57550ef-2f67-46eb-98cb-432dd135be16
+    jinja: '{{sentence1}} Based on the previous passage, is it true that "{{sentence2}}"?
+      Yes or no? ||| {{ answer_choices[label] }}'
+    metadata: !TemplateMetadata
+      _do_eval: true
+      _do_train: false
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: based on the previous passage
+    reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+  d965164b-fa96-41b5-8852-e0f6dfe5524e: !Template
+    answer_choices:
+    - 'True'
+    - 'False'
+    answer_choices_key: null
+    id: d965164b-fa96-41b5-8852-e0f6dfe5524e
+    jinja: '{{sentence1}}
+
+      Question: {{sentence2}} True or False? ||| {{ answer_choices[label] }}'
+    metadata: !TemplateMetadata
+      _do_eval: true
+      _do_train: false
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: GPT-3 style
+    reference: Same as reported in Figure G31 of the GPT-3 paper.

--- a/promptsource/templates/super_glue/axb/templates.yaml
+++ b/promptsource/templates/super_glue/axb/templates.yaml
@@ -22,8 +22,8 @@ templates:
     - 'No'
     answer_choices_key: null
     id: 1b2d6e85-a5a9-4d1b-9e3b-630b490c6a34
-    jinja: '{{sentence1}} Are we justified in saying that "{{sentence2}}"? Yes or no?
-      ||| {{ answer_choices[label] }} '
+    jinja: '{{sentence1}} Are we justified in saying that "{{sentence2}}"? Yes or
+      no? ||| {{ answer_choices[label] }} '
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -54,8 +54,8 @@ templates:
     - 'No'
     answer_choices_key: null
     id: 552d6c20-ab5b-462f-b5fb-3c7b80c78dcc
-    jinja: '{{sentence1}} Using only the above description and what you know about the
-      world, is "{{sentence2}}" definitely correct? Yes or no? ||| {{ answer_choices[label]
+    jinja: '{{sentence1}} Using only the above description and what you know about
+      the world, is "{{sentence2}}" definitely correct? Yes or no? ||| {{ answer_choices[label]
       }}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
@@ -97,12 +97,11 @@ templates:
   c92d765f-83b1-4684-a0a3-580929b5e46b: !Template
     answer_choices:
     - 'Yes'
-    - Maybe
     - 'No'
     answer_choices_key: null
     id: c92d765f-83b1-4684-a0a3-580929b5e46b
-    jinja: "{{sentence1}} \n\nQuestion: Does this imply that \"{{sentence2}}\"? Yes,\
-      \ no, or maybe? ||| {{answer_choices[label]}}"
+    jinja: "{{sentence1}} \n\nQuestion: Does this imply that \"{{sentence2}}\"? Yes\
+      \ or no? ||| {{answer_choices[label]}}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:

--- a/promptsource/templates/super_glue/axg/templates.yaml
+++ b/promptsource/templates/super_glue/axg/templates.yaml
@@ -19,12 +19,11 @@ templates:
   0f8afaef-19a0-472f-9e9f-c803426f8f22: !Template
     answer_choices:
     - 'Yes'
-    - Maybe
     - 'No'
     answer_choices_key: null
     id: 0f8afaef-19a0-472f-9e9f-c803426f8f22
-    jinja: "{{premise}} \n\nQuestion: Does this imply that \"{{hypothesis}}\"? Yes,\
-      \ no, or maybe? ||| {{answer_choices[label]}}"
+    jinja: "{{premise}} \n\nQuestion: Does this imply that \"{{hypothesis}}\"? Yes\
+      \ or no? ||| {{answer_choices[label]}}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:

--- a/promptsource/templates/super_glue/axg/templates.yaml
+++ b/promptsource/templates/super_glue/axg/templates.yaml
@@ -1,0 +1,162 @@
+dataset: super_glue
+subset: axg
+templates:
+  0f530aa8-b254-4687-8032-bab1a65610c0: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: 0f530aa8-b254-4687-8032-bab1a65610c0
+    jinja: 'Given {{premise}} Should we assume that "{{hypothesis}}" is true? Yes
+      or no? ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: should assume
+    reference: Webson & Pavlick 2021
+  0f8afaef-19a0-472f-9e9f-c803426f8f22: !Template
+    answer_choices:
+    - 'Yes'
+    - Maybe
+    - 'No'
+    answer_choices_key: null
+    id: 0f8afaef-19a0-472f-9e9f-c803426f8f22
+    jinja: "{{premise}} \n\nQuestion: Does this imply that \"{{hypothesis}}\"? Yes,\
+      \ no, or maybe? ||| {{answer_choices[label]}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: does this imply
+    reference: v0.1
+  3b7a57e0-7733-4b21-9bed-a381fdc2415f: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: 3b7a57e0-7733-4b21-9bed-a381fdc2415f
+    jinja: '{{premise}} Based on the previous passage, is it true that "{{hypothesis}}"?
+      Yes or no? ||| {{ answer_choices[label] }}'
+    metadata: !TemplateMetadata
+      _do_eval: true
+      _do_train: false
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: based on the previous passage
+    reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+  4361cf07-1b58-478f-b97c-3b140832fb77: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: 4361cf07-1b58-478f-b97c-3b140832fb77
+    jinja: 'Given that {{premise}} Therefore, it must be true that "{{hypothesis}}"?
+      Yes or no? ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: must be true
+    reference: v0.1
+  626823f5-ff12-46d5-9e68-b2dc4bfe7cd4: !Template
+    answer_choices:
+    - 'True'
+    - 'False'
+    answer_choices_key: null
+    id: 626823f5-ff12-46d5-9e68-b2dc4bfe7cd4
+    jinja: '{{premise}}
+
+      Question: {{hypothesis}} True or False? ||| {{ answer_choices[label] }}'
+    metadata: !TemplateMetadata
+      _do_eval: true
+      _do_train: false
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: GPT-3 style
+    reference: Same as reported in Figure G31 of the GPT-3 paper.
+  7e1439f6-d54d-43e6-bdc7-306ad5fd9203: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: 7e1439f6-d54d-43e6-bdc7-306ad5fd9203
+    jinja: 'Given {{premise}} Is it guaranteed true that "{{hypothesis}}"? Yes or
+      no? ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: guaranteed true
+    reference: Webson & Pavlick 2021
+  c008c778-7621-496e-baa3-7b5817400659: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: c008c778-7621-496e-baa3-7b5817400659
+    jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes or no? |||
+      {{ answer_choices[label] }}
+    metadata: !TemplateMetadata
+      _do_eval: true
+      _do_train: false
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: does it follow that
+    reference: v0.1
+  d4a1dd92-e184-4843-bc1f-1f625c833249: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: d4a1dd92-e184-4843-bc1f-1f625c833249
+    jinja: '{{premise}} Are we justified in saying that "{{hypothesis}}"? Yes or no?
+      ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: justified in saying
+    reference: Webson & Pavlick 2021
+  db13469f-7161-4670-8a59-8c1137d1fa8b: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: db13469f-7161-4670-8a59-8c1137d1fa8b
+    jinja: 'Suppose {{premise}} Can we infer that "{{hypothesis}}"? Yes or no? |||
+      {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: can we infer
+    reference: Webson & Pavlick 2021
+  e21f5367-0cc8-412d-b8d9-78548438a384: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: e21f5367-0cc8-412d-b8d9-78548438a384
+    jinja: '{{premise}} Using only the above description and what you know about the
+      world, is "{{hypothesis}}" definitely correct? Yes or no? ||| {{ answer_choices[label]
+      }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: MNLI crowdsource
+    reference: Adapted from Williams et al. 2018's instructions to crowdsourcing workers.

--- a/promptsource/templates/super_glue/boolq/templates.yaml
+++ b/promptsource/templates/super_glue/boolq/templates.yaml
@@ -1,14 +1,34 @@
 dataset: super_glue
 subset: boolq
 templates:
+  3e386463-1715-4578-9cba-07d11a0d3b61: !Template
+    answer_choices: null
+    answer_choices_key: False ||| True
+    id: 3e386463-1715-4578-9cba-07d11a0d3b61
+    jinja: '{% if label != -1 %}
+
+      Passage: {{passage}}
+
+
+      After reading this passage, I have a question: {{question}}? True or False?
+      ||| {{answer_choices[label]}}
+
+      {% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: after_reading
+    reference: ''
   492f0f88-4370-46cd-839b-1de37a55aeda: !Template
     answer_choices:
     - 'False'
     - 'True'
     answer_choices_key: null
     id: 492f0f88-4370-46cd-839b-1de37a55aeda
-    jinja: "{{ passage }} \nquestion: {{ question }}\nanswer: ||| {{ answer_choices[label]\
-      \ }} "
+    jinja: "{% if label != -1 %}\n{{ passage }} \nquestion: {{ question }}\nanswer:\
+      \ ||| {{ answer_choices[label] }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -24,8 +44,8 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: 6cb6a026-c070-470a-b75d-bb8fdf424e35
-    jinja: "{{ passage }} \n\nHaving read that, I wonder {{ question }}? ||| {{ answer_choices[label]\
-      \ }} "
+    jinja: "{% if label != -1 %}\n{{ passage }} \n\nHaving read that, I wonder {{\
+      \ question }}? ||| {{ answer_choices[label] }} \n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -35,14 +55,33 @@ templates:
       original_task: true
     name: "I wonder\u2026"
     reference: ''
+  7cf7acdf-e3a2-459f-a3e8-2e2d27dd6aa5: !Template
+    answer_choices: null
+    answer_choices_key: No ||| Yes
+    id: 7cf7acdf-e3a2-459f-a3e8-2e2d27dd6aa5
+    jinja: '{% if label != -1 %}
+
+      Text: {{passage}}
+
+
+      Answer the following yes/no question: {{question}}? Yes or no? ||| {{answer_choices[label]}}
+
+      {% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: yes_no_question
+    reference: ''
   7d21d974-0624-4d4f-9e8c-644e2d009cb5: !Template
     answer_choices:
     - 'No'
     - 'Yes'
     answer_choices_key: null
     id: 7d21d974-0624-4d4f-9e8c-644e2d009cb5
-    jinja: "{{ passage }} \n\nHaving read that, could you tell me {{ question }}?\
-      \ ||| {{ answer_choices[label] }} "
+    jinja: "{% if label != -1 %}\n{{ passage }} \n\nHaving read that, could you tell\
+      \ me {{ question }}? ||| {{ answer_choices[label] }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -52,14 +91,37 @@ templates:
       original_task: true
     name: "could you tell me\u2026"
     reference: ''
+  922d3e87-ac58-4731-84d1-f0a40e47afb5: !Template
+    answer_choices: null
+    answer_choices_key: No ||| Yes
+    id: 922d3e87-ac58-4731-84d1-f0a40e47afb5
+    jinja: '{% if label != -1 %}
+
+      EXAM
+
+      1. Answer by yes or no.
+
+
+      Document: {{passage}}
+
+      Question: {{question}}? ||| {{answer_choices[label]}}
+
+      {% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: exam
+    reference: ''
   9a1bf459-8047-437c-9def-f21e960429cc: !Template
     answer_choices:
     - 'No'
     - 'Yes'
     answer_choices_key: null
     id: 9a1bf459-8047-437c-9def-f21e960429cc
-    jinja: "Based on the following passage, {{ passage }} \n{{ question }}? ||| {{\
-      \ answer_choices[label] }} "
+    jinja: "{% if label != -1 %}\nBased on the following passage, {{ passage }} \n\
+      {{ question }}? ||| {{ answer_choices[label] }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -69,16 +131,41 @@ templates:
       original_task: true
     name: based on the following passage
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+  9f4c6b0a-437b-40c0-b467-db4b7218d38d: !Template
+    answer_choices: null
+    answer_choices_key: False ||| True
+    id: 9f4c6b0a-437b-40c0-b467-db4b7218d38d
+    jinja: '{% if label != -1 %}
+
+      Exercise: read the text and answer the question by True or False.
+
+
+      Text: {{passage}}
+
+      Question: {{question}}? ||| {{answer_choices[label]}}
+
+      {% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: exercise
+    reference: ''
   b2b3cb60-d6e3-491c-a09a-8201e13e417e: !Template
     answer_choices:
     - 'No'
     - 'Yes'
     answer_choices_key: null
     id: b2b3cb60-d6e3-491c-a09a-8201e13e417e
-    jinja: '{{ passage }}
+    jinja: '{% if label != -1 %}
+
+      {{ passage }}
 
       Based on the previous passage, {{ question }}? ||| {{ answer_choices[label]
-      }} '
+      }}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -88,3 +175,24 @@ templates:
       original_task: true
     name: based on the previous passage
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+  eb78772c-e81e-4b8a-a77b-b75efd1c212a: !Template
+    answer_choices: null
+    answer_choices_key: False || True
+    id: eb78772c-e81e-4b8a-a77b-b75efd1c212a
+    jinja: '{% if label != -1 %}
+
+      {{passage}}
+
+
+      Q: {{question}}?
+
+      Is "Yes" a valid answer? True or False? ||| {{answer_choices[label]}}
+
+      {% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: valid_binary
+    reference: ''

--- a/promptsource/templates/super_glue/boolq/templates.yaml
+++ b/promptsource/templates/super_glue/boolq/templates.yaml
@@ -23,11 +23,11 @@ templates:
     reference: ''
   492f0f88-4370-46cd-839b-1de37a55aeda: !Template
     answer_choices:
-    - 'False'
-    - 'True'
+    - 'No'
+    - 'Yes'
     answer_choices_key: null
     id: 492f0f88-4370-46cd-839b-1de37a55aeda
-    jinja: "{% if label != -1 %}\n{{ passage }} \nquestion: {{ question }}\nanswer:\
+    jinja: "{% if label != -1 %}\n{{ passage }} \nQuestion: {{ question }}\nAnswer:\
       \ ||| {{ answer_choices[label] }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
@@ -120,8 +120,14 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: 9a1bf459-8047-437c-9def-f21e960429cc
-    jinja: "{% if label != -1 %}\nBased on the following passage, {{ passage }} \n\
-      {{ question }}? ||| {{ answer_choices[label] }}\n{% endif %}"
+    jinja: '{% if label != -1 %}
+
+      Based on the following passage, {{ question }}? {{ passage }}
+
+
+      ||| {{ answer_choices[label] }}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -184,9 +190,7 @@ templates:
       {{passage}}
 
 
-      Q: {{question}}?
-
-      Is "Yes" a valid answer? True or False? ||| {{answer_choices[label]}}
+      Q: {{question}}? True or False? ||| {{answer_choices[label]}}
 
       {% endif %}'
     metadata: !TemplateMetadata

--- a/promptsource/templates/super_glue/boolq/templates.yaml
+++ b/promptsource/templates/super_glue/boolq/templates.yaml
@@ -177,7 +177,7 @@ templates:
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
   eb78772c-e81e-4b8a-a77b-b75efd1c212a: !Template
     answer_choices: null
-    answer_choices_key: False || True
+    answer_choices_key: False ||| True
     id: eb78772c-e81e-4b8a-a77b-b75efd1c212a
     jinja: '{% if label != -1 %}
 

--- a/promptsource/templates/super_glue/cb/templates.yaml
+++ b/promptsource/templates/super_glue/cb/templates.yaml
@@ -1,121 +1,258 @@
 dataset: super_glue
 subset: cb
 templates:
-  0acadc5c-8cd0-4e33-b117-379321bc0df1: !Template
-    answer_choices:
-    - 'No'
-    - 'Yes'
-    - Neutral
-    answer_choices_key: null
-    id: 0acadc5c-8cd0-4e33-b117-379321bc0df1
-    jinja: 'Sentence 1: {{premise}}
-
-      Sentence 2: {{hypothesis}}
-
-      Question: Does Sentence 1 contradict Sentence 2? Yes, No, or Neutral? |||
-
-      {{answer_choices[label]}}'
-    metadata: !TemplateMetadata
-      _do_eval: true
-      _do_train: false
-      choices_in_prompt: true
-      metrics: []
-      original_task: false
-    name: does S1 contradict S2?
-    reference: Copied from Victor's prompts for XNLI.
-  5bca1a90-340b-42b4-9c0d-e5eb1c25605e: !Template
+  2e76cd0f-68ca-4f03-83ed-11cf15b25a84: !Template
     answer_choices:
     - 'Yes'
     - 'No'
     - Maybe
     answer_choices_key: null
-    id: 5bca1a90-340b-42b4-9c0d-e5eb1c25605e
-    jinja: Given that {{premise}} Does it follow that {{hypothesis}}? {{"Yes, no,
-      or maybe?"}} ||| {{ answer_choices[label] }}
+    id: 2e76cd0f-68ca-4f03-83ed-11cf15b25a84
+    jinja: 'Suppose {{premise}} Can we infer that "{{hypothesis}}"? Yes, no, or maybe?
+      ||| {{ answer_choices[label] }} '
     metadata: !TemplateMetadata
-      _do_eval: true
-      _do_train: false
       choices_in_prompt: true
-      metrics: []
+      metrics:
+      - Accuracy
       original_task: true
-    name: "given\u2026 does it follow that\u2026 "
-    reference: ''
-  684f44af-f09a-4231-a318-94473a9624b7: !Template
-    answer_choices:
-    - It must be true.
-    - It must be false.
-    - It might be true.
-    answer_choices_key: null
-    id: 684f44af-f09a-4231-a318-94473a9624b7
-    jinja: Given that {{premise}}, it {{"must be true, might be true, or must be false"}}
-      that {{hypothesis}}? ||| {{ answer_choices[label] }}
-    metadata: !TemplateMetadata
-      _do_eval: true
-      _do_train: false
-      choices_in_prompt: true
-      metrics: []
-      original_task: false
-    name: "given\u2026 it must be true that\u2026"
-    reference: 'Maybe a little verbose for a generative model, but anecdotally this
-      is the most natural way of how I say an NLI sentence pair out loud to humans.
-      Caveat: NLI annotations are not meant to be strictly truth-conditional entailment,
-      so "must" is not ideal.'
-  774c170e-9fff-4b0b-871a-30967b0186f6: !Template
+    name: can we infer
+    reference: Webson & Pavlick 2021
+  358860fd-61ad-45fd-92a6-a72ca9107ebc: !Template
     answer_choices:
     - 'Yes'
     - 'No'
     - Maybe
     answer_choices_key: null
-    id: 774c170e-9fff-4b0b-871a-30967b0186f6
-    jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}
+    id: 358860fd-61ad-45fd-92a6-a72ca9107ebc
+    jinja: '{{premise}} Based on the previous passage, is it true that "{{hypothesis}}"?
       Yes, no, or maybe? ||| {{ answer_choices[label] }}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: false
       choices_in_prompt: true
-      metrics: []
+      metrics:
+      - Accuracy
       original_task: true
     name: based on the previous passage
     reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
-  86120953-771a-4dca-a681-d628117ba6d2: !Template
+  3f43a599-ffdb-490e-8952-c0ce41dd4621: !Template
+    answer_choices:
+    - 'True'
+    - 'False'
+    - Inconclusive
+    answer_choices_key: null
+    id: 3f43a599-ffdb-490e-8952-c0ce41dd4621
+    jinja: '{{premise}} Based on that information, is the claim: "{{hypothesis}}"
+      {{"true"}}, {{"false"}}, or {{"inconclusive"}}? ||| {{ answer_choices[label]
+      }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: claim true/false/inconclusive
+    reference: Bers et al.
+  404eed25-558a-4d39-9515-7de46d60d4e0: !Template
     answer_choices:
     - 'Yes'
     - 'No'
-    - Neutral
+    - Maybe
     answer_choices_key: null
-    id: 86120953-771a-4dca-a681-d628117ba6d2
-    jinja: 'Sentence 1: {{premise}}
-
-      Sentence 2: {{hypothesis}}
-
-      Question: Does Sentence 1 entail Sentence 2? Yes, No, or Neutral? |||
-
-      {{answer_choices[label]}}'
+    id: 404eed25-558a-4d39-9515-7de46d60d4e0
+    jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes, no, or maybe?
+      ||| {{ answer_choices[label] }}
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: false
       choices_in_prompt: true
-      metrics: []
+      metrics:
+      - Accuracy
       original_task: true
-    name: does S1 entail S2?
-    reference: Copied from Victor's prompts for XNLI.
-  bab42d43-d1e6-4a42-8112-75a398fd582c: !Template
+    name: does it follow that
+    reference: v0.1
+  5c9b1fa9-93f0-4f82-b9e3-e0967e4d7260: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    - Maybe
+    answer_choices_key: null
+    id: 5c9b1fa9-93f0-4f82-b9e3-e0967e4d7260
+    jinja: '{{premise}} Are we justified in saying that "{{hypothesis}}"? Yes, no,
+      or maybe? ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: justified in saying
+    reference: Webson & Pavlick 2021
+  6b0c6191-183d-4731-8050-ab17c909335c: !Template
+    answer_choices:
+    - Always
+    - Never
+    - Sometimes
+    answer_choices_key: null
+    id: 6b0c6191-183d-4731-8050-ab17c909335c
+    jinja: Suppose it's true that {{premise}} Then, is "{{hypothesis}}" {{"always"}},
+      {{"sometimes"}}, or {{"never"}} true? ||| {{ answer_choices[label] }}
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: always/sometimes/never
+    reference: Bers et al.
+  75db2bc2-3caa-4956-9653-13c7dd6255df: !Template
     answer_choices:
     - 'True'
     - 'False'
     - Neither
     answer_choices_key: null
-    id: bab42d43-d1e6-4a42-8112-75a398fd582c
+    id: 75db2bc2-3caa-4956-9653-13c7dd6255df
     jinja: '{{premise}}
 
-      Question: {{hypothesis}}. True, False, or Neither? ||| {{ answer_choices[label]
+      Question: {{hypothesis}} True, False, or Neither? ||| {{ answer_choices[label]
       }}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: false
       choices_in_prompt: true
-      metrics: []
+      metrics:
+      - Accuracy
       original_task: true
     name: GPT-3 style
     reference: 'Same as reported in Figure G7 of the GPT-3 paper, except that there
       is no task identifying tokens like "anli R1: ".'
+  87237a07-7cce-470a-80ac-3e5e3a5283ba: !Template
+    answer_choices:
+    - Always
+    - Never
+    - Sometimes
+    answer_choices_key: null
+    id: 87237a07-7cce-470a-80ac-3e5e3a5283ba
+    jinja: "{{premise}} \n\nKeeping in mind the above text, consider: {{hypothesis}}\
+      \ Is this {{\"always\"}}, {{\"sometimes\"}}, or {{\"never\"}} correct? ||| {{\
+      \ answer_choices[label] }}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: consider always/sometimes/never
+    reference: Bers et al.
+  8798b8a4-1f59-4c72-9c1b-3e3044a7462a: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    - Maybe
+    answer_choices_key: null
+    id: 8798b8a4-1f59-4c72-9c1b-3e3044a7462a
+    jinja: 'Given {{premise}} Is it guaranteed true that "{{hypothesis}}"? Yes, no,
+      or maybe? ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: guaranteed true
+    reference: Webson & Pavlick 2021
+  8e3b8d3d-1362-47dc-922a-82c03f965989: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    - Maybe
+    answer_choices_key: null
+    id: 8e3b8d3d-1362-47dc-922a-82c03f965989
+    jinja: 'Given that {{premise}} Therefore, it must be true that "{{hypothesis}}"?
+      Yes, no, or maybe? ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: must be true
+    reference: v0.1
+  90ab1002-093c-4e54-b48f-626655e36b65: !Template
+    answer_choices:
+    - Guaranteed
+    - Impossible
+    - Possible
+    answer_choices_key: null
+    id: 90ab1002-093c-4e54-b48f-626655e36b65
+    jinja: "Assume it is true that {{premise}} \n\nTherefore, \"{{hypothesis}}\" is\
+      \ {{\"guaranteed\"}}, {{\"possible\"}}, or {{\"impossible\"}}? ||| {{ answer_choices[label]\
+      \ }}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: guaranteed/possible/impossible
+    reference: Bers et al.
+  a485d120-6eef-4ff6-8684-42df1639b101: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    - Maybe
+    answer_choices_key: null
+    id: a485d120-6eef-4ff6-8684-42df1639b101
+    jinja: "{{premise}} \n\nQuestion: Does this imply that \"{{hypothesis}}\"? Yes,\
+      \ no, or maybe? ||| {{answer_choices[label]}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: does this imply
+    reference: v0.1
+  bee62bfa-5307-4e1c-97b2-2ad2f7bcb179: !Template
+    answer_choices:
+    - Correct
+    - Incorrect
+    - Inconclusive
+    answer_choices_key: null
+    id: bee62bfa-5307-4e1c-97b2-2ad2f7bcb179
+    jinja: '{{premise}} Using only the above description and what you know about the
+      world, "{{hypothesis}}" is definitely correct, incorrect, or inconclusive? |||
+      {{ answer_choices[label] }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: MNLI crowdsource
+    reference: Adapted from Williams et al. 2018's instructions to crowdsourcing workers.
+  e503b148-8e6c-43b5-9ed6-312794c54d9b: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    - Maybe
+    answer_choices_key: null
+    id: e503b148-8e6c-43b5-9ed6-312794c54d9b
+    jinja: 'Given {{premise}} Should we assume that "{{hypothesis}}" is true? Yes,
+      no, or maybe? ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: should assume
+    reference: Webson & Pavlick 2021
+  ea56b7f3-6e07-45bc-b619-c527eac4a41b: !Template
+    answer_choices:
+    - 'True'
+    - 'False'
+    - Inconclusive
+    answer_choices_key: null
+    id: ea56b7f3-6e07-45bc-b619-c527eac4a41b
+    jinja: 'Take the following as truth: {{premise}}
+
+      Then the following statement: "{{hypothesis}}" is {{"true"}}, {{"false"}}, or
+      {{"inconclusive"}}? ||| {{ answer_choices[label] }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: take the following as truth
+    reference: Bers et al.

--- a/promptsource/templates/super_glue/cb/templates.yaml
+++ b/promptsource/templates/super_glue/cb/templates.yaml
@@ -42,13 +42,13 @@ templates:
     reference: ''
   684f44af-f09a-4231-a318-94473a9624b7: !Template
     answer_choices:
-    - must be true
-    - must be false
-    - might be true
+    - It must be true.
+    - It must be false.
+    - It might be true.
     answer_choices_key: null
     id: 684f44af-f09a-4231-a318-94473a9624b7
     jinja: Given that {{premise}}, it {{"must be true, might be true, or must be false"}}
-      that {{hypothesis}}? ||| It {{ answer_choices[label] }}.
+      that {{hypothesis}}? ||| {{ answer_choices[label] }}
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: false

--- a/promptsource/templates/super_glue/copa/templates.yaml
+++ b/promptsource/templates/super_glue/copa/templates.yaml
@@ -42,8 +42,8 @@ templates:
     answer_choices_key: '{{choice1}} ||| {{choice2}}'
     id: 4d879cbe-2fd7-424a-9d78-3f5200313fba
     jinja: "{{ premise }} \n\nI am hesitating between two options. Help me choose\
-      \ the most logical {% if question == \"cause\" %} cause: {% else %} effect:\
-      \ {% endif %}\n- {{choice1}}\n- {{choice2}} ||| {{ answer_choices[label] }}"
+      \ the more likely {% if question == \"cause\" %} cause: {% else %} effect: {%\
+      \ endif %}\n- {{choice1}}\n- {{choice2}} ||| {{ answer_choices[label] }}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -58,7 +58,7 @@ templates:
     jinja: '{{ premise }} {% if question == "cause" %} This happened because... {%
       else %} As a consequence... {% endif %}
 
-      Help me pick the most plausible option:
+      Help me pick the more plausible option:
 
       - {{choice1}}
 
@@ -108,7 +108,7 @@ templates:
     id: 8ce80f8a-239e-4393-892c-f63dbb0d9929
     jinja: "{{ premise }} \n\nWhat's the best option?\n- {{choice1}}\n- {{choice2}}\n\
       \nWe are looking for {% if question == \"cause\" %} a cause {% else %} an effect\
-      \ {% endif %}.\n||| {{answer_choices[label]}}"
+      \ {% endif %}\n||| {{answer_choices[label]}}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -136,7 +136,7 @@ templates:
     answer_choices: null
     answer_choices_key: '{{choice1}} ||| {{choice2}}'
     id: a1f9951e-2b6b-4530-9636-9cdf4c1658c5
-    jinja: 'Pick the most logical continuation to the following sentence:
+    jinja: 'Pick the more likely continuation to the following sentence:
 
       {{ premise }} {% if question == "cause" %} as a result of: {% else %} as a consequence:
       {% endif %}
@@ -149,7 +149,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: most_logical
+    name: more likely
     reference: ''
   a61d8c21-da25-47bf-b5fe-14a8edd650af: !Template
     answer_choices: null
@@ -205,20 +205,4 @@ templates:
       - Accuracy
       original_task: true
     name: choose
-    reference: ''
-  f794f8d0-e81b-4ba9-bc3d-dc8201c38954: !Template
-    answer_choices: null
-    answer_choices_key: '{{choice1}} ||| {{choice2}}'
-    id: f794f8d0-e81b-4ba9-bc3d-dc8201c38954
-    jinja: "{% if question == \"effect\" %} \n{{ premise }} Which may cause \"{{ answer_choices[0]\
-      \ }}\" or \"{{ answer_choices[1] }}\"? ||| {{ answer_choices[label] }}\n{% endif\
-      \ %}"
-    metadata: !TemplateMetadata
-      _do_eval: true
-      _do_train: true
-      choices_in_prompt: true
-      metrics:
-      - Accuracy
-      original_task: true
-    name: "\u2026which may cause C1 or C2?"
     reference: ''

--- a/promptsource/templates/super_glue/copa/templates.yaml
+++ b/promptsource/templates/super_glue/copa/templates.yaml
@@ -1,6 +1,26 @@
 dataset: super_glue
 subset: copa
 templates:
+  0edd8660-f299-4819-a5ac-633c11177228: !Template
+    answer_choices: null
+    answer_choices_key: '{{choice1}} ||| {{choice2}}'
+    id: 0edd8660-f299-4819-a5ac-633c11177228
+    jinja: 'Exercise: choose the most plausible alternative.
+
+
+      {{ premise }} {% if question == "cause" %} because... {% else %} so... {% endif
+      %}
+
+      - {{choice1}}
+
+      - {{choice2}} ||| {{ answer_choices[label] }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: exercise
+    reference: ''
   150789fe-e309-47a1-82c9-0a4dc2c6b12b: !Template
     answer_choices: null
     answer_choices_key: '{{choice1}} ||| {{choice2}}'
@@ -16,6 +36,39 @@ templates:
       - Accuracy
       original_task: true
     name: "\u2026What could happen next, C1 or C2?"
+    reference: ''
+  4d879cbe-2fd7-424a-9d78-3f5200313fba: !Template
+    answer_choices: null
+    answer_choices_key: '{{choice1}} ||| {{choice2}}'
+    id: 4d879cbe-2fd7-424a-9d78-3f5200313fba
+    jinja: "{{ premise }} \n\nI am hesitating between two options. Help me choose\
+      \ the most logical {% if question == \"cause\" %} cause: {% else %} effect:\
+      \ {% endif %}\n- {{choice1}}\n- {{choice2}} ||| {{ answer_choices[label] }}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: i_am_hesitating
+    reference: ''
+  66ea075e-4d03-4a78-b1fa-9a5228cf0c9d: !Template
+    answer_choices: null
+    answer_choices_key: '{{choice1}} ||| {{choice2}}'
+    id: 66ea075e-4d03-4a78-b1fa-9a5228cf0c9d
+    jinja: '{{ premise }} {% if question == "cause" %} This happened because... {%
+      else %} As a consequence... {% endif %}
+
+      Help me pick the most plausible option:
+
+      - {{choice1}}
+
+      - {{choice2}} ||| {{ answer_choices[label] }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: plausible_alternatives
     reference: ''
   744047dc-1298-45a2-8d68-d67e3f834ded: !Template
     answer_choices: null
@@ -49,6 +102,20 @@ templates:
       original_task: true
     name: "\u2026As a result, C1 or C2?"
     reference: ''
+  8ce80f8a-239e-4393-892c-f63dbb0d9929: !Template
+    answer_choices: null
+    answer_choices_key: '{{choice1}} ||| {{choice2}}'
+    id: 8ce80f8a-239e-4393-892c-f63dbb0d9929
+    jinja: "{{ premise }} \n\nWhat's the best option?\n- {{choice1}}\n- {{choice2}}\n\
+      \nWe are looking for {% if question == \"cause\" %} a cause {% else %} an effect\
+      \ {% endif %}.\n||| {{answer_choices[label]}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: best_option
+    reference: ''
   8cf2ba73-aee5-4651-b5d4-b1b88afe4abb: !Template
     answer_choices: null
     answer_choices_key: '{{choice1}} ||| {{choice2}}'
@@ -65,6 +132,45 @@ templates:
       original_task: true
     name: "\u2026which may be caused by"
     reference: ''
+  a1f9951e-2b6b-4530-9636-9cdf4c1658c5: !Template
+    answer_choices: null
+    answer_choices_key: '{{choice1}} ||| {{choice2}}'
+    id: a1f9951e-2b6b-4530-9636-9cdf4c1658c5
+    jinja: 'Pick the most logical continuation to the following sentence:
+
+      {{ premise }} {% if question == "cause" %} as a result of: {% else %} as a consequence:
+      {% endif %}
+
+      - {{choice1}}
+
+      - {{choice2}} ||| {{ answer_choices[label] }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: most_logical
+    reference: ''
+  a61d8c21-da25-47bf-b5fe-14a8edd650af: !Template
+    answer_choices: null
+    answer_choices_key: '{{choice1}} ||| {{choice2}}'
+    id: a61d8c21-da25-47bf-b5fe-14a8edd650af
+    jinja: '{{ premise }}
+
+
+      Select the most plausible {% if question == "cause" %} cause: {% else %} effect:
+      {% endif %}
+
+      - {{choice1}}
+
+      - {{choice2}} ||| {{ answer_choices[label] }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: cause_effect
+    reference: ''
   a8bf11c3-bea2-45ba-a533-957d8bee5e2e: !Template
     answer_choices: null
     answer_choices_key: '{{choice1}} ||| {{choice2}}'
@@ -80,6 +186,25 @@ templates:
       - Accuracy
       original_task: true
     name: "\u2026why? C1 or C2"
+    reference: ''
+  f32348cd-d3cb-4619-87b9-e24f99c78567: !Template
+    answer_choices: null
+    answer_choices_key: '{{choice1}} ||| {{choice2}}'
+    id: f32348cd-d3cb-4619-87b9-e24f99c78567
+    jinja: '{{ premise }} {% if question == "cause" %} because... {% else %} so...
+      {% endif %}
+
+      Choose between:
+
+      - {{choice1}}
+
+      - {{choice2}} ||| {{ answer_choices[label] }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: choose
     reference: ''
   f794f8d0-e81b-4ba9-bc3d-dc8201c38954: !Template
     answer_choices: null

--- a/promptsource/templates/super_glue/multirc/templates.yaml
+++ b/promptsource/templates/super_glue/multirc/templates.yaml
@@ -42,7 +42,7 @@ templates:
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
   431a5c97-af33-4053-83c8-afb0dfc04448: !Template
     answer_choices: null
-    answer_choices_key: Yes ||| No
+    answer_choices_key: No ||| Yes
     id: 431a5c97-af33-4053-83c8-afb0dfc04448
     jinja: '{{paragraph}}
 
@@ -97,7 +97,7 @@ templates:
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
   7bf537ea-ff8d-44c7-8fc9-305b35e3be66: !Template
     answer_choices: null
-    answer_choices_key: Yes ||| No
+    answer_choices_key: No ||| Yes
     id: 7bf537ea-ff8d-44c7-8fc9-305b35e3be66
     jinja: '{{paragraph}}
 
@@ -135,7 +135,7 @@ templates:
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
   ae9b2b0b-1731-4370-adcc-36c4a959490d: !Template
     answer_choices: null
-    answer_choices_key: Yes ||| No
+    answer_choices_key: No ||| Yes
     id: ae9b2b0b-1731-4370-adcc-36c4a959490d
     jinja: 'Is "{{answer}}" a correct answer to the following question?
 
@@ -156,7 +156,7 @@ templates:
     reference: ''
   b63fd1c3-b4a6-43c3-8429-6a389235b2a4: !Template
     answer_choices: null
-    answer_choices_key: Yes ||| No
+    answer_choices_key: No ||| Yes
     id: b63fd1c3-b4a6-43c3-8429-6a389235b2a4
     jinja: '{{paragraph}}
 

--- a/promptsource/templates/super_glue/multirc/templates.yaml
+++ b/promptsource/templates/super_glue/multirc/templates.yaml
@@ -10,8 +10,7 @@ templates:
 
       Question: {{question}}
 
-      I found this answer ("{{answer}}") on the internet. Is that correct? Yes or
-      no?
+      I found this answer "{{answer}}". Is that correct? Yes or no?
 
       |||
 
@@ -163,7 +162,7 @@ templates:
 
       Question: {{question}}
 
-      I think that "{{answer}}" is a valid answer. Could you confirm? Yes or no.
+      I think "{{answer}}" is a valid answer. Could you confirm? Yes or no?
 
       |||
 

--- a/promptsource/templates/super_glue/multirc/templates.yaml
+++ b/promptsource/templates/super_glue/multirc/templates.yaml
@@ -1,6 +1,28 @@
 dataset: super_glue
 subset: multirc
 templates:
+  2d95962b-a545-41ae-8d76-07ee6704ef65: !Template
+    answer_choices: null
+    answer_choices_key: No ||| Yes
+    id: 2d95962b-a545-41ae-8d76-07ee6704ef65
+    jinja: '{{paragraph}}
+
+
+      Question: {{question}}
+
+      I found this answer ("{{answer}}") on the internet. Is that correct? Yes or
+      no?
+
+      |||
+
+      {{answer_choices[label]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: found_this_answer
+    reference: ''
   42d47df9-09de-4691-8e49-7cfadd636cdd: !Template
     answer_choices:
     - 'No'
@@ -18,6 +40,27 @@ templates:
       original_task: true
     name: "is\u2026 a correct answer?"
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+  431a5c97-af33-4053-83c8-afb0dfc04448: !Template
+    answer_choices: null
+    answer_choices_key: Yes ||| No
+    id: 431a5c97-af33-4053-83c8-afb0dfc04448
+    jinja: '{{paragraph}}
+
+      Question: {{question}}
+
+
+      I am grading my students'' exercises. Is the answer "{{answer}}" correct?
+
+      |||
+
+      {{answer_choices[label]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: grading
+    reference: ''
   4fc9e1ea-7451-4dba-a2cb-ce870e35ef8b: !Template
     answer_choices:
     - 'No'
@@ -52,6 +95,27 @@ templates:
       original_task: true
     name: "paragraph\u2026 question\u2026 is it\u2026 ?"
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+  7bf537ea-ff8d-44c7-8fc9-305b35e3be66: !Template
+    answer_choices: null
+    answer_choices_key: Yes ||| No
+    id: 7bf537ea-ff8d-44c7-8fc9-305b35e3be66
+    jinja: '{{paragraph}}
+
+
+      Decide whether "{{answer}}" is a valid answer to the following question: {{question}}
+
+      Answer yes or no.
+
+      |||
+
+      {{answer_choices[label]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: decide_valid
+    reference: ''
   7d878b89-2774-429a-82fb-ac801379e3ae: !Template
     answer_choices:
     - 'No'
@@ -69,6 +133,48 @@ templates:
       original_task: true
     name: "is the correct answer\u2026"
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+  ae9b2b0b-1731-4370-adcc-36c4a959490d: !Template
+    answer_choices: null
+    answer_choices_key: Yes ||| No
+    id: ae9b2b0b-1731-4370-adcc-36c4a959490d
+    jinja: 'Is "{{answer}}" a correct answer to the following question?
+
+      Question: {{question}}
+
+
+      Rely on the following text: {{paragraph}}
+
+      |||
+
+      {{answer_choices[label]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: correct
+    reference: ''
+  b63fd1c3-b4a6-43c3-8429-6a389235b2a4: !Template
+    answer_choices: null
+    answer_choices_key: Yes ||| No
+    id: b63fd1c3-b4a6-43c3-8429-6a389235b2a4
+    jinja: '{{paragraph}}
+
+
+      Question: {{question}}
+
+      I think that "{{answer}}" is a valid answer. Could you confirm? Yes or no.
+
+      |||
+
+      {{answer_choices[label]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: confirm
+    reference: ''
   d2d78b88-8845-45b5-935a-6451da00b285: !Template
     answer_choices:
     - 'No'

--- a/promptsource/templates/super_glue/record/templates.yaml
+++ b/promptsource/templates/super_glue/record/templates.yaml
@@ -6,8 +6,8 @@ templates:
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 014b669e-2e3b-40ce-bdde-418966c7d666
     jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nWhich\
-      \ one is the \"{{\"@placeholder\"}}\"? {{ entities | join(\", \") }}? ||| {{ answers\
-      \ | choice }}\n{% endif %}"
+      \ one is the \"{{\"@placeholder\"}}\"? {{ entities | join(\", \") }}? ||| {{\
+      \ answers | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -22,10 +22,10 @@ templates:
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 11e27d59-b1f5-43a1-9ccc-17f1c3249173
     jinja: "{% if ( answers | length ) > 0 %} \nThe following document has been corrupted.\
-      \ Tell me what \"{{\"@placeholder\"}}\" is referring to.\n\nDocument: {{ passage }}\
-      \ \n{{ query }} \n|||\n{{ answers | choice }}\n{% endif %}"
+      \ Tell me what \"{{\"@placeholder\"}}\" is referring to.\n\nDocument: {{ passage\
+      \ }} \n{{ query }} \n|||\n{{ answers | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
-      choices_in_prompt: true
+      choices_in_prompt: false
       metrics:
       - Squad
       original_task: true
@@ -36,8 +36,9 @@ templates:
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 441c70e3-095a-44a1-8163-bc3b666b7ea1
     jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \n\nYou\
-      \ should decide what \"{{\"@placeholder\"}}\" is referring to. Choose between:\n- {{answer_choices\
-      \ | join(\"\\n- \")}}\n|||\n{{ answers | choice }}\n{% endif %}"
+      \ should decide what \"{{\"@placeholder\"}}\" is referring to. Choose between:\n\
+      - {{answer_choices | join(\"\\n- \")}}\n|||\n{{ answers | choice }}\n{% endif\
+      \ %}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -50,8 +51,8 @@ templates:
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 91555c1c-c1e4-469b-a2a4-fc952ce1a145
     jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nIn the\
-      \ question above, the \"{{\"@placeholder\"}}\" stands for ||| {{ answers | choice }}\n\
-      {% endif %}"
+      \ question above, the \"{{\"@placeholder\"}}\" stands for ||| {{ answers | choice\
+      \ }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -66,8 +67,8 @@ templates:
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 99dd38ce-32f3-4d58-93c5-59821002b9cc
     jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nWhat\
-      \ could the \"{{\"@placeholder\"}}\" be? {{ entities | join(\", \") }}? ||| {{ answers\
-      \ | choice }}\n{% endif %}"
+      \ could the \"{{\"@placeholder\"}}\" be? {{ entities | join(\", \") }}? |||\
+      \ {{ answers | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true

--- a/promptsource/templates/super_glue/record/templates.yaml
+++ b/promptsource/templates/super_glue/record/templates.yaml
@@ -6,7 +6,7 @@ templates:
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 014b669e-2e3b-40ce-bdde-418966c7d666
     jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nWhich\
-      \ one is the "{{"@placeholder"}}"? {{ entities | join(\", \") }}? ||| {{ answers\
+      \ one is the \"{{\"@placeholder\"}}\"? {{ entities | join(\", \") }}? ||| {{ answers\
       \ | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
@@ -22,8 +22,8 @@ templates:
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 11e27d59-b1f5-43a1-9ccc-17f1c3249173
     jinja: "{% if ( answers | length ) > 0 %} \nThe following document has been corrupted.\
-      \ Tell me what \"{{"{{"@placeholder"}}"}}\" is referring to.\n\nDocument: {{ passage\
-      \ }} \n{{ query }} \n|||\n{{ answers | choice }}\n{% endif %}"
+      \ Tell me what \"{{\"@placeholder\"}}\" is referring to.\n\nDocument: {{ passage }}\
+      \ \n{{ query }} \n|||\n{{ answers | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -36,9 +36,8 @@ templates:
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 441c70e3-095a-44a1-8163-bc3b666b7ea1
     jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \n\nYou\
-      \ should decide what \"{{"{{"@placeholder"}}"}}\" is referring to. Choose between:\n\
-      - {{answer_choices | join(\"\\n- \")}}\n|||\n{{ answers | choice }}\n{% endif\
-      \ %}"
+      \ should decide what \"{{\"@placeholder\"}}\" is referring to. Choose between:\n- {{answer_choices\
+      \ | join(\"\\n- \")}}\n|||\n{{ answers | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -51,7 +50,7 @@ templates:
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 91555c1c-c1e4-469b-a2a4-fc952ce1a145
     jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nIn the\
-      \ question above, the "{{"@placeholder"}}" stands for ||| {{ answers | choice }}\n\
+      \ question above, the \"{{\"@placeholder\"}}\" stands for ||| {{ answers | choice }}\n\
       {% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
@@ -67,7 +66,7 @@ templates:
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 99dd38ce-32f3-4d58-93c5-59821002b9cc
     jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nWhat\
-      \ could the "{{"@placeholder"}}" be? {{ entities | join(\", \") }}? ||| {{ answers\
+      \ could the \"{{\"@placeholder\"}}\" be? {{ entities | join(\", \") }}? ||| {{ answers\
       \ | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
@@ -180,8 +179,8 @@ templates:
     answer_choices_key: '{{ entities | join("|||") }}'
     id: e68d13c5-df75-4de0-b59e-f2eaf4af6ce7
     jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nCan\
-      \ you figure out what does the "{{"@placeholder"}}" mean? It means ||| {{ answers\
-      \ | choice }}\n{% endif %}"
+      \ you figure out what does the \"{{\"@placeholder\"}}\" mean? It means ||| {{\
+      \ answers | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true

--- a/promptsource/templates/super_glue/record/templates.yaml
+++ b/promptsource/templates/super_glue/record/templates.yaml
@@ -6,30 +6,59 @@ templates:
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 014b669e-2e3b-40ce-bdde-418966c7d666
     jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nWhich\
-      \ one is the \"@placeholder\"? {{ entities | join(\", \") }}? ||| {{ answers\
+      \ one is the "{{"@placeholder"}}"? {{ entities | join(\", \") }}? ||| {{ answers\
       \ | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
       choices_in_prompt: true
       metrics:
-      - Span Squad
+      - Squad
       original_task: true
     name: Which one is the placeholder?
+    reference: ''
+  11e27d59-b1f5-43a1-9ccc-17f1c3249173: !Template
+    answer_choices: null
+    answer_choices_key: '{{ entities | join("|||") }}'
+    id: 11e27d59-b1f5-43a1-9ccc-17f1c3249173
+    jinja: "{% if ( answers | length ) > 0 %} \nThe following document has been corrupted.\
+      \ Tell me what \"{{"{{"@placeholder"}}"}}\" is referring to.\n\nDocument: {{ passage\
+      \ }} \n{{ query }} \n|||\n{{ answers | choice }}\n{% endif %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Squad
+      original_task: true
+    name: corrupted
+    reference: ''
+  441c70e3-095a-44a1-8163-bc3b666b7ea1: !Template
+    answer_choices: null
+    answer_choices_key: '{{ entities | join("|||") }}'
+    id: 441c70e3-095a-44a1-8163-bc3b666b7ea1
+    jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \n\nYou\
+      \ should decide what \"{{"{{"@placeholder"}}"}}\" is referring to. Choose between:\n\
+      - {{answer_choices | join(\"\\n- \")}}\n|||\n{{ answers | choice }}\n{% endif\
+      \ %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Squad
+      original_task: true
+    name: choose_between
     reference: ''
   91555c1c-c1e4-469b-a2a4-fc952ce1a145: !Template
     answer_choices: null
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 91555c1c-c1e4-469b-a2a4-fc952ce1a145
     jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nIn the\
-      \ question above, the \"@placeholder\" stands for ||| {{ answers | choice }}\n\
+      \ question above, the "{{"@placeholder"}}" stands for ||| {{ answers | choice }}\n\
       {% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
       choices_in_prompt: false
       metrics:
-      - Span Squad
+      - Squad
       original_task: true
     name: In the question above, the placeholder stands for
     reference: ''
@@ -38,16 +67,45 @@ templates:
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 99dd38ce-32f3-4d58-93c5-59821002b9cc
     jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nWhat\
-      \ could the \"@placeholder\" be? {{ entities | join(\", \") }}? ||| {{ answers\
+      \ could the "{{"@placeholder"}}" be? {{ entities | join(\", \") }}? ||| {{ answers\
       \ | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
       choices_in_prompt: true
       metrics:
-      - Span Squad
+      - Squad
       original_task: true
     name: What could the placeholder be?
+    reference: ''
+  9b688cf3-28bf-4f33-94cf-e73e4fa8c608: !Template
+    answer_choices: null
+    answer_choices_key: '{{entities | join("|||")}}'
+    id: 9b688cf3-28bf-4f33-94cf-e73e4fa8c608
+    jinja: '{% if ( answers | length ) > 0 %}
+
+      {{ passage }}
+
+      {{ query }}
+
+
+      I am trying to decide what "{{"@placeholder"}}" means in the previous text.
+
+      Help by choosing an option between:
+
+      - {{ entities | join("\n- ") }}
+
+      |||
+
+      {{ answers | choice }}
+
+      {% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Squad
+      original_task: true
+    name: trying_to_decide
     reference: ''
   a5ed27ed-162b-4ac1-9c7a-85059d5214be: !Template
     answer_choices: null
@@ -60,23 +118,76 @@ templates:
       _do_train: true
       choices_in_prompt: false
       metrics:
-      - Span Squad
+      - Squad
       original_task: true
     name: "the placeholder refers to\u2026"
+    reference: ''
+  d3fce74e-0d9d-404a-a009-9ebbf5794c2c: !Template
+    answer_choices: null
+    answer_choices_key: '{{entities | join("|||")}}'
+    id: d3fce74e-0d9d-404a-a009-9ebbf5794c2c
+    jinja: '{% if ( answers | length ) > 0 %}
+
+      Exercise: Extract from the text the correct entity that "{{"@placeholder"}}"
+      is referring to.
+
+
+      {{ passage }}
+
+      {{ query }}
+
+      |||
+
+      {{ answers | choice }}
+
+      {% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Squad
+      original_task: true
+    name: exercise
+    reference: ''
+  de5b635e-c2f4-40bb-81ac-650f1b45564b: !Template
+    answer_choices: null
+    answer_choices_key: '{{entities | join("|||")}}'
+    id: de5b635e-c2f4-40bb-81ac-650f1b45564b
+    jinja: '{% if ( answers | length ) > 0 %}
+
+      {{ passage }}
+
+      {{ query }}
+
+
+      Pick one option, "{{"@placeholder"}}" refers to:
+
+      - {{answer_choices | join("\n- ")}}
+
+      |||
+
+      {{ answers | choice }}
+
+      {% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Squad
+      original_task: true
+    name: pick_one_option
     reference: ''
   e68d13c5-df75-4de0-b59e-f2eaf4af6ce7: !Template
     answer_choices: null
     answer_choices_key: '{{ entities | join("|||") }}'
     id: e68d13c5-df75-4de0-b59e-f2eaf4af6ce7
     jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nCan\
-      \ you figure out what does the \"@placeholder\" mean? It means ||| {{ answers\
+      \ you figure out what does the "{{"@placeholder"}}" mean? It means ||| {{ answers\
       \ | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
       choices_in_prompt: false
       metrics:
-      - Span Squad
+      - Squad
       original_task: true
     name: "Can you figure out\u2026"
     reference: ''

--- a/promptsource/templates/super_glue/rte/templates.yaml
+++ b/promptsource/templates/super_glue/rte/templates.yaml
@@ -68,12 +68,11 @@ templates:
   9e078fb4-505b-413c-bb5e-3cd16ddcf5d7: !Template
     answer_choices:
     - 'Yes'
-    - Maybe
     - 'No'
     answer_choices_key: null
     id: 9e078fb4-505b-413c-bb5e-3cd16ddcf5d7
-    jinja: "{{premise}} \n\nQuestion: Does this imply that \"{{hypothesis}}\"? Yes,\
-      \ no, or maybe? ||| {{answer_choices[label]}}"
+    jinja: "{{premise}} \n\nQuestion: Does this imply that \"{{hypothesis}}\"? Yes\
+      \ or no? ||| {{answer_choices[label]}}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:

--- a/promptsource/templates/super_glue/rte/templates.yaml
+++ b/promptsource/templates/super_glue/rte/templates.yaml
@@ -1,65 +1,58 @@
 dataset: super_glue
 subset: rte
 templates:
-  0583671e-b717-4353-a0d4-ea1e4ac56429: !Template
+  2b52a83c-0021-41fe-b44c-5aaa076d71a2: !Template
     answer_choices:
     - 'Yes'
     - 'No'
     answer_choices_key: null
-    id: 0583671e-b717-4353-a0d4-ea1e4ac56429
-    jinja: Given that {{premise}} Does it follow that "{{hypothesis}}"? ||| {{ answer_choices[label]
-      }}
+    id: 2b52a83c-0021-41fe-b44c-5aaa076d71a2
+    jinja: '{{premise}} Using only the above description and what you know about the
+      world, is "{{hypothesis}}" definitely correct? Yes or no? ||| {{ answer_choices[label]
+      }}'
     metadata: !TemplateMetadata
-      _do_eval: true
-      _do_train: false
-      choices_in_prompt: false
-      metrics: []
-      original_task: true
-    name: "given\u2026 does it follow that\u2026 "
-    reference: ''
-  1abaa658-e7f0-4e54-b7ad-312ba009d544: !Template
-    answer_choices:
-    - 'Yes'
-    - 'No'
-    answer_choices_key: null
-    id: 1abaa658-e7f0-4e54-b7ad-312ba009d544
-    jinja: 'Sentence 1: {{premise}}
-
-      Sentence 2: {{hypothesis}}
-
-      Question: Does Sentence 1 entail Sentence 2? Yes or no? |||
-
-      {{answer_choices[label]}}'
-    metadata: !TemplateMetadata
-      _do_eval: true
-      _do_train: false
       choices_in_prompt: true
-      metrics: []
+      metrics:
+      - Accuracy
       original_task: true
-    name: does S1 entail S2?
-    reference: Adapted from Victor's prompts for XNLI.
-  1bf2eee4-448b-48df-98e0-dee86edf7b96: !Template
+    name: MNLI crowdsource
+    reference: Adapted from Williams et al. 2018's instructions to crowdsourcing workers.
+  2d0d63da-ffcf-4f6e-941a-b8da922be43e: !Template
     answer_choices:
     - 'Yes'
     - 'No'
     answer_choices_key: null
-    id: 1bf2eee4-448b-48df-98e0-dee86edf7b96
-    jinja: '{{premise}} Therefore, we are licensed to say that "{{hypothesis}}", right?
-      ||| {{ answer_choices[label] }}'
+    id: 2d0d63da-ffcf-4f6e-941a-b8da922be43e
+    jinja: 'Given {{premise}} Is it guaranteed true that "{{hypothesis}}"? Yes or
+      no? ||| {{ answer_choices[label] }} '
     metadata: !TemplateMetadata
-      _do_eval: true
-      _do_train: false
-      choices_in_prompt: false
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: true
-    name: "\u2026 Therefore, we're licensed to say that\u2026"
-    reference: ''
-  2721e378-68b2-40e6-be7e-fc2783b16042: !Template
+    name: guaranteed true
+    reference: Webson & Pavlick 2021
+  4163e6f1-1a83-4c73-b867-02eb7ac80316: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: 4163e6f1-1a83-4c73-b867-02eb7ac80316
+    jinja: 'Suppose {{premise}} Can we infer that "{{hypothesis}}"? Yes or no? |||
+      {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: can we infer
+    reference: Webson & Pavlick 2021
+  8fb1c6aa-20e9-438c-bece-c6af1c746449: !Template
     answer_choices:
     - 'True'
     - 'False'
     answer_choices_key: null
-    id: 2721e378-68b2-40e6-be7e-fc2783b16042
+    id: 8fb1c6aa-20e9-438c-bece-c6af1c746449
     jinja: '{{premise}}
 
       Question: {{hypothesis}} True or False? ||| {{ answer_choices[label] }}'
@@ -67,57 +60,103 @@ templates:
       _do_eval: true
       _do_train: false
       choices_in_prompt: true
-      metrics: []
+      metrics:
+      - Accuracy
       original_task: true
     name: GPT-3 style
-    reference: Same as reported in Figure G31 of the GPT-3 paper, although I'm not
-      sure about phrasing the not_entailment label (could be either neutral and contradiction)
-      simply as "False".
-  325dbe5c-167d-4b17-95db-1d93d8806782: !Template
+    reference: Same as reported in Figure G31 of the GPT-3 paper.
+  9e078fb4-505b-413c-bb5e-3cd16ddcf5d7: !Template
     answer_choices:
     - 'Yes'
+    - Maybe
     - 'No'
     answer_choices_key: null
-    id: 325dbe5c-167d-4b17-95db-1d93d8806782
-    jinja: Suppose {{premise}} Can we infer that {{hypothesis}}? ||| {{ answer_choices[label]
-      }}
+    id: 9e078fb4-505b-413c-bb5e-3cd16ddcf5d7
+    jinja: "{{premise}} \n\nQuestion: Does this imply that \"{{hypothesis}}\"? Yes,\
+      \ no, or maybe? ||| {{answer_choices[label]}}"
     metadata: !TemplateMetadata
-      _do_eval: true
-      _do_train: false
-      choices_in_prompt: false
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: true
-    name: "Suppose\u2026 Can we infer that\u2026"
-    reference: ''
-  4aac6388-3e90-4d06-be90-68fc31a89fa4: !Template
+    name: does this imply
+    reference: v0.1
+  b8dc85c6-28b6-4340-979a-8e77c2a0dde8: !Template
     answer_choices:
     - 'Yes'
     - 'No'
     answer_choices_key: null
-    id: 4aac6388-3e90-4d06-be90-68fc31a89fa4
-    jinja: '{{premise}} Does the previous passage support the claim that "{{hypothesis}}"?
-      ||| {{ answer_choices[label] }}'
+    id: b8dc85c6-28b6-4340-979a-8e77c2a0dde8
+    jinja: 'Given {{premise}} Should we assume that "{{hypothesis}}" is true? Yes
+      or no? ||| {{ answer_choices[label] }} '
     metadata: !TemplateMetadata
-      _do_eval: true
-      _do_train: false
-      choices_in_prompt: false
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: true
-    name: "\u2026does the previous passage support the claim that"
-    reference: ''
-  ad3361d7-505f-4b5d-93dd-e426394a3943: !Template
+    name: should assume
+    reference: Webson & Pavlick 2021
+  e2fb58f2-b1f2-4aef-b74b-c4ee1c571fff: !Template
     answer_choices:
     - 'Yes'
     - 'No'
     answer_choices_key: null
-    id: ad3361d7-505f-4b5d-93dd-e426394a3943
-    jinja: '{{premise}} Based on the previous passage, is it true that {{hypothesis}}?
-      ||| {{ answer_choices[label] }}'
+    id: e2fb58f2-b1f2-4aef-b74b-c4ee1c571fff
+    jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes or no? |||
+      {{ answer_choices[label] }}
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: false
-      choices_in_prompt: false
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: does it follow that
+    reference: v0.1
+  ed1f4b75-8826-4852-9bd6-aedf368678f5: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: ed1f4b75-8826-4852-9bd6-aedf368678f5
+    jinja: '{{premise}} Based on the previous passage, is it true that "{{hypothesis}}"?
+      Yes or no? ||| {{ answer_choices[label] }}'
+    metadata: !TemplateMetadata
+      _do_eval: true
+      _do_train: false
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: true
     name: based on the previous passage
     reference: "Adapted from the BoolQ prompts in Schick & Sch\xFCtze 2021."
+  ee0ce095-122a-4509-bf0b-33d1495295f7: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: ee0ce095-122a-4509-bf0b-33d1495295f7
+    jinja: '{{premise}} Are we justified in saying that "{{hypothesis}}"? Yes or no?
+      ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: justified in saying
+    reference: Webson & Pavlick 2021
+  fb4f8144-37f5-4977-88da-37a5d0bfd0e8: !Template
+    answer_choices:
+    - 'Yes'
+    - 'No'
+    answer_choices_key: null
+    id: fb4f8144-37f5-4977-88da-37a5d0bfd0e8
+    jinja: 'Given that {{premise}} Therefore, it must be true that "{{hypothesis}}"?
+      Yes or no? ||| {{ answer_choices[label] }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: must be true
+    reference: v0.1

--- a/promptsource/templates/super_glue/wic/templates.yaml
+++ b/promptsource/templates/super_glue/wic/templates.yaml
@@ -43,10 +43,10 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: 611d13dc-d414-4b9b-9204-e4f325e859e7
-    jinja: "{% if label != -1%}\nHomework\n\nDecide whether the word \"\
-      {{word}}\" is used with the same meaning in the two following sentences. Answer\
-      \ by yes or no.\n{{sentence1}}\n{{sentence2}}\n||| \n{{answer_choices[label]}}\n\
-      {% endif %}"
+    jinja: "{% if label != -1%}\nHomework\n\nDecide whether the word \"{{word}}\"\
+      \ is used with the same meaning in the two following sentences. Answer by yes\
+      \ or no.\n{{sentence1}}\n{{sentence2}}\n||| \n{{answer_choices[label]}}\n{%\
+      \ endif %}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -101,8 +101,8 @@ templates:
       Sentence 2: {{sentence2}}
 
 
-      Determine whether the word "{{word}}" is used in the same sense
-      in both sentences. Yes or no?
+      Determine whether the word "{{word}}" is used in the same sense in both sentences.
+      Yes or no?
 
       |||
 
@@ -110,7 +110,7 @@ templates:
 
       {% endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: true
@@ -161,8 +161,8 @@ templates:
     id: dd2080cf-3117-49ba-9aff-c988a21fdb69
     jinja: '{% if label != -1%}
 
-      The word "{{word}}" has multiple meanings. Does it have the
-      same meaning in sentences 1 and 2? Yes or no?
+      The word "{{word}}" has multiple meanings. Does it have the same meaning in
+      sentences 1 and 2? Yes or no?
 
 
       Sentence 1: {{sentence1}}

--- a/promptsource/templates/super_glue/wic/templates.yaml
+++ b/promptsource/templates/super_glue/wic/templates.yaml
@@ -43,7 +43,7 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: 611d13dc-d414-4b9b-9204-e4f325e859e7
-    jinja: "{% if label != -1%}\nHomework - Grammar\n\nDecide whether the word \"\
+    jinja: "{% if label != -1%}\nHomework\n\nDecide whether the word \"\
       {{word}}\" is used with the same meaning in the two following sentences. Answer\
       \ by yes or no.\n{{sentence1}}\n{{sentence2}}\n||| \n{{answer_choices[label]}}\n\
       {% endif %}"
@@ -77,7 +77,7 @@ templates:
     answer_choices_key: null
     id: c3a0a5d8-cfe9-4a7f-8a3c-3c526e0ad0c6
     jinja: "{% if label != -1%}\n{{sentence1}}\n{{sentence2}}\nQuestion: Is the word\
-      \ '{{word}}' used in the same way in the two sentences above?\n||| \n{{answer_choices[label]}}\n\
+      \ '{{word}}' used in the same sense in the two sentences above?\n||| \n{{answer_choices[label]}}\n\
       {% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
@@ -101,8 +101,8 @@ templates:
       Sentence 2: {{sentence2}}
 
 
-      The task is to determine whether the word "{{word}}" is used in the same sense
-      in both sentences.
+      Determine whether the word "{{word}}" is used in the same sense
+      in both sentences. Yes or no?
 
       |||
 
@@ -141,7 +141,7 @@ templates:
     answer_choices_key: null
     id: d9e1db2a-ab0b-4621-bb41-01d5788d3873
     jinja: "{% if label != -1%}\n{{sentence1}}\n{{sentence2}}\nQuestion: Is the word\
-      \ '{{word}}' used in the same way in the two sentences above? Yes, No?\n|||\
+      \ '{{word}}' used in the same sense in the two sentences above? Yes, No?\n|||\
       \ \n{{answer_choices[label]}}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
@@ -161,7 +161,7 @@ templates:
     id: dd2080cf-3117-49ba-9aff-c988a21fdb69
     jinja: '{% if label != -1%}
 
-      The word "{{word}}" is polysemous (it has multiple meanings). Does it have the
+      The word "{{word}}" has multiple meanings. Does it have the
       same meaning in sentences 1 and 2? Yes or no?
 
 

--- a/promptsource/templates/super_glue/wic/templates.yaml
+++ b/promptsource/templates/super_glue/wic/templates.yaml
@@ -7,8 +7,9 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: 14e73f39-a0d1-44c2-b9a4-4e48f9f1608e
-    jinja: "Does the word \"{{word}}\" have the same meaning in these two sentences?\
-      \ Yes, No?\n{{sentence1}}\n{{sentence2}}\n||| \n{{answer_choices[label]}}"
+    jinja: "{% if label != -1%}\nDoes the word \"{{word}}\" have the same meaning\
+      \ in these two sentences? Yes, No?\n{{sentence1}}\n{{sentence2}}\n||| \n{{answer_choices[label]}}\n\
+      {% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -24,8 +25,9 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: 3503ead5-4fa5-4f77-95dc-f0c2ed3eecdc
-    jinja: "Does the word \"{{word}}\" have the same meaning in these two sentences?\n\
-      {{sentence1}}\n{{sentence2}}\n||| \n{{answer_choices[label]}}"
+    jinja: "{% if label != -1%}\nDoes the word \"{{word}}\" have the same meaning\
+      \ in these two sentences?\n{{sentence1}}\n{{sentence2}}\n||| \n{{answer_choices[label]}}\n\
+      {% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -35,14 +37,48 @@ templates:
       original_task: true
     name: question-context-meaning
     reference: Generalized question-context format
+  611d13dc-d414-4b9b-9204-e4f325e859e7: !Template
+    answer_choices:
+    - 'No'
+    - 'Yes'
+    answer_choices_key: null
+    id: 611d13dc-d414-4b9b-9204-e4f325e859e7
+    jinja: "{% if label != -1%}\nHomework - Grammar\n\nDecide whether the word \"\
+      {{word}}\" is used with the same meaning in the two following sentences. Answer\
+      \ by yes or no.\n{{sentence1}}\n{{sentence2}}\n||| \n{{answer_choices[label]}}\n\
+      {% endif %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: grammar_homework
+    reference: ''
+  725b5ed0-7728-4890-95a4-a74cb7ae1bb4: !Template
+    answer_choices:
+    - 'False'
+    - 'True'
+    answer_choices_key: null
+    id: 725b5ed0-7728-4890-95a4-a74cb7ae1bb4
+    jinja: "{% if label != -1%}\nSentence A: {{sentence1}}\nSentence B: {{sentence2}}\n\
+      \n\"{{word}}\" has a similar meaning in sentences A and B. True or False?\n\
+      ||| \n{{answer_choices[label]}}\n{% endif %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: affirmation_true_or_false
+    reference: ''
   c3a0a5d8-cfe9-4a7f-8a3c-3c526e0ad0c6: !Template
     answer_choices:
     - 'No'
     - 'Yes'
     answer_choices_key: null
     id: c3a0a5d8-cfe9-4a7f-8a3c-3c526e0ad0c6
-    jinja: "{{sentence1}}\n{{sentence2}}\nQuestion: Is the word '{{word}}' used in\
-      \ the same way in the two sentences above?\n||| \n{{answer_choices[label]}}"
+    jinja: "{% if label != -1%}\n{{sentence1}}\n{{sentence2}}\nQuestion: Is the word\
+      \ '{{word}}' used in the same way in the two sentences above?\n||| \n{{answer_choices[label]}}\n\
+      {% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -52,14 +88,43 @@ templates:
       original_task: true
     name: GPT-3-prompt
     reference: Following table G32. https://arxiv.org/pdf/2005.14165.pdf
+  ce8b5a93-1841-4897-84db-b100f1c84f4b: !Template
+    answer_choices:
+    - 'No'
+    - 'Yes'
+    answer_choices_key: null
+    id: ce8b5a93-1841-4897-84db-b100f1c84f4b
+    jinja: '{% if label != -1%}
+
+      Sentence 1: {{sentence1}}
+
+      Sentence 2: {{sentence2}}
+
+
+      The task is to determine whether the word "{{word}}" is used in the same sense
+      in both sentences.
+
+      |||
+
+      {{answer_choices[label]}}
+
+      {% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: same_sense
+    reference: ''
   cfbc1637-10b8-4f20-a31c-55292f3cebd0: !Template
     answer_choices:
     - 'No'
     - 'Yes'
     answer_choices_key: null
     id: cfbc1637-10b8-4f20-a31c-55292f3cebd0
-    jinja: "Determine if the word '{{word}}' is used in the same way in the two sentences\
-      \ below. \n{{sentence1}}\n{{sentence2}}\n||| \n{{answer_choices[label]}}"
+    jinja: "{% if label != -1%}\nDetermine if the word '{{word}}' is used in the same\
+      \ way in the two sentences below. \n{{sentence1}}\n{{sentence2}}\n||| \n{{answer_choices[label]}}\n\
+      {% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -75,8 +140,9 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: d9e1db2a-ab0b-4621-bb41-01d5788d3873
-    jinja: "{{sentence1}}\n{{sentence2}}\nQuestion: Is the word '{{word}}' used in\
-      \ the same way in the two sentences above? Yes, No?\n||| \n{{answer_choices[label]}}"
+    jinja: "{% if label != -1%}\n{{sentence1}}\n{{sentence2}}\nQuestion: Is the word\
+      \ '{{word}}' used in the same way in the two sentences above? Yes, No?\n|||\
+      \ \n{{answer_choices[label]}}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -87,13 +153,42 @@ templates:
     name: GPT-3-prompt-with-label
     reference: Following table G32. https://arxiv.org/pdf/2005.14165.pdf add additional
       label
+  dd2080cf-3117-49ba-9aff-c988a21fdb69: !Template
+    answer_choices:
+    - 'No'
+    - 'Yes'
+    answer_choices_key: null
+    id: dd2080cf-3117-49ba-9aff-c988a21fdb69
+    jinja: '{% if label != -1%}
+
+      The word "{{word}}" is polysemous (it has multiple meanings). Does it have the
+      same meaning in sentences 1 and 2? Yes or no?
+
+
+      Sentence 1: {{sentence1}}
+
+      Sentence 2: {{sentence2}}
+
+      |||
+
+      {{answer_choices[label]}}
+
+      {% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: polysemous
+    reference: ''
   f934a96d-fe4d-4075-aa47-5595b9a604c7: !Template
     answer_choices:
     - 'No'
     - 'Yes'
     answer_choices_key: null
     id: f934a96d-fe4d-4075-aa47-5595b9a604c7
-    jinja: "{{sentence1}}\n{{sentence2}}\nSimilar sense of {{word}}?\n||| \n{{answer_choices[label]}}"
+    jinja: "{% if label != -1%}\n{{sentence1}}\n{{sentence2}}\nSimilar sense of {{word}}?\n\
+      ||| \n{{answer_choices[label]}}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true

--- a/promptsource/templates/super_glue/wsc.fixed/templates.yaml
+++ b/promptsource/templates/super_glue/wsc.fixed/templates.yaml
@@ -3,47 +3,93 @@ subset: wsc.fixed
 templates:
   212fb8b1-8436-4f64-8f37-a9094fe029f4: !Template
     answer_choices:
-    - 'no'
-    - 'yes'
+    - 'No'
+    - 'Yes'
     answer_choices_key: null
     id: 212fb8b1-8436-4f64-8f37-a9094fe029f4
     jinja: '{{ text }} In the previous sentence, does the pronoun "{{ span2_text.lower()
-      }}" refer to {{ span1_text }}? ||| {{ answer_choices[label] }}'
+      }}" refer to {{ span1_text }}? Yes or no? ||| {{ answer_choices[label] }}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: true
-    name: In the previous sentence, does the pronoun refer to
+    name: does the pronoun refer to
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+  23361c5d-b67f-4c2a-9da7-16301c55d0e1: !Template
+    answer_choices:
+    - 'No'
+    - 'Yes'
+    answer_choices_key: null
+    id: 23361c5d-b67f-4c2a-9da7-16301c55d0e1
+    jinja: '{{ text }} Here, by "{{ span2_text }}" they mean "{{ span1_text }}". Yes
+      or no? ||| {{ answer_choices[label] }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: by p they mean
+    reference: ''
+  2f17f18b-6daa-44ef-a2dd-dddaf04aec0e: !Template
+    answer_choices:
+    - 'False'
+    - 'True'
+    answer_choices_key: null
+    id: 2f17f18b-6daa-44ef-a2dd-dddaf04aec0e
+    jinja: "{{ text }} \n\nIn other words, {{ text.split(\" \")[span2_index:] | join(\"\
+      \ \") | replace(span2_text, span1_text) }} True or false? ||| {{ answer_choices[label]\
+      \ }}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: in other words
+    reference: ''
+  4b3e29cc-ccb8-4e4c-a845-4935ca29cf34: !Template
+    answer_choices:
+    - 'No'
+    - 'Yes'
+    answer_choices_key: null
+    id: 4b3e29cc-ccb8-4e4c-a845-4935ca29cf34
+    jinja: '{{ text }} I think they mean "{{ text.split(" ")[span2_index:] | join("
+      ") | replace(span2_text, span1_text) }}" Yes or no? ||| {{ answer_choices[label]
+      }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: I think they mean
+    reference: ''
   7482d24f-cf45-4013-b82d-369489fc958b: !Template
     answer_choices:
-    - 'no'
-    - 'yes'
+    - 'No'
+    - 'Yes'
     answer_choices_key: null
     id: 7482d24f-cf45-4013-b82d-369489fc958b
     jinja: '{{ text }} Here, does "{{ span2_text.lower() }}" stand for {{ span1_text
-      }}? ||| {{ answer_choices[label] }}'
+      }}? Yes or no? ||| {{ answer_choices[label] }}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: true
-    name: Here p stands for
-    reference: Not ideal because sometimes the queried pronoun is in the possessive
-      case.
+    name: does p stand for
+    reference: ''
   7d377293-d043-4b6c-8ec1-d61eaf14ec67: !Template
     answer_choices:
-    - 'no'
-    - 'yes'
+    - 'No'
+    - 'Yes'
     answer_choices_key: null
     id: 7d377293-d043-4b6c-8ec1-d61eaf14ec67
-    jinja: "Passage: {{ text }} \nQuestion: In the passage above, does the pronoun\
-      \ \"{{ span2_text }}\" refer to {{ span1_text }}?\nAnswer: ||| {{ answer_choices[label]\
+    jinja: "Passage: {{ text }} \n\nQuestion: In the passage above, does the pronoun\
+      \ \"{{ span2_text }}\" refer to {{ span1_text }}?\n\nAnswer: ||| {{ answer_choices[label]\
       \ }}"
     metadata: !TemplateMetadata
       _do_eval: true
@@ -52,12 +98,45 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: "passage\u2026 does the pronoun refer to"
+    name: GPT-3 Style
     reference: Adapted from Figure G33, p. 59, Brown et al. 2020
+  809eacd0-2f6c-4e3a-b52a-57c783879d36: !Template
+    answer_choices:
+    - 'No'
+    - 'Yes'
+    answer_choices_key: null
+    id: 809eacd0-2f6c-4e3a-b52a-57c783879d36
+    jinja: '{{ text }} In the previous sentence, can the pronoun "{{ span2_text }}"
+      be replaced with "{{ span1_text }}"? Yes or no? ||| {{ answer_choices[label]
+      }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: replaced with
+    reference: ''
+  87f97aa0-1fa9-4f0b-b8e6-89d3c1f19bd6: !Template
+    answer_choices:
+    - 'False'
+    - 'True'
+    answer_choices_key: null
+    id: 87f97aa0-1fa9-4f0b-b8e6-89d3c1f19bd6
+    jinja: "Context: {{ text }} \n\n{% if span2_text.lower()  == \"they\" or span2_text.lower()\
+      \ == \"them\" %}\nQuestion: \"{{ span2_text }}\" are {{ span1_text }}. True\
+      \ or false?\n{% else %}\nQuestion: \"{{ span2_text }}\" is {{ span1_text }}.\
+      \ True or false?\n{% endif %}\n\nAnswer: ||| {{ answer_choices[label] }}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: p is/are r
+    reference: ''
   aae24b54-c3a7-4f69-8b77-f6dc115988f8: !Template
     answer_choices:
-    - 'false'
-    - 'true'
+    - 'False'
+    - 'True'
     answer_choices_key: null
     id: aae24b54-c3a7-4f69-8b77-f6dc115988f8
     jinja: "{{ text }} \nIn the passage above, the pronoun \"{{ span2_text }}\" refers\
@@ -69,18 +148,18 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: in the passage above, the pronoun refers to
+    name: the pronoun refers to
     reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
   d88f3e21-42dc-49a5-924d-69b764a14816: !Template
     answer_choices:
-    - 'no'
-    - 'yes'
+    - 'No'
+    - 'Yes'
     answer_choices_key: null
     id: d88f3e21-42dc-49a5-924d-69b764a14816
-    jinja: "{{ text }} \n{% if span2_text  == \"they\" or span2_text == \"them\" %}\n\
-      Question: Who are \"{{ span2_text.lower() }}\"? {{ span1_text }}?\n{% else %}\n\
-      Question: Who is \"{{ span2_text.lower() }}\"? Is it {{ span1_text }}?\n{% endif\
-      \ %}\nAnswer: ||| {{ answer_choices[label] }}"
+    jinja: "{{ text }} \n{% if span2_text.lower()  == \"they\" or span2_text.lower()\
+      \ == \"them\" %}\nQuestion: Who are \"{{ span2_text.lower() }}\"? {{ span1_text\
+      \ }}?\n{% else %}\nQuestion: Who is \"{{ span2_text.lower() }}\"? Is it {{ span1_text\
+      \ }}?\n{% endif %}\nAnswer: ||| {{ answer_choices[label] }}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true


### PR DESCRIPTION
MultiRC
- Wrap "@placeholder" in escaping
- Replaced `Span Squad` with `Squad` as per [slack discussion](https://huggingface.slack.com/archives/C023Z96L7B4/p1631106461072000?thread_ts=1631100879.070900&cid=C023Z96L7B4)

COPA
- I wrote 7 original templates that apply the whole set. Not all of the existing templates applied to the whole set (which makes them invalid for reporting eval number unless we combine them in a fancy way...)

RECORD
- wrote more prompts

BoolQ:
- Corrected bug on test set (`label=-1` is equivalent to no label)
- wrote more propmts