### PR TITLE
add jigsaw_toxicity_pred

### DIFF
--- a/promptsource/templates/jigsaw_toxicity_pred/templates.yaml
+++ b/promptsource/templates/jigsaw_toxicity_pred/templates.yaml
@@ -1,0 +1,205 @@
+dataset: jigsaw_toxicity_pred
+templates:
+  05e33801-746c-49fc-b839-3f8901462c85: !Template
+    answer_choices:
+    - 'No'
+    - 'Yes'
+    answer_choices_key: null
+    id: 05e33801-746c-49fc-b839-3f8901462c85
+    jinja: 'Is this forum comment obscene?
+
+
+      Comment: {{comment_text}}
+
+      |||
+
+      {{answer_choices[obscene]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - AUC
+      original_task: true
+    name: is_it_obscene
+    reference: ''
+  07ec1eff-a0c4-4c0f-9e3a-0fb610e1471d: !Template
+    answer_choices:
+    - 'No'
+    - 'Yes'
+    answer_choices_key: null
+    id: 07ec1eff-a0c4-4c0f-9e3a-0fb610e1471d
+    jinja: 'Comment: {{comment_text}}
+
+
+      I am looking at this online comment. Is it expressing a threat? Yes or no.
+
+      |||
+
+      {{answer_choices[threat]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - AUC
+      original_task: true
+    name: is_it_threat
+    reference: ''
+  487ddaa3-aa28-490c-9cf6-bb238da9db71: !Template
+    answer_choices:
+    - 'No'
+    - 'Yes'
+    answer_choices_key: null
+    id: 487ddaa3-aa28-490c-9cf6-bb238da9db71
+    jinja: 'I am the moderator of Wikipedia. Would you describe this comment as toxic?
+      Answer yes or no.
+
+      Comment: {{comment_text}}
+
+      |||
+
+      {{answer_choices[toxic]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - AUC
+      original_task: true
+    name: moderator_toxic
+    reference: ''
+  4a697eb3-66f1-4e1c-92d0-98c00fe8f55a: !Template
+    answer_choices:
+    - 'No'
+    - 'Yes'
+    answer_choices_key: null
+    id: 4a697eb3-66f1-4e1c-92d0-98c00fe8f55a
+    jinja: 'I am moderating comments on Wikipedia. Would you describe this comment
+      as obscene? Answer yes or no.
+
+      Comment: {{comment_text}}
+
+      |||
+
+      {{answer_choices[obscene]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - AUC
+      original_task: true
+    name: moderator_obscene
+    reference: ''
+  53f5e1a7-32fa-4ce6-8d24-2e7b17f3a2b4: !Template
+    answer_choices:
+    - 'No'
+    - 'Yes'
+    answer_choices_key: null
+    id: 53f5e1a7-32fa-4ce6-8d24-2e7b17f3a2b4
+    jinja: 'I am moderating Wikipedia''s online comments. Is this comment expressing
+      hate against individuals? Answer yes or no.
+
+
+      {{comment_text}} |||
+
+      {{answer_choices[identity_hate]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - AUC
+      original_task: true
+    name: moderator_identity_hate
+    reference: ''
+  88b48f8f-7276-428e-ada3-0c8bf4c78b26: !Template
+    answer_choices:
+    - 'No'
+    - 'Yes'
+    answer_choices_key: null
+    id: 88b48f8f-7276-428e-ada3-0c8bf4c78b26
+    jinja: 'Is this online comment toxic? Yes or no?
+
+      Comment: {{comment_text}}|||{{answer_choices[toxic]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - AUC
+      original_task: true
+    name: is_it_toxic
+    reference: ''
+  afff2a37-8588-4e2c-8799-7452108404bf: !Template
+    answer_choices:
+    - 'No'
+    - 'Yes'
+    answer_choices_key: null
+    id: afff2a37-8588-4e2c-8799-7452108404bf
+    jinja: 'I am Wikipedia''s online moderator. Do you think the following comment
+      is an insult? Yes or no?
+
+
+      {{comment_text}}
+
+      |||
+
+      {{answer_choices[insult]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - AUC
+      original_task: true
+    name: moderator_insult
+    reference: ''
+  c32fc159-1268-4f12-8d3f-ac342f496357: !Template
+    answer_choices:
+    - 'No'
+    - 'Yes'
+    answer_choices_key: null
+    id: c32fc159-1268-4f12-8d3f-ac342f496357
+    jinja: 'Is this comment hateful against an individual or a group of individuals?
+      Answer yes or no.
+
+
+      {{comment_text}} |||
+
+      {{answer_choices[identity_hate]}} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - AUC
+      original_task: true
+    name: is_it_identity_hate
+    reference: ''
+  d8c3462d-d2a8-4523-8442-1fd104045565: !Template
+    answer_choices:
+    - 'No'
+    - 'Yes'
+    answer_choices_key: null
+    id: d8c3462d-d2a8-4523-8442-1fd104045565
+    jinja: '{{comment_text}}
+
+
+      The previous text is an online comment. Is it an insult? Answer yes or no.
+
+      |||
+
+      {{answer_choices[insult]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - AUC
+      original_task: true
+    name: is_it_insult
+    reference: ''
+  eeca25cf-f6a3-4fe3-8c43-7ccdd915af4d: !Template
+    answer_choices:
+    - 'No'
+    - 'Yes'
+    answer_choices_key: null
+    id: eeca25cf-f6a3-4fe3-8c43-7ccdd915af4d
+    jinja: 'The online moderator of Wikipedia has to decide whether this comment is
+      expressing a threat. Would you say so? Answer yes or no.
+
+
+      {{comment_text}} |||
+
+      {{answer_choices[threat]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - AUC
+      original_task: true
+    name: moderator_threat
+    reference: ''


### PR DESCRIPTION
A few points:
- i didn't prompt `severe_toxic` as it is labeled as True in extremely rare cases (less than 1%) and I am not sure what it the difference with `toxic` (I currently asking around to get an answer on this)
- 2 prompts per label
- the dataset requires manual download, please change these lines `promptsource/utils.py`:
```python
def get_dataset_builder(path, conf=None):
    "Get a dataset builder from name and conf."
    # `datasets.load.prepare_module` pulls infos from hf/datasets's master.
    # story_cloze hasn't been merged yet (https://github.com/huggingface/datasets/pull/2907)
    # This is a temporary fix for the tests (more specifically test_templates.py)
    # Once PR 2907 is merged, we can remove this if condition (along with the `custom_datasets` folder)
    # Also see `promptsource.seqio_tasks.utils.get_dataset_splits`
    if path == "story_cloze":
        path = pkg_resources.resource_filename("promptsource", "custom_datasets/story_cloze")
    module_path = datasets.load.prepare_module(path, dataset=True)
    builder_cls = datasets.load.import_main_class(module_path[0], dataset=True)
    if "jigsaw_toxicity_pred" in path:
        data_dir = "/home/hf/dev/promptsource/data/jigsaw_toxic_comment"
    else:
        data_dir = None
    if conf:
        builder_instance = builder_cls(name=conf, cache_dir=None, hash=module_path[1], data_dir=data_dir)
    else:
        builder_instance = builder_cls(cache_dir=None, hash=module_path[1], data_dir=data_dir)
    return builder_instance


def get_dataset(path, conf=None):
    "Get a dataset from name and conf."
    builder_instance = get_dataset_builder(path, conf)
    fail = False
    if builder_instance.info.size_in_bytes is not None:
        builder_instance.download_and_prepare()
        dts = builder_instance.as_dataset()
        dataset = dts
    else:
        dataset = builder_instance
        fail = True
    return dataset, fail

```

cf #477