### PR TITLE
Community names and rename app

### DIFF
--- a/promptsource/app.py
+++ b/promptsource/app.py
@@ -9,9 +9,17 @@ from jinja2 import TemplateSyntaxError
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import DjangoLexer
+
 from promptsource.session import _get_state
 from promptsource.templates import Template, TemplateCollection
-from promptsource.utils import get_dataset, get_dataset_confs, list_datasets, removeHyphen, renameDatasetColumn, render_features
+from promptsource.utils import (
+    get_dataset,
+    get_dataset_confs,
+    list_datasets,
+    removeHyphen,
+    renameDatasetColumn,
+    render_features,
+)
 
 
 #

--- a/promptsource/app.py
+++ b/promptsource/app.py
@@ -9,9 +9,9 @@ from jinja2 import TemplateSyntaxError
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import DjangoLexer
-from session import _get_state
-from templates import Template, TemplateCollection
-from utils import get_dataset, get_dataset_confs, list_datasets, removeHyphen, renameDatasetColumn, render_features
+from promptsource.session import _get_state
+from promptsource.templates import Template, TemplateCollection
+from promptsource.utils import get_dataset, get_dataset_confs, list_datasets, removeHyphen, renameDatasetColumn, render_features
 
 
 #
@@ -36,7 +36,7 @@ state = _get_state()
 #
 # Initial page setup
 #
