### PR TITLE
Update wsc273 based on current templates in wsc.fixed.

### DIFF
--- a/promptsource/templates/winograd_wsc/wsc273/templates.yaml
+++ b/promptsource/templates/winograd_wsc/wsc273/templates.yaml
@@ -1,73 +1,127 @@
 dataset: winograd_wsc
 subset: wsc273
 templates:
-  4e7480eb-dc34-4c3f-bff3-bac11932fb07: !Template
+  18233597-fcd3-415d-a184-a971e98119d9: !Template
     answer_choices: null
-    answer_choices_key: null
-    id: 4e7480eb-dc34-4c3f-bff3-bac11932fb07
-    jinja: "Identify the pronoun in \"{{text}}\" |||  \n{{pronoun}}"
+    answer_choices_key: '{{ options | join("|||") }}'
+    id: 18233597-fcd3-415d-a184-a971e98119d9
+    jinja: '{{ text }} Here, does "{{ pronoun }}" stand for {{ answer_choices[0] }}
+      or {{ answer_choices[1] }}? ||| {{ answer_choices[label] }}'
     metadata: !TemplateMetadata
-      _do_eval: false
-      _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: identify_pronoun
+      _do_eval: true
+      _do_train: true
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: does p stand for
     reference: ''
-  528d1392-b70e-4cec-a72a-380fab9955c7: !Template
+  3f04226a-fb68-4d82-bda1-658f1a316365: !Template
     answer_choices: null
-    answer_choices_key: null
-    id: 528d1392-b70e-4cec-a72a-380fab9955c7
-    jinja: "Identify the pronoun in \"{{text}}\" and the entity it is referring to\
-      \ |||  \n\"{{pronoun}}\" which refers to the \"{{options[label]}}\""
+    answer_choices_key: '{{ options | join("|||") }}'
+    id: 3f04226a-fb68-4d82-bda1-658f1a316365
+    jinja: "{{ text }} \n{% if pronoun.lower()  == \"they\" or pronoun.lower() ==\
+      \ \"them\" %}\nQuestion: Who or what are \"{{ pronoun }}\"? {{ answer_choices[0]\
+      \ }} or {{ answer_choices[1] }}?\n{% else %}\nQuestion: Who or what is \"{{\
+      \ pronoun }}\"? Is it {{ answer_choices[0] }} or {{ answer_choices[1] }}?\n\
+      {% endif %}\nAnswer: ||| {{ answer_choices[label] }}"
     metadata: !TemplateMetadata
-      _do_eval: false
-      _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: identify_pronoun_entity
+      _do_eval: true
+      _do_train: true
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: Who or what is/are
     reference: ''
-  c07d5f26-303f-44d9-a941-659debdd9ec2: !Template
+  53603685-806f-4332-ae9a-e393b6ad2d89: !Template
     answer_choices: null
-    answer_choices_key: null
-    id: c07d5f26-303f-44d9-a941-659debdd9ec2
-    jinja: 'Who does the pronoun "{{pronoun}}" in "{{text}}" refer to? |||
-
-      {{options[label]}}'
+    answer_choices_key: '{{options | join("|||")}}'
+    id: 53603685-806f-4332-ae9a-e393b6ad2d89
+    jinja: '{{ text }} In the previous sentence, can the pronoun "{{pronoun }}" be
+      replaced with "{{ answer_choices[0] }}" or "{{ answer_choices[1] }}"? ||| {{
+      answer_choices[label] }}'
     metadata: !TemplateMetadata
-      _do_eval: false
-      _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: pronoun
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: replaced with
     reference: ''
-  df01735f-5f06-408f-930d-618f3cfc9261: !Template
+  62aa8a33-2f62-43ec-aa7e-20d2052e2a8c: !Template
     answer_choices: null
