### PR TITLE
Fix conditional target in SuperGlue

### DIFF
--- a/promptsource/seqio_tasks/utils.py
+++ b/promptsource/seqio_tasks/utils.py
@@ -37,7 +37,11 @@ def apply_template(dataset, template):
         ex = promptsource.utils.removeHyphen(ex)
         inputs_and_targets = template.apply(ex)
         answer_choices = template.get_answer_choices_list(ex)
-        if len(inputs_and_targets) == 2:
+        result_length = len(inputs_and_targets)
+        if result_length == 1:
+            inputs = inputs_and_targets[0]
+            ex = {"inputs": inputs, "targets": "<NO LABEL>"}
+        elif result_length == 2:
             inputs, targets = inputs_and_targets
             ex = {"inputs": inputs, "targets": targets}
         # When template results in an empty example, template.apply returns [""]

--- a/promptsource/seqio_tasks/utils.py
+++ b/promptsource/seqio_tasks/utils.py
@@ -37,13 +37,12 @@ def apply_template(dataset, template):
         ex = promptsource.utils.removeHyphen(ex)
         inputs_and_targets = template.apply(ex)
         answer_choices = template.get_answer_choices_list(ex)
-        result_length = len(inputs_and_targets)
-        if result_length == 1:
-            inputs = inputs_and_targets[0]
-            ex = {"inputs": inputs, "targets": "<NO LABEL>"}
-        elif result_length == 2:
+        if len(inputs_and_targets) == 2:
             inputs, targets = inputs_and_targets
-            ex = {"inputs": inputs, "targets": targets}
+            if targets == "":
+                ex = {"inputs": inputs, "targets": "<NO LABEL>"}
+            else:
+                ex = {"inputs": inputs, "targets": targets}
         # When template results in an empty example, template.apply returns [""]
         # Also, if the template gets split wrong, len can be > 2
         # We will filter these out later

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -202,7 +202,7 @@ class Template(yaml.YAMLObject):
 
         # Splits on the separator, and then replaces back any occurrences of the
         # separator in the original example
-        return [self._unescape_pipe(part) for part in rendered_example.split("|||")]
+        return [self._unescape_pipe(part).strip() for part in rendered_example.split("|||")]
 
     pipe_protector = "3ed2dface8203c4c9dfb1a5dc58e41e0"
 

--- a/promptsource/templates/super_glue/boolq/templates.yaml
+++ b/promptsource/templates/super_glue/boolq/templates.yaml
@@ -5,13 +5,15 @@ templates:
     answer_choices: null
     answer_choices_key: False ||| True
     id: 3e386463-1715-4578-9cba-07d11a0d3b61
-    jinja: '{% if label != -1 %}
-
-      Passage: {{passage}}
+    jinja: 'Passage: {{passage}}
 
 
       After reading this passage, I have a question: {{question}}? True or False?
-      ||| {{answer_choices[label]}}
+      |||
+
+      {% if label != -1 %}
+
+      {{answer_choices[label]}}
 
       {% endif %}'
     metadata: !TemplateMetadata
@@ -27,8 +29,8 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: 492f0f88-4370-46cd-839b-1de37a55aeda
-    jinja: "{% if label != -1 %}\n{{ passage }} \nQuestion: {{ question }}\nAnswer:\
-      \ ||| {{ answer_choices[label] }}\n{% endif %}"
+    jinja: "{{ passage }} \nQuestion: {{ question }}\nAnswer: ||| \n{% if label !=\
+      \ -1 %}\n{{ answer_choices[label] }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -44,8 +46,8 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: 6cb6a026-c070-470a-b75d-bb8fdf424e35
-    jinja: "{% if label != -1 %}\n{{ passage }} \n\nHaving read that, I wonder {{\
-      \ question }}? ||| {{ answer_choices[label] }} \n{% endif %}"
+    jinja: "{{ passage }} \n\nHaving read that, I wonder {{ question }}? |||\n{% if\
+      \ label != -1 %}\n{{ answer_choices[label] }} \n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -59,12 +61,14 @@ templates:
     answer_choices: null
     answer_choices_key: No ||| Yes
     id: 7cf7acdf-e3a2-459f-a3e8-2e2d27dd6aa5
-    jinja: '{% if label != -1 %}
-
-      Text: {{passage}}
+    jinja: 'Text: {{passage}}
 
 
-      Answer the following yes/no question: {{question}}? Yes or no? ||| {{answer_choices[label]}}
+      Answer the following yes/no question: {{question}}? Yes or no? |||
+
+      {% if label != -1 %}
+
+      {{answer_choices[label]}}
 
       {% endif %}'
     metadata: !TemplateMetadata
@@ -80,8 +84,8 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: 7d21d974-0624-4d4f-9e8c-644e2d009cb5
-    jinja: "{% if label != -1 %}\n{{ passage }} \n\nHaving read that, could you tell\
-      \ me {{ question }}? ||| {{ answer_choices[label] }}\n{% endif %}"
+    jinja: "{{ passage }} \n\nHaving read that, could you tell me {{ question }}?\
+      \ ||| {% if label != -1 %}{{ answer_choices[label] }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -95,18 +99,8 @@ templates:
     answer_choices: null
     answer_choices_key: No ||| Yes
     id: 922d3e87-ac58-4731-84d1-f0a40e47afb5
-    jinja: '{% if label != -1 %}
-
-      EXAM
-
-      1. Answer by yes or no.
-
-
-      Document: {{passage}}
-
-      Question: {{question}}? ||| {{answer_choices[label]}}
-
-      {% endif %}'
+    jinja: "EXAM\n1. Answer by yes or no.\n\nDocument: {{passage}}\nQuestion: {{question}}?\
+      \ ||| \n{% if label != -1 %}\n{{answer_choices[label]}}\n{% endif %}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -120,12 +114,14 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: 9a1bf459-8047-437c-9def-f21e960429cc
-    jinja: '{% if label != -1 %}
-
-      Based on the following passage, {{ question }}? {{ passage }}
+    jinja: 'Based on the following passage, {{ question }}? {{ passage }}
 
 
-      ||| {{ answer_choices[label] }}
+      |||
+
+      {% if label != -1 %}
+
+      {{ answer_choices[label] }}
 
       {% endif %}'
     metadata: !TemplateMetadata
@@ -141,14 +137,16 @@ templates:
     answer_choices: null
     answer_choices_key: False ||| True
     id: 9f4c6b0a-437b-40c0-b467-db4b7218d38d
-    jinja: '{% if label != -1 %}
-
-      Exercise: read the text and answer the question by True or False.
+    jinja: 'Exercise: read the text and answer the question by True or False.
 
 
       Text: {{passage}}
 
-      Question: {{question}}? ||| {{answer_choices[label]}}
+      Question: {{question}}? |||
+
+      {% if label != -1 %}
+
+      {{answer_choices[label]}}
 
       {% endif %}'
     metadata: !TemplateMetadata
@@ -164,11 +162,9 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: b2b3cb60-d6e3-491c-a09a-8201e13e417e
-    jinja: '{% if label != -1 %}
+    jinja: '{{ passage }}
 
