### PR TITLE
added a prompt for LAMBADA

### DIFF
--- a/promptsource/templates/lambada/templates.yaml
+++ b/promptsource/templates/lambada/templates.yaml
@@ -1,0 +1,15 @@
+dataset: lambada
+templates:
+  d5707bd9-d3cc-4535-b4c1-5c2aee8cb8c7: !Template
+    answer_choices: null
+    answer_choices_key: null
+    id: d5707bd9-d3cc-4535-b4c1-5c2aee8cb8c7
+    jinja: '{{ text.split('' '')[:-1] | join('' '') }} ||| {{ text.split('' '')[-1]
+      }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: predict the last word
+    reference: ''


### PR DESCRIPTION
By design, LAMBADA asks a model to predict the last word of a paragraph, so the one obvious prompt (which simply omits the last word of the paragraph) is possibly the only prompt needed for this dataset.

@VictorSanh no need to cache it immediately, but do cache it before you launch the next eval runs if possible.