-st.set_page_config(layout="wide")
+st.set_page_config(page_title="Promptsource", layout="wide")
 mode = st.sidebar.selectbox(
     label="Choose a mode",
     options=["Helicopter view", "Prompted dataset viewer", "Sourcing"],

--- a/promptsource/metadata.py
+++ b/promptsource/metadata.py
@@ -1,0 +1,3 @@
+# These are users whose datasets should be included in the results returned by
+# filter_english_datasets (regardless of their metadata)
+INCLUDED_USERS = {"Zaid"}

--- a/promptsource/metadata.py
+++ b/promptsource/metadata.py
@@ -1,3 +1,0 @@
-# These are users whose datasets should be included in the results returned by
-# filter_english_datasets (regardless of their metadata)
-INCLUDED_USERS = {"Zaid"}

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pkg_resources
 import yaml
 from jinja2 import BaseLoader, Environment, meta
-from metadata import INCLUDED_USERS
+from .metadata import INCLUDED_USERS
 
 
 # Truncation of jinja template variables

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -10,8 +10,6 @@ import pkg_resources
 import yaml
 from jinja2 import BaseLoader, Environment, meta
 
-from .metadata import INCLUDED_USERS
-
 
 # Truncation of jinja template variables
 # 1710 = 300 words x 4.7 avg characters per word + 300 spaces
@@ -24,6 +22,10 @@ env = Environment(loader=BaseLoader)
 
 # Allow the python function zip()
 env.globals.update(zip=zip)
+
+# These are users whose datasets should be included in the results returned by
+# filter_english_datasets (regardless of their metadata)
+INCLUDED_USERS = {"Zaid"}
 
 
 def highlight(input):

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -4,6 +4,7 @@ import uuid
 from collections import Counter, defaultdict
 from shutil import rmtree
 from typing import Dict, List, Optional, Tuple
+from promptsource.utils import INCLUDED_USERS
 
 import pandas as pd
 import pkg_resources
@@ -263,7 +264,7 @@ class TemplateCollection:
     def __init__(self):
 
         # Dict of all the DatasetTemplates, key is the tuple (dataset_name, subset_name)
-        self.datasets_templates: Dict[(str, Optional[str]), DatasetTemplates] = self._collect_dataset()
+        self.datasets_templates: Dict[(str, Optional[str]), DatasetTemplates] = self._collect_datasets()
 
     @property
     def keys(self):
@@ -275,7 +276,7 @@ class TemplateCollection:
     def remove(self, dataset_name: str, subset_name: Optional[str] = None) -> None:
         del self.datasets_templates[dataset_name, subset_name]
 
-    def _collect_dataset(self) -> Dict[Tuple[str, str], "DatasetTemplates"]:
+    def _collect_datasets(self) -> Dict[Tuple[str, str], "DatasetTemplates"]:
         """
         Initialize a DatasetTemplates object for each templates.yaml detected in the templates folder
 
@@ -286,14 +287,24 @@ class TemplateCollection:
 
         output = {}  # format is {(dataset_name, subset_name): DatasetsTemplates}
         for dataset in dataset_folders:
-            for filename in os.listdir(os.path.join(TEMPLATES_FOLDER_PATH, dataset)):
-                if filename.endswith(".yaml"):
-                    # If there is no sub-folder, there is no subset for this dataset
-                    output[(dataset, None)] = DatasetTemplates(dataset)
-                else:
-                    # This is a subfolder, and its name corresponds to the subset name
-                    output[(dataset, filename)] = DatasetTemplates(dataset_name=dataset, subset_name=filename)
+            if dataset in INCLUDED_USERS:
+                for filename in os.listdir(os.path.join(TEMPLATES_FOLDER_PATH, dataset)):
+                    output = {**output, **self._collect_dataset(dataset + "/" + filename)}
+            else:
+                output = {**output, **self._collect_dataset(dataset)}
         return output
+
+    def _collect_dataset(self, dataset):
+        output = {}  # format is {(dataset_name, subset_name): DatasetsTemplates}
+        for filename in os.listdir(os.path.join(TEMPLATES_FOLDER_PATH, dataset)):
+            if filename.endswith(".yaml"):
+                # If there is no sub-folder, there is no subset for this dataset
+                output[(dataset, None)] = DatasetTemplates(dataset)
+            else:
+                # This is a subfolder, and its name corresponds to the subset name
+                output[(dataset, filename)] = DatasetTemplates(dataset_name=dataset, subset_name=filename)
+        return output
+
 
     def get_dataset(self, dataset_name: str, subset_name: Optional[str] = None) -> "DatasetTemplates":
         """

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pkg_resources
 import yaml
 from jinja2 import BaseLoader, Environment, meta
+
 from .metadata import INCLUDED_USERS
 
 

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -4,12 +4,13 @@ import uuid
 from collections import Counter, defaultdict
 from shutil import rmtree
 from typing import Dict, List, Optional, Tuple
-from promptsource.utils import INCLUDED_USERS
 
 import pandas as pd
 import pkg_resources
 import yaml
 from jinja2 import BaseLoader, Environment, meta
+
+from promptsource.utils import INCLUDED_USERS
 
 
 # Truncation of jinja template variables
@@ -304,7 +305,6 @@ class TemplateCollection:
                 # This is a subfolder, and its name corresponds to the subset name
                 output[(dataset, filename)] = DatasetTemplates(dataset_name=dataset, subset_name=filename)
         return output
-
 
     def get_dataset(self, dataset_name: str, subset_name: Optional[str] = None) -> "DatasetTemplates":
         """

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -9,8 +9,7 @@ import pandas as pd
 import pkg_resources
 import yaml
 from jinja2 import BaseLoader, Environment, meta
-
-from promptsource.utils import INCLUDED_USERS
+from metadata import INCLUDED_USERS
 
 
 # Truncation of jinja template variables

--- a/promptsource/utils.py
+++ b/promptsource/utils.py
@@ -3,7 +3,7 @@
 import datasets
 import pkg_resources
 import requests
-from metadata import INCLUDED_USERS
+from .metadata import INCLUDED_USERS
 
 
 def removeHyphen(example):

--- a/promptsource/utils.py
+++ b/promptsource/utils.py
@@ -154,7 +154,7 @@ def list_datasets(template_collection, _priority_filter, _priority_max_templates
 These are users whose datasets should be included in the results returned by
 filter_english_datasets (regardless of their metadata)
 """
-INCLUDED_USERS = {"Zaid"}
+INCLUDED_USERS = {"Zaid"} 
 
 
 DATASET_ORDER = dict(

--- a/promptsource/utils.py
+++ b/promptsource/utils.py
@@ -4,7 +4,7 @@ import datasets
 import pkg_resources
 import requests
 
-from .metadata import INCLUDED_USERS
+from promptsource.templates import INCLUDED_USERS
 
 
 def removeHyphen(example):

--- a/promptsource/utils.py
+++ b/promptsource/utils.py
@@ -154,7 +154,7 @@ def list_datasets(template_collection, _priority_filter, _priority_max_templates
 These are users whose datasets should be included in the results returned by
 filter_english_datasets (regardless of their metadata)
 """
-INCLUDED_USERS = ("Zaid",)
+INCLUDED_USERS = {"Zaid"}
 
 
 DATASET_ORDER = dict(

--- a/promptsource/utils.py
+++ b/promptsource/utils.py
@@ -3,6 +3,7 @@
 import datasets
 import pkg_resources
 import requests
+from metadata import INCLUDED_USERS
 
 
 def removeHyphen(example):
@@ -148,13 +149,6 @@ def list_datasets(template_collection, _priority_filter, _priority_max_templates
     else:
         dataset_list.sort(key=lambda x: DATASET_ORDER.get(x, 1000))
     return dataset_list
-
-
-"""
-These are users whose datasets should be included in the results returned by
-filter_english_datasets (regardless of their metadata)
-"""
-INCLUDED_USERS = {"Zaid"}
 
 
 DATASET_ORDER = dict(

--- a/promptsource/utils.py
+++ b/promptsource/utils.py
@@ -3,6 +3,7 @@
 import datasets
 import pkg_resources
 import requests
+
 from .metadata import INCLUDED_USERS
 
 

--- a/promptsource/utils.py
+++ b/promptsource/utils.py
@@ -154,7 +154,7 @@ def list_datasets(template_collection, _priority_filter, _priority_max_templates
 These are users whose datasets should be included in the results returned by
 filter_english_datasets (regardless of their metadata)
 """
-INCLUDED_USERS = {"Zaid"} 
+INCLUDED_USERS = {"Zaid"}
 
 
 DATASET_ORDER = dict(


### PR DESCRIPTION
This PR does two things:
- Correctly parse dataset names from the community. Since they have slashes and are in subdirectories, we can't tell which is a subset and which is part of a user's datasets without looking at our list of users to include.
- Rename the main module to app.py. This is to enable the correct handling of absolute imports. It seems that streamlit, at least up to 0.88, can neither handle relative imports nor absolute imports if the module has the same name as the package. (Can anyone reproduce? Perhaps I'm missing something, but this is the only fix I've found.) We had hacked around it up to this point by using absolute imports to submodules, but this breaks when we want modules to start importing from each other. Hence, why these two changes are coupled.