-      {{ passage }}
-
-      Based on the previous passage, {{ question }}? ||| {{ answer_choices[label]
+      Based on the previous passage, {{ question }}? ||| {% if label != -1 %}{{ answer_choices[label]
       }}
 
       {% endif %}'
@@ -185,12 +181,14 @@ templates:
     answer_choices: null
     answer_choices_key: False ||| True
     id: eb78772c-e81e-4b8a-a77b-b75efd1c212a
-    jinja: '{% if label != -1 %}
-
-      {{passage}}
+    jinja: '{{passage}}
 
 
-      Q: {{question}}? True or False? ||| {{answer_choices[label]}}
+      Q: {{question}}? True or False? |||
+
+      {% if label != -1 %}
+
+      {{answer_choices[label]}}
 
       {% endif %}'
     metadata: !TemplateMetadata

--- a/promptsource/templates/super_glue/cb/templates.yaml
+++ b/promptsource/templates/super_glue/cb/templates.yaml
@@ -9,7 +9,7 @@ templates:
     answer_choices_key: null
     id: 2e76cd0f-68ca-4f03-83ed-11cf15b25a84
     jinja: 'Suppose {{premise}} Can we infer that "{{hypothesis}}"? Yes, no, or maybe?
-      ||| {{ answer_choices[label] }} '
+      ||| {% if label !=-1 %}{{ answer_choices[label] }}{% endif %} '
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -25,7 +25,8 @@ templates:
     answer_choices_key: null
     id: 358860fd-61ad-45fd-92a6-a72ca9107ebc
     jinja: '{{premise}} Based on the previous passage, is it true that "{{hypothesis}}"?
-      Yes, no, or maybe? ||| {{ answer_choices[label] }}'
+      Yes, no, or maybe? ||| {% if label !=-1 %}{{ answer_choices[label] }}{% endif
+      %}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: false
@@ -43,8 +44,8 @@ templates:
     answer_choices_key: null
     id: 3f43a599-ffdb-490e-8952-c0ce41dd4621
     jinja: '{{premise}} Based on that information, is the claim: "{{hypothesis}}"
-      {{"true"}}, {{"false"}}, or {{"inconclusive"}}? ||| {{ answer_choices[label]
-      }}'
+      {{"true"}}, {{"false"}}, or {{"inconclusive"}}? ||| {% if label !=-1 %}{{ answer_choices[label]
+      }}{% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -60,7 +61,7 @@ templates:
     answer_choices_key: null
     id: 404eed25-558a-4d39-9515-7de46d60d4e0
     jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes, no, or maybe?
-      ||| {{ answer_choices[label] }}
+      ||| {% if label !=-1 %}{{ answer_choices[label] }}{% endif %}
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: false
@@ -78,7 +79,7 @@ templates:
     answer_choices_key: null
     id: 5c9b1fa9-93f0-4f82-b9e3-e0967e4d7260
     jinja: '{{premise}} Are we justified in saying that "{{hypothesis}}"? Yes, no,
-      or maybe? ||| {{ answer_choices[label] }} '
+      or maybe? ||| {% if label !=-1 %}{{ answer_choices[label] }}{% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -94,7 +95,8 @@ templates:
     answer_choices_key: null
     id: 6b0c6191-183d-4731-8050-ab17c909335c
     jinja: Suppose it's true that {{premise}} Then, is "{{hypothesis}}" {{"always"}},
-      {{"sometimes"}}, or {{"never"}} true? ||| {{ answer_choices[label] }}
+      {{"sometimes"}}, or {{"never"}} true? ||| {% if label !=-1 %}{{ answer_choices[label]
+      }}{% endif %}
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -111,8 +113,8 @@ templates:
     id: 75db2bc2-3caa-4956-9653-13c7dd6255df
     jinja: '{{premise}}
 
-      Question: {{hypothesis}} True, False, or Neither? ||| {{ answer_choices[label]
-      }}'
+      Question: {{hypothesis}} True, False, or Neither? ||| {% if label !=-1 %}{{
+      answer_choices[label] }}{% endif %}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: false
@@ -131,8 +133,8 @@ templates:
     answer_choices_key: null
     id: 87237a07-7cce-470a-80ac-3e5e3a5283ba
     jinja: "{{premise}} \n\nKeeping in mind the above text, consider: {{hypothesis}}\
-      \ Is this {{\"always\"}}, {{\"sometimes\"}}, or {{\"never\"}} correct? ||| {{\
-      \ answer_choices[label] }}"
+      \ Is this {{\"always\"}}, {{\"sometimes\"}}, or {{\"never\"}} correct? ||| {%\
+      \ if label !=-1 %}{{ answer_choices[label] }}{% endif %}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -147,8 +149,8 @@ templates:
     - Maybe
     answer_choices_key: null
     id: 8798b8a4-1f59-4c72-9c1b-3e3044a7462a
-    jinja: 'Given {{premise}} Is it guaranteed true that "{{hypothesis}}"? Yes, no,
-      or maybe? ||| {{ answer_choices[label] }} '
+    jinja: Given {{premise}} Is it guaranteed true that "{{hypothesis}}"? Yes, no,
+      or maybe? ||| {% if label !=-1 %}{{ answer_choices[label] }}{% endif %}
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -163,8 +165,9 @@ templates:
     - Maybe
     answer_choices_key: null
     id: 8e3b8d3d-1362-47dc-922a-82c03f965989
-    jinja: 'Given that {{premise}} Therefore, it must be true that "{{hypothesis}}"?
-      Yes, no, or maybe? ||| {{ answer_choices[label] }} '
+    jinja: Given that {{premise}} Therefore, it must be true that "{{hypothesis}}"?
+      Yes, no, or maybe? ||| {% if label !=-1 %}{{ answer_choices[label] }}{% endif
+      %}
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -180,8 +183,8 @@ templates:
     answer_choices_key: null
     id: 90ab1002-093c-4e54-b48f-626655e36b65
     jinja: "Assume it is true that {{premise}} \n\nTherefore, \"{{hypothesis}}\" is\
-      \ {{\"guaranteed\"}}, {{\"possible\"}}, or {{\"impossible\"}}? ||| {{ answer_choices[label]\
-      \ }}"
+      \ {{\"guaranteed\"}}, {{\"possible\"}}, or {{\"impossible\"}}? ||| {% if label\
+      \ !=-1 %}{{ answer_choices[label] }}{% endif %}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -197,7 +200,7 @@ templates:
     answer_choices_key: null
     id: a485d120-6eef-4ff6-8684-42df1639b101
     jinja: "{{premise}} \n\nQuestion: Does this imply that \"{{hypothesis}}\"? Yes,\
-      \ no, or maybe? ||| {{answer_choices[label]}}"
+      \ no, or maybe? ||| {% if label !=-1 %}{{answer_choices[label]}}{% endif %}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -214,7 +217,7 @@ templates:
     id: bee62bfa-5307-4e1c-97b2-2ad2f7bcb179
     jinja: '{{premise}} Using only the above description and what you know about the
       world, "{{hypothesis}}" is definitely correct, incorrect, or inconclusive? |||
-      {{ answer_choices[label] }}'
+      {% if label !=-1 %}{{ answer_choices[label] }}{% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -229,8 +232,8 @@ templates:
     - Maybe
     answer_choices_key: null
     id: e503b148-8e6c-43b5-9ed6-312794c54d9b
-    jinja: 'Given {{premise}} Should we assume that "{{hypothesis}}" is true? Yes,
-      no, or maybe? ||| {{ answer_choices[label] }} '
+    jinja: Given {{premise}} Should we assume that "{{hypothesis}}" is true? Yes,
+      no, or maybe? ||| {% if label !=-1 %}{{ answer_choices[label] }}{% endif %}
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -248,7 +251,8 @@ templates:
     jinja: 'Take the following as truth: {{premise}}
 
       Then the following statement: "{{hypothesis}}" is {{"true"}}, {{"false"}}, or
-      {{"inconclusive"}}? ||| {{ answer_choices[label] }}'
+      {{"inconclusive"}}? ||| {% if label !=-1 %}{{ answer_choices[label] }}{% endif
+      %}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:

--- a/promptsource/templates/super_glue/copa/templates.yaml
+++ b/promptsource/templates/super_glue/copa/templates.yaml
@@ -13,7 +13,7 @@ templates:
 
       - {{choice1}}
 
-      - {{choice2}} ||| {{ answer_choices[label] }}'
+      - {{choice2}} ||| {% if label != -1 %}{{ answer_choices[label] }}{%endif%}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -26,8 +26,8 @@ templates:
     answer_choices_key: '{{choice1}} ||| {{choice2}}'
     id: 150789fe-e309-47a1-82c9-0a4dc2c6b12b
     jinja: "{% if question == \"effect\" %} \n{{ premise }} What could happen next,\
-      \ \"{{ answer_choices[0] }}\" or \"{{ answer_choices[1] }}\"? ||| {{ answer_choices[label]\
-      \ }}\n{% endif %}"
+      \ \"{{ answer_choices[0] }}\" or \"{{ answer_choices[1] }}\"? ||| {% if label\
+      \ != -1 %}{{ answer_choices[label] }}{%endif%}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -43,7 +43,8 @@ templates:
     id: 4d879cbe-2fd7-424a-9d78-3f5200313fba
     jinja: "{{ premise }} \n\nI am hesitating between two options. Help me choose\
       \ the more likely {% if question == \"cause\" %} cause: {% else %} effect: {%\
-      \ endif %}\n- {{choice1}}\n- {{choice2}} ||| {{ answer_choices[label] }}"
+      \ endif %}\n- {{choice1}}\n- {{choice2}} ||| {% if label != -1 %}{{ answer_choices[label]\
+      \ }}{%endif%}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -62,7 +63,7 @@ templates:
 
       - {{choice1}}
 
-      - {{choice2}} ||| {{ answer_choices[label] }}'
+      - {{choice2}} ||| {% if label != -1 %}{{ answer_choices[label] }}{%endif%}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -75,8 +76,8 @@ templates:
     answer_choices_key: '{{choice1 }} ||| {{choice2}}'
     id: 744047dc-1298-45a2-8d68-d67e3f834ded
     jinja: '"{{ answer_choices[0] }}" or "{{ answer_choices[1] }}"? {{ premise }}
-      {% if question == "cause" %} because {% else %} so {% endif %} ||| {{ answer_choices[label]
-      }}'
+      {% if question == "cause" %} because {% else %} so {% endif %} ||| {% if label
+      != -1 %}{{ answer_choices[label] }}{% endif %}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -91,8 +92,8 @@ templates:
     answer_choices_key: '{{choice1}} ||| {{choice2}}'
     id: 84da62c2-9440-4cfc-bdd4-d70c65e33a82
     jinja: "{% if question == \"effect\" %} \n{{ premise }} As a result, \"{{ answer_choices[0]\
-      \ }}\" or \"{{ answer_choices[1] }}\"? ||| {{ answer_choices[label] }}\n{% endif\
-      \ %}"
+      \ }}\" or \"{{ answer_choices[1] }}\"? ||| {% if label != -1 %}{{ answer_choices[label]\
+      \ }}{%endif%}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -108,7 +109,7 @@ templates:
     id: 8ce80f8a-239e-4393-892c-f63dbb0d9929
     jinja: "{{ premise }} \n\nWhat's the best option?\n- {{choice1}}\n- {{choice2}}\n\
       \nWe are looking for {% if question == \"cause\" %} a cause {% else %} an effect\
-      \ {% endif %}\n||| {{answer_choices[label]}}"
+      \ {% endif %}\n||| {% if label != -1 %}{{answer_choices[label]}}{%endif%}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -121,8 +122,8 @@ templates:
     answer_choices_key: '{{choice1}} ||| {{choice2}}'
     id: 8cf2ba73-aee5-4651-b5d4-b1b88afe4abb
     jinja: "{% if question == \"cause\" %} \n{{ premise }} Which may be caused by\
-      \ \"{{ answer_choices[0] }}\" or \"{{ answer_choices[1] }}\"? ||| {{ answer_choices[label]\
-      \ }}\n{% endif %}"
+      \ \"{{ answer_choices[0] }}\" or \"{{ answer_choices[1] }}\"? ||| {% if label\
+      \ != -1 %}{{ answer_choices[label] }}{%endif%}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -143,7 +144,7 @@ templates:
 
       - {{choice1}}
 
-      - {{choice2}} ||| {{ answer_choices[label] }}'
+      - {{choice2}} ||| {% if label != -1 %}{{ answer_choices[label] }}{%endif%}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -163,7 +164,7 @@ templates:
 
       - {{choice1}}
 
-      - {{choice2}} ||| {{ answer_choices[label] }}'
+      - {{choice2}} ||| {% if label != -1 %}{{ answer_choices[label] }}{%endif%}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -176,8 +177,8 @@ templates:
     answer_choices_key: '{{choice1}} ||| {{choice2}}'
     id: a8bf11c3-bea2-45ba-a533-957d8bee5e2e
     jinja: "{% if question == \"cause\" %} \n{{ premise }} Why? \"{{ answer_choices[0]\
-      \ }}\" or \"{{ answer_choices[1] }}\"? ||| {{ answer_choices[label] }}\n{% endif\
-      \ %}"
+      \ }}\" or \"{{ answer_choices[1] }}\"? ||| {% if label != -1 %}{{ answer_choices[label]\
+      \ }}{%endif%}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -198,7 +199,7 @@ templates:
 
       - {{choice1}}
 
-      - {{choice2}} ||| {{ answer_choices[label] }}'
+      - {{choice2}} ||| {% if label != -1 %}{{ answer_choices[label] }}{%endif%}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:

--- a/promptsource/templates/super_glue/multirc/templates.yaml
+++ b/promptsource/templates/super_glue/multirc/templates.yaml
@@ -14,7 +14,7 @@ templates:
 
       |||
 
-      {{answer_choices[label]}}'
+      {% if label != -1 %}{{answer_choices[label]}}{% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -29,7 +29,8 @@ templates:
     answer_choices_key: null
     id: 42d47df9-09de-4691-8e49-7cfadd636cdd
     jinja: "{{ paragraph }}\nBased on the previous passage, {{ question }} \nIs \"\
-      {{ answer }}\" a correct answer? ||| {{ answer_choices[label] }}"
+      {{ answer }}\" a correct answer? ||| {% if label != -1 %}{{ answer_choices[label]\
+      \ }}{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -52,7 +53,7 @@ templates:
 
       |||
 
-      {{answer_choices[label]}}'
+      {% if label != -1 %}{{answer_choices[label]}}{% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -67,7 +68,7 @@ templates:
     answer_choices_key: null
     id: 4fc9e1ea-7451-4dba-a2cb-ce870e35ef8b
     jinja: "{{ paragraph }}\n{{ question }} \nWould it be good to answer \"{{ answer\
-      \ }}\"? ||| {{ answer_choices[label] }}"
+      \ }}\"? ||| {% if label != -1 %}{{ answer_choices[label] }}{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -83,8 +84,8 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: 59a2d847-27f3-4002-a125-cf9a291b3098
-    jinja: "{{ paragraph }}\nQuestion: {{ question }} \nIs it {{ answer }}? ||| {{\
-      \ answer_choices[label] }}"
+    jinja: "{{ paragraph }}\nQuestion: {{ question }} \nIs it {{ answer }}? ||| {%\
+      \ if label != -1 %}{{ answer_choices[label] }}{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -107,7 +108,7 @@ templates:
 
       |||
 
-      {{answer_choices[label]}}'
+      {% if label != -1 %}{{answer_choices[label]}}{% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -122,7 +123,7 @@ templates:
     answer_choices_key: null
     id: 7d878b89-2774-429a-82fb-ac801379e3ae
     jinja: "{{ paragraph }}\nQuestion: {{ question }} \nIs the correct answer {{ answer\
-      \ }}? ||| {{ answer_choices[label] }}"
+      \ }}? ||| {% if label != -1 %}{{ answer_choices[label] }}{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -145,7 +146,7 @@ templates:
 
       |||
 
-      {{answer_choices[label]}}'
+      {% if label != -1 %}{{answer_choices[label]}}{% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -166,7 +167,7 @@ templates:
 
       |||
 
-      {{answer_choices[label]}}'
+      {% if label != -1 %}{{answer_choices[label]}}{% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -181,7 +182,8 @@ templates:
     answer_choices_key: null
     id: d2d78b88-8845-45b5-935a-6451da00b285
     jinja: "{{ paragraph }}\n{{ question }} \nI was going to say \"{{ answer }}\"\
-      . Does that sound right? ||| {{ answer_choices[label] }}"
+      . Does that sound right? ||| {% if label != -1 %}{{ answer_choices[label] }}{%\
+      \ endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true

--- a/promptsource/templates/super_glue/record/templates.yaml
+++ b/promptsource/templates/super_glue/record/templates.yaml
@@ -5,9 +5,9 @@ templates:
     answer_choices: null
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 014b669e-2e3b-40ce-bdde-418966c7d666
-    jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nWhich\
-      \ one is the \"{{\"@placeholder\"}}\"? {{ entities | join(\", \") }}? ||| {{\
-      \ answers | choice }}\n{% endif %}"
+    jinja: "{{ passage }} \n{{ query }} \nWhich one is the \"{{\"@placeholder\"}}\"\
+      ? {{ entities | join(\", \") }}? ||| {% if ( answers | length ) > 0 %} {{ answers\
+      \ | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -21,9 +21,9 @@ templates:
     answer_choices: null
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 11e27d59-b1f5-43a1-9ccc-17f1c3249173
-    jinja: "{% if ( answers | length ) > 0 %} \nThe following document has been corrupted.\
-      \ Tell me what \"{{\"@placeholder\"}}\" is referring to.\n\nDocument: {{ passage\
-      \ }} \n{{ query }} \n|||\n{{ answers | choice }}\n{% endif %}"
+    jinja: "The following document has been corrupted. Tell me what \"{{\"@placeholder\"\
+      }}\" is referring to.\n\nDocument: {{ passage }} \n{{ query }} \n||| {% if (\
+      \ answers | length ) > 0 %}{{ answers | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -35,10 +35,9 @@ templates:
     answer_choices: null
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 441c70e3-095a-44a1-8163-bc3b666b7ea1
-    jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \n\nYou\
-      \ should decide what \"{{\"@placeholder\"}}\" is referring to. Choose between:\n\
-      - {{answer_choices | join(\"\\n- \")}}\n|||\n{{ answers | choice }}\n{% endif\
-      \ %}"
+    jinja: "{{ passage }} \n{{ query }} \n\nYou should decide what \"{{\"@placeholder\"\
+      }}\" is referring to. Choose between:\n- {{answer_choices | join(\"\\n- \")}}\n\
+      ||| {% if ( answers | length ) > 0 %}{{ answers | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -50,9 +49,9 @@ templates:
     answer_choices: null
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 91555c1c-c1e4-469b-a2a4-fc952ce1a145
-    jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nIn the\
-      \ question above, the \"{{\"@placeholder\"}}\" stands for ||| {{ answers | choice\
-      \ }}\n{% endif %}"
+    jinja: "{{ passage }} \n{{ query }} \nIn the question above, the \"{{\"@placeholder\"\
+      }}\" stands for ||| {% if ( answers | length ) > 0 %}{{ answers | choice }}{%\
+      \ endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -66,9 +65,9 @@ templates:
     answer_choices: null
     answer_choices_key: '{{ entities | join("|||") }}'
     id: 99dd38ce-32f3-4d58-93c5-59821002b9cc
-    jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nWhat\
-      \ could the \"{{\"@placeholder\"}}\" be? {{ entities | join(\", \") }}? |||\
-      \ {{ answers | choice }}\n{% endif %}"
+    jinja: "{{ passage }} \n{{ query }} \nWhat could the \"{{\"@placeholder\"}}\"\
+      \ be? {{ entities | join(\", \") }}? ||| {% if ( answers | length ) > 0 %}{{\
+      \ answers | choice }}{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -82,9 +81,7 @@ templates:
     answer_choices: null
     answer_choices_key: '{{entities | join("|||")}}'
     id: 9b688cf3-28bf-4f33-94cf-e73e4fa8c608
-    jinja: '{% if ( answers | length ) > 0 %}
-
-      {{ passage }}
+    jinja: '{{ passage }}
 
       {{ query }}
 
@@ -95,7 +92,7 @@ templates:
 
       - {{ entities | join("\n- ") }}
 
-      |||
+      ||| {% if ( answers | length ) > 0 %}
 
       {{ answers | choice }}
 
@@ -111,8 +108,8 @@ templates:
     answer_choices: null
     answer_choices_key: '{{ entities | join("|||") }}'
     id: a5ed27ed-162b-4ac1-9c7a-85059d5214be
-    jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nHere,\
-      \ the placeholder refers to ||| {{ answers | choice }}\n{% endif %}"
+    jinja: "{{ passage }} \n{{ query }} \nHere, the placeholder refers to ||| {% if\
+      \ ( answers | length ) > 0 %}{{ answers | choice }}\n{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -126,9 +123,7 @@ templates:
     answer_choices: null
     answer_choices_key: '{{entities | join("|||")}}'
     id: d3fce74e-0d9d-404a-a009-9ebbf5794c2c
-    jinja: '{% if ( answers | length ) > 0 %}
-
-      Exercise: Extract from the text the correct entity that "{{"@placeholder"}}"
+    jinja: 'Exercise: Extract from the text the correct entity that "{{"@placeholder"}}"
       is referring to.
 
 
@@ -136,7 +131,7 @@ templates:
 
       {{ query }}
 
-      |||
+      ||| {% if ( answers | length ) > 0 %}
 
       {{ answers | choice }}
 
@@ -152,9 +147,7 @@ templates:
     answer_choices: null
     answer_choices_key: '{{entities | join("|||")}}'
     id: de5b635e-c2f4-40bb-81ac-650f1b45564b
-    jinja: '{% if ( answers | length ) > 0 %}
-
-      {{ passage }}
+    jinja: '{{ passage }}
 
       {{ query }}
 
@@ -163,7 +156,7 @@ templates:
 
       - {{answer_choices | join("\n- ")}}
 
-      |||
+      ||| {% if ( answers | length ) > 0 %}
 
       {{ answers | choice }}
 
@@ -179,9 +172,9 @@ templates:
     answer_choices: null
     answer_choices_key: '{{ entities | join("|||") }}'
     id: e68d13c5-df75-4de0-b59e-f2eaf4af6ce7
-    jinja: "{% if ( answers | length ) > 0 %} \n{{ passage }} \n{{ query }} \nCan\
-      \ you figure out what does the \"{{\"@placeholder\"}}\" mean? It means ||| {{\
-      \ answers | choice }}\n{% endif %}"
+    jinja: "{{ passage }} \n{{ query }} \nCan you figure out what does the \"{{\"\
+      @placeholder\"}}\" mean? It means ||| {% if ( answers | length ) > 0 %}{{ answers\
+      \ | choice }}{% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true

--- a/promptsource/templates/super_glue/rte/templates.yaml
+++ b/promptsource/templates/super_glue/rte/templates.yaml
@@ -8,8 +8,8 @@ templates:
     answer_choices_key: null
     id: 2b52a83c-0021-41fe-b44c-5aaa076d71a2
     jinja: '{{premise}} Using only the above description and what you know about the
-      world, is "{{hypothesis}}" definitely correct? Yes or no? ||| {{ answer_choices[label]
-      }}'
+      world, is "{{hypothesis}}" definitely correct? Yes or no? ||| {% if label != -1 %}{{ answer_choices[label]
+      }}{% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -24,7 +24,7 @@ templates:
     answer_choices_key: null
     id: 2d0d63da-ffcf-4f6e-941a-b8da922be43e
     jinja: 'Given {{premise}} Is it guaranteed true that "{{hypothesis}}"? Yes or
-      no? ||| {{ answer_choices[label] }} '
+      no? ||| {% if label != -1 %}{{ answer_choices[label] }}{% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -39,7 +39,7 @@ templates:
     answer_choices_key: null
     id: 4163e6f1-1a83-4c73-b867-02eb7ac80316
     jinja: 'Suppose {{premise}} Can we infer that "{{hypothesis}}"? Yes or no? |||
-      {{ answer_choices[label] }} '
+      {% if label != -1 %}{{ answer_choices[label] }}{% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -55,7 +55,7 @@ templates:
     id: 8fb1c6aa-20e9-438c-bece-c6af1c746449
     jinja: '{{premise}}
 
-      Question: {{hypothesis}} True or False? ||| {{ answer_choices[label] }}'
+      Question: {{hypothesis}} True or False? ||| {% if label != -1 %}{{ answer_choices[label] }}{% endif %}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: false
@@ -72,7 +72,7 @@ templates:
     answer_choices_key: null
     id: 9e078fb4-505b-413c-bb5e-3cd16ddcf5d7
     jinja: "{{premise}} \n\nQuestion: Does this imply that \"{{hypothesis}}\"? Yes\
-      \ or no? ||| {{answer_choices[label]}}"
+      \ or no? ||| {% if label != -1 %}{{answer_choices[label]}}{% endif %}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -87,7 +87,7 @@ templates:
     answer_choices_key: null
     id: b8dc85c6-28b6-4340-979a-8e77c2a0dde8
     jinja: 'Given {{premise}} Should we assume that "{{hypothesis}}" is true? Yes
-      or no? ||| {{ answer_choices[label] }} '
+      or no? ||| {% if label != -1 %}{{ answer_choices[label] }}{% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -102,7 +102,7 @@ templates:
     answer_choices_key: null
     id: e2fb58f2-b1f2-4aef-b74b-c4ee1c571fff
     jinja: Given that {{premise}} Does it follow that {{hypothesis}} Yes or no? |||
-      {{ answer_choices[label] }}
+      {% if label != -1 %}{{ answer_choices[label] }}{% endif %}
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: false
@@ -119,7 +119,7 @@ templates:
     answer_choices_key: null
     id: ed1f4b75-8826-4852-9bd6-aedf368678f5
     jinja: '{{premise}} Based on the previous passage, is it true that "{{hypothesis}}"?
-      Yes or no? ||| {{ answer_choices[label] }}'
+      Yes or no? ||| {% if label != -1 %}{{ answer_choices[label] }}{% endif %}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: false
@@ -136,7 +136,7 @@ templates:
     answer_choices_key: null
     id: ee0ce095-122a-4509-bf0b-33d1495295f7
     jinja: '{{premise}} Are we justified in saying that "{{hypothesis}}"? Yes or no?
-      ||| {{ answer_choices[label] }} '
+      ||| {% if label != -1 %}{{ answer_choices[label] }}{% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -151,7 +151,7 @@ templates:
     answer_choices_key: null
     id: fb4f8144-37f5-4977-88da-37a5d0bfd0e8
     jinja: 'Given that {{premise}} Therefore, it must be true that "{{hypothesis}}"?
-      Yes or no? ||| {{ answer_choices[label] }} '
+      Yes or no? ||| {% if label != -1 %}{{ answer_choices[label] }}{% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:

--- a/promptsource/templates/super_glue/wic/templates.yaml
+++ b/promptsource/templates/super_glue/wic/templates.yaml
@@ -7,9 +7,18 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: 14e73f39-a0d1-44c2-b9a4-4e48f9f1608e
-    jinja: "{% if label != -1%}\nDoes the word \"{{word}}\" have the same meaning\
-      \ in these two sentences? Yes, No?\n{{sentence1}}\n{{sentence2}}\n||| \n{{answer_choices[label]}}\n\
-      {% endif %}"
+    jinja: 'Does the word "{{word}}" have the same meaning in these two sentences?
+      Yes, No?
+
+      {{sentence1}}
+
+      {{sentence2}}
+
+      ||| {% if label != -1%}
+
+      {{answer_choices[label]}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -25,9 +34,17 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: 3503ead5-4fa5-4f77-95dc-f0c2ed3eecdc
-    jinja: "{% if label != -1%}\nDoes the word \"{{word}}\" have the same meaning\
-      \ in these two sentences?\n{{sentence1}}\n{{sentence2}}\n||| \n{{answer_choices[label]}}\n\
-      {% endif %}"
+    jinja: 'Does the word "{{word}}" have the same meaning in these two sentences?
+
+      {{sentence1}}
+
+      {{sentence2}}
+
+      ||| {% if label != -1%}
+
+      {{answer_choices[label]}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -43,10 +60,21 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: 611d13dc-d414-4b9b-9204-e4f325e859e7
-    jinja: "{% if label != -1%}\nHomework\n\nDecide whether the word \"{{word}}\"\
-      \ is used with the same meaning in the two following sentences. Answer by yes\
-      \ or no.\n{{sentence1}}\n{{sentence2}}\n||| \n{{answer_choices[label]}}\n{%\
-      \ endif %}"
+    jinja: 'Homework
+
+
+      Decide whether the word "{{word}}" is used with the same meaning in the two
+      following sentences. Answer by yes or no.
+
+      {{sentence1}}
+
+      {{sentence2}}
+
+      ||| {% if label != -1%}
+
+      {{answer_choices[label]}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -60,9 +88,18 @@ templates:
     - 'True'
     answer_choices_key: null
     id: 725b5ed0-7728-4890-95a4-a74cb7ae1bb4
-    jinja: "{% if label != -1%}\nSentence A: {{sentence1}}\nSentence B: {{sentence2}}\n\
-      \n\"{{word}}\" has a similar meaning in sentences A and B. True or False?\n\
-      ||| \n{{answer_choices[label]}}\n{% endif %}"
+    jinja: 'Sentence A: {{sentence1}}
+
+      Sentence B: {{sentence2}}
+
+
+      "{{word}}" has a similar meaning in sentences A and B. True or False?
+
+      ||| {% if label != -1%}
+
+      {{answer_choices[label]}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -76,9 +113,18 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: c3a0a5d8-cfe9-4a7f-8a3c-3c526e0ad0c6
-    jinja: "{% if label != -1%}\n{{sentence1}}\n{{sentence2}}\nQuestion: Is the word\
-      \ '{{word}}' used in the same sense in the two sentences above?\n||| \n{{answer_choices[label]}}\n\
-      {% endif %}"
+    jinja: '{{sentence1}}
+
+      {{sentence2}}
+
+      Question: Is the word ''{{word}}'' used in the same sense in the two sentences
+      above?
+
+      ||| {% if label != -1%}
+
+      {{answer_choices[label]}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -94,9 +140,7 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: ce8b5a93-1841-4897-84db-b100f1c84f4b
-    jinja: '{% if label != -1%}
-
-      Sentence 1: {{sentence1}}
+    jinja: 'Sentence 1: {{sentence1}}
 
       Sentence 2: {{sentence2}}
 
@@ -104,7 +148,7 @@ templates:
       Determine whether the word "{{word}}" is used in the same sense in both sentences.
       Yes or no?
 
-      |||
+      ||| {% if label != -1%}
 
       {{answer_choices[label]}}
 
@@ -122,8 +166,8 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: cfbc1637-10b8-4f20-a31c-55292f3cebd0
-    jinja: "{% if label != -1%}\nDetermine if the word '{{word}}' is used in the same\
-      \ way in the two sentences below. \n{{sentence1}}\n{{sentence2}}\n||| \n{{answer_choices[label]}}\n\
+    jinja: "Determine if the word '{{word}}' is used in the same way in the two sentences\
+      \ below. \n{{sentence1}}\n{{sentence2}}\n||| {% if label != -1%}\n{{answer_choices[label]}}\n\
       {% endif %}"
     metadata: !TemplateMetadata
       _do_eval: true
@@ -140,9 +184,18 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: d9e1db2a-ab0b-4621-bb41-01d5788d3873
-    jinja: "{% if label != -1%}\n{{sentence1}}\n{{sentence2}}\nQuestion: Is the word\
-      \ '{{word}}' used in the same sense in the two sentences above? Yes, No?\n|||\
-      \ \n{{answer_choices[label]}}\n{% endif %}"
+    jinja: '{{sentence1}}
+
+      {{sentence2}}
+
+      Question: Is the word ''{{word}}'' used in the same sense in the two sentences
+      above? Yes, No?
+
+      ||| {% if label != -1%}
+
+      {{answer_choices[label]}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true
@@ -159,17 +212,15 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: dd2080cf-3117-49ba-9aff-c988a21fdb69
-    jinja: '{% if label != -1%}
-
-      The word "{{word}}" has multiple meanings. Does it have the same meaning in
-      sentences 1 and 2? Yes or no?
+    jinja: 'The word "{{word}}" has multiple meanings. Does it have the same meaning
+      in sentences 1 and 2? Yes or no?
 
 
       Sentence 1: {{sentence1}}
 
       Sentence 2: {{sentence2}}
 
-      |||
+      ||| {% if label != -1%}
 
       {{answer_choices[label]}}
 
@@ -187,8 +238,17 @@ templates:
     - 'Yes'
     answer_choices_key: null
     id: f934a96d-fe4d-4075-aa47-5595b9a604c7
-    jinja: "{% if label != -1%}\n{{sentence1}}\n{{sentence2}}\nSimilar sense of {{word}}?\n\
-      ||| \n{{answer_choices[label]}}\n{% endif %}"
+    jinja: '{{sentence1}}
+
+      {{sentence2}}
+
+      Similar sense of {{word}}?
+
+      ||| {% if label != -1%}
+
+      {{answer_choices[label]}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       _do_eval: true
       _do_train: true


### PR DESCRIPTION
Fix plumbing for conditional targets.
When there is no target (for instance on test sets), we should return the prompted input but not the prompted target (which is now by default `<NO LABEL>` on seqio/caching side).
That wasn't the case before as the whole template was wrapped into an if condition, and thus the whole test set (for instance) was just ignored...

This will be needed for SuperGLUE