### PR TITLE
Issues/510: Add an argument for read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ There are 3 modes in the app:
 
 <img src="assets/promptsource_app.png" width="800">
 
+## Running (read-only)
+To host a public streamlit app, launch it with
+```bash
+streamlit run promptsource/promptsource.py -- -r
+```
+
 ## Contributing
 Join the **Hackaprompt** and help writing templates!
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ WIP
 ## Running
 From the root directory of the repo, you can launch the editor with
 ```
-streamlit run promptsource/promptsource.py
+streamlit run promptsource/app.py
 ```
 
 There are 3 modes in the app:
@@ -24,7 +24,7 @@ There are 3 modes in the app:
 ## Running (read-only)
 To host a public streamlit app, launch it with
 ```bash
-streamlit run promptsource/promptsource.py -- -r
+streamlit run promptsource/app.py -- -r
 ```
 
 ## Contributing

--- a/promptsource/app.py
+++ b/promptsource/app.py
@@ -38,7 +38,7 @@ if args.read_only:
     side_bar_title_prefix = "Promptsource (Read only)"
 else:
     select_options = ["Helicopter view", "Prompted dataset viewer", "Sourcing"]
-    side_bar_title_prefix = "Prompt sourcing"
+    side_bar_title_prefix = "Promptsource"
 
 #
 # Helper functions for datasets library

--- a/promptsource/app.py
+++ b/promptsource/app.py
@@ -29,7 +29,7 @@ from promptsource.utils import (
 # streamlit run promptsource/app.py -- -r
 # streamlit run promptsource/app.py -- --read-only
 # Check https://github.com/streamlit/streamlit/issues/337 for more information.
-parser = argparse.ArgumentParser(description="run promptsource.py with args")
+parser = argparse.ArgumentParser(description="run app.py with args")
 parser.add_argument("-r", "--read-only", action="store_true", help="whether to run it as read-only mode")
 
 args = parser.parse_args()

--- a/promptsource/app.py
+++ b/promptsource/app.py
@@ -35,7 +35,7 @@ parser.add_argument("-r", "--read-only", action="store_true", help="whether to r
 args = parser.parse_args()
 if args.read_only:
     select_options = ["Helicopter view", "Prompted dataset viewer"]
-    side_bar_title_prefix = "Read-only mode"
+    side_bar_title_prefix = "Promptsource (Read only)"
 else:
     select_options = ["Helicopter view", "Prompted dataset viewer", "Sourcing"]
     side_bar_title_prefix = "Prompt sourcing"

--- a/promptsource/app.py
+++ b/promptsource/app.py
@@ -25,8 +25,8 @@ from promptsource.utils import (
 # add an argument for read-only
 # At the moment, streamlit does not handle python script arguments gracefully.
 # Thus, for read-only mode, you have to type one of the below two:
-# streamlit run promptsource/promptsource.py -- -r
-# streamlit run promptsource/promptsource.py -- --read-only
+# streamlit run promptsource/app.py -- -r
+# streamlit run promptsource/app.py -- --read-only
 # Check https://github.com/streamlit/streamlit/issues/337 for more information.
 parser = argparse.ArgumentParser(description='run promptsource.py with args')
 parser.add_argument('-r', '--read-only', action='store_true', 

--- a/promptsource/app.py
+++ b/promptsource/app.py
@@ -1,7 +1,7 @@
+import argparse
 import textwrap
 from multiprocessing import Manager, Pool
 
-import argparse
 import pandas as pd
 import plotly.express as px
 import streamlit as st
@@ -22,15 +22,15 @@ from promptsource.utils import (
     render_features,
 )
 
+
 # add an argument for read-only
 # At the moment, streamlit does not handle python script arguments gracefully.
 # Thus, for read-only mode, you have to type one of the below two:
 # streamlit run promptsource/app.py -- -r
 # streamlit run promptsource/app.py -- --read-only
 # Check https://github.com/streamlit/streamlit/issues/337 for more information.
-parser = argparse.ArgumentParser(description='run promptsource.py with args')
-parser.add_argument('-r', '--read-only', action='store_true', 
-                    help='whether to run it as read-only mode')
+parser = argparse.ArgumentParser(description="run promptsource.py with args")
+parser.add_argument("-r", "--read-only", action="store_true", help="whether to run it as read-only mode")
 
 args = parser.parse_args()
 if args.read_only:

--- a/promptsource/promptsource.py
+++ b/promptsource/promptsource.py
@@ -1,6 +1,7 @@
 import textwrap
 from multiprocessing import Manager, Pool
 
+import argparse
 import pandas as pd
 import plotly.express as px
 import streamlit as st
@@ -13,11 +14,27 @@ from session import _get_state
 from templates import Template, TemplateCollection
 from utils import get_dataset, get_dataset_confs, list_datasets, removeHyphen, renameDatasetColumn, render_features
 
+# add an argument for read-only
+# At the moment, streamlit does not handle python script arguments gracefully.
+# Thus, for read-only mode, you have to type one of the below two:
+# streamlit run promptsource/promptsource.py -- -r
+# streamlit run promptsource/promptsource.py -- --read-only
+# Check https://github.com/streamlit/streamlit/issues/337 for more information.
+parser = argparse.ArgumentParser(description='run promptsource.py with args')
+parser.add_argument('-r', '--read-only', action='store_true', 
+                    help='whether to run it as read-only mode')
+
+args = parser.parse_args()
+if args.read_only:
+    select_options = ["Helicopter view", "Prompted dataset viewer"]
+    side_bar_title_prefix = "Read-only mode"
+else:
+    select_options = ["Helicopter view", "Prompted dataset viewer", "Sourcing"]
+    side_bar_title_prefix = "Prompt sourcing"
 
 #
 # Helper functions for datasets library
 #
-
 get_dataset = st.cache(allow_output_mutation=True)(get_dataset)
 get_dataset_confs = st.cache(get_dataset_confs)
 
@@ -39,11 +56,11 @@ state = _get_state()
 st.set_page_config(layout="wide")
 mode = st.sidebar.selectbox(
     label="Choose a mode",
-    options=["Helicopter view", "Prompted dataset viewer", "Sourcing"],
+    options=select_options,
     index=0,
     key="mode_select",
 )
-st.sidebar.title(f"Prompt sourcing 🌸 - {mode}")
+st.sidebar.title(f"{side_bar_title_prefix} 🌸 - {mode}")
 
 #
 # Adds pygments styles to the page.


### PR DESCRIPTION
At the moment, streamlit does not handle python script arguments gracefully.
Thus, for read-only mode, you have to type one of the below two:

`streamlit run promptsource/app.py -- -r`
`streamlit run promptsource/app.py -- --read-only`

Check https://github.com/streamlit/streamlit/issues/337 for more information.