-    answer_choices_key: null
-    id: df01735f-5f06-408f-930d-618f3cfc9261
-    jinja: "Who does the pronoun \"{{pronoun}}\" in \"{{text}}\" refer to?\n\nThe\
-      \ options are {{options | join(\" and \")}} |||  \n{{options[label]}}"
+    answer_choices_key: '{{ options | join("|||") }}'
+    id: 62aa8a33-2f62-43ec-aa7e-20d2052e2a8c
+    jinja: "{{ text }} \nIn the passage above, the pronoun \"{{ pronoun }}\" refers\
+      \ to {{ answer_choices[0] }} or {{ answer_choices[1] }}? ||| {{ answer_choices[label]\
+      \ }}"
     metadata: !TemplateMetadata
-      _do_eval: false
-      _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: pronoun_options
+      _do_eval: true
+      _do_train: true
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: the pronoun refers to
+    reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+  6e8a2985-ecc1-4184-86b9-929d2d25746e: !Template
+    answer_choices: null
+    answer_choices_key: '{{options | join("|||")}}'
+    id: 6e8a2985-ecc1-4184-86b9-929d2d25746e
+    jinja: "Context: {{ text }} \n\n{% if pronoun.lower()  == \"they\" or pronoun.lower()\
+      \ == \"them\" %}\nQuestion: \"{{ pronoun }}\" are {{ answer_choices[0] }} or\
+      \ {{ answer_choices[1] }}?\n{% else %}\nQuestion: \"{{ pronoun }}\" is {{ answer_choices[0]\
+      \ }} or {{ answer_choices[1] }}?\n{% endif %}\n\nAnswer: ||| {{ answer_choices[label]\
+      \ }}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: p is/are r
     reference: ''
-  e24ae7b1-9e55-49a2-b4aa-c8d9b13814de: !Template
+  7ee12960-5512-431a-b1eb-b3a975761f6c: !Template
     answer_choices: null
-    answer_choices_key: null
-    id: e24ae7b1-9e55-49a2-b4aa-c8d9b13814de
-    jinja: "Identify the phrase in \"{{text}}\" in which the key action or context\
-      \ surrounding the pronoun is described |||  \n{{quote}}"
+    answer_choices_key: '{{options | join("|||")}}'
+    id: 7ee12960-5512-431a-b1eb-b3a975761f6c
+    jinja: "Passage: {{ text }} \n\nQuestion: In the passage above, does the pronoun\
+      \ \"{{ pronoun }}\" refer to {{ answer_choices[0] }} or {{answer_choices[1]\
+      \ }}?\n\nAnswer: ||| {{ answer_choices[label] }}"
     metadata: !TemplateMetadata
-      _do_eval: false
-      _do_train: false
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: key_action
+      _do_eval: true
+      _do_train: true
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: GPT-3 Style
+    reference: Adapted from Figure G33, p. 59, Brown et al. 2020
+  a0e4b805-e0bc-4b20-81bd-2b265ace8644: !Template
+    answer_choices: null
+    answer_choices_key: '{{options | join("|||")}}'
+    id: a0e4b805-e0bc-4b20-81bd-2b265ace8644
+    jinja: '{{ text }} In the previous sentence, does the pronoun "{{ pronoun }}"
+      refer to {{ answer_choices[0] }} or {{ answer_choices[1] }}? ||| {{ answer_choices[label]
+      }}'
+    metadata: !TemplateMetadata
+      _do_eval: true
+      _do_train: true
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: does the pronoun refer to
+    reference: "Adapted from Perez et al. 2021 and Schick & Sch\xFCtz 2021."
+  e617cc59-9eca-4b17-ba2e-a87b79fe8c89: !Template
+    answer_choices: null
+    answer_choices_key: '{{options | join("|||")}}'
+    id: e617cc59-9eca-4b17-ba2e-a87b79fe8c89
+    jinja: '{{ text }} Here, by "{{ pronoun }}" do they mean "{{ answer_choices[0]
+      }}" or "{{ answer_choices[1]}}"? ||| {{ answer_choices[label] }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: by p they mean
     reference: ''


### PR DESCRIPTION
Per @awebson, this copies and adapts the current templates in wsc.fixed for wsc273. In addition to converting from yes/no questions to either/or ones, I made the following changes:
- Deleted two templates that were not natural to convert
- Change "who is/are" to "who or what is/are" since not all referents are people in this dataset.

Part of #477.