### PR TITLE
Add metrics to the ade-corpus-v2 dataset

### DIFF
--- a/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_classification/templates.yaml
+++ b/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_classification/templates.yaml
@@ -19,8 +19,8 @@ templates:
     answer_choices: No ||| Yes
     id: 78c4ce65-dd66-46ed-878d-11f4eca5e544
     jinja: "Read the below text and answer the question.\n\nText: {{text}} \n\nQuestion:\
-      \ Is the above text related to adverse drug effect (ADE)? Please answer it with\
-      \ either \"Yes\" or \"No\".\n\n|||\n{{answer_choices[label]}}"
+      \ Is the above text related to adverse drug effect (ADE)? Your answer should\
+      \ be either \"Yes\" or \"No\".\n\n|||\n{{answer_choices[label]}}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -31,9 +31,9 @@ templates:
   dabc0337-5bd3-4150-98b3-794a15ce1a3a: !Template
     answer_choices: null
     id: dabc0337-5bd3-4150-98b3-794a15ce1a3a
-    jinja: "{% if label==1 %}\nWrite a medical report that is related to adverse drug\
-      \ effect (ADE). \n{% else %}\nWrite a medical report that is not related to\
-      \ adverse drug effect (ADE). \n{% endif %}\n|||\n{{text}}"
+    jinja: "{% if label==1 %}\nPlease write a short medical report that is related\
+      \ to adverse drug effect (ADE). \n{% else %}\nWrite a medical report that is\
+      \ not related to adverse drug effect (ADE). \n{% endif %}\n|||\n{{text}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:

--- a/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_classification/templates.yaml
+++ b/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_classification/templates.yaml
@@ -2,9 +2,12 @@ dataset: ade_corpus_v2
 subset: Ade_corpus_v2_classification
 templates:
   56bd12a8-b8ee-464e-98cc-5f586ba9f74d: !Template
-    answer_choices: Not Related ||| Related
+    answer_choices: No ||| Yes
     id: 56bd12a8-b8ee-464e-98cc-5f586ba9f74d
-    jinja: Is "{{text}}" related to adverse drug effect (ADE)? ||| {{answer_choices[label]}}
+    jinja: 'Please answer the below Yes / No question.
+
+
+      Is "{{text}}" related to adverse drug effect (ADE)? ||| {{answer_choices[label]}}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -13,11 +16,11 @@ templates:
     name: binary-classification
     reference: ''
   78c4ce65-dd66-46ed-878d-11f4eca5e544: !Template
-    answer_choices: Yes ||| No
+    answer_choices: No ||| Yes
     id: 78c4ce65-dd66-46ed-878d-11f4eca5e544
     jinja: "Read the below text and answer the question.\n\nText: {{text}} \n\nQuestion:\
-      \ Is the above text related to adverse drug effect (ADE)?\n\nA. Yes.\n\nB. No.\n\
-      |||\n{{answer_choices[label]}}"
+      \ Is the above text related to adverse drug effect (ADE)? Please answer it with\
+      \ either \"Yes\" or \"No\".\n\n|||\n{{answer_choices[label]}}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:

--- a/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_classification/templates.yaml
+++ b/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_classification/templates.yaml
@@ -22,7 +22,7 @@ templates:
       choices_in_prompt: true
       metrics:
       - Accuracy
-      original_task: false
+      original_task: true
     name: verbose-binary-classification
     reference: ''
   dabc0337-5bd3-4150-98b3-794a15ce1a3a: !Template

--- a/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_classification/templates.yaml
+++ b/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_classification/templates.yaml
@@ -6,8 +6,11 @@ templates:
     id: 56bd12a8-b8ee-464e-98cc-5f586ba9f74d
     jinja: Is "{{text}}" related to adverse drug effect (ADE)? ||| {{answer_choices[label]}}
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      - BLEU
+      - ROUGE
       original_task: true
     name: baseline
     reference: ''
@@ -20,9 +23,10 @@ templates:
       \ to adverse drug effect.\n\nB. No, it is not related to adverse drug effect.\n\
       |||\n{{answer_choices[label]}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: false
     name: verbose
     reference: ''
   dabc0337-5bd3-4150-98b3-794a15ce1a3a: !Template
@@ -32,8 +36,10 @@ templates:
       \ effect (ADE). \n{% else %}\nWrite a medical report that is not related to\
       \ adverse drug effect (ADE). \n{% endif %}\n|||\n{{text}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
     name: label-to-text
     reference: ''

--- a/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_classification/templates.yaml
+++ b/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_classification/templates.yaml
@@ -2,32 +2,28 @@ dataset: ade_corpus_v2
 subset: Ade_corpus_v2_classification
 templates:
   56bd12a8-b8ee-464e-98cc-5f586ba9f74d: !Template
-    answer_choices: Not-Related ||| Related
+    answer_choices: Not Related ||| Related
     id: 56bd12a8-b8ee-464e-98cc-5f586ba9f74d
     jinja: Is "{{text}}" related to adverse drug effect (ADE)? ||| {{answer_choices[label]}}
     metadata: !TemplateMetadata
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
-      - BLEU
-      - ROUGE
       original_task: true
-    name: baseline
+    name: binary-classification
     reference: ''
   78c4ce65-dd66-46ed-878d-11f4eca5e544: !Template
-    answer_choices: Yes, it is related to adverse drug effect. ||| No, it is not related
-      to adverse drug effect.
+    answer_choices: Yes ||| No
     id: 78c4ce65-dd66-46ed-878d-11f4eca5e544
     jinja: "Read the below text and answer the question.\n\nText: {{text}} \n\nQuestion:\
-      \ Is the above text related to adverse drug effect (ADE)?\n\nA. Yes, it is related\
-      \ to adverse drug effect.\n\nB. No, it is not related to adverse drug effect.\n\
+      \ Is the above text related to adverse drug effect (ADE)?\n\nA. Yes.\n\nB. No.\n\
       |||\n{{answer_choices[label]}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: false
-    name: verbose
+    name: verbose-binary-classification
     reference: ''
   dabc0337-5bd3-4150-98b3-794a15ce1a3a: !Template
     answer_choices: null

--- a/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_ade_relation/templates.yaml
+++ b/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_ade_relation/templates.yaml
@@ -4,7 +4,13 @@ templates:
   0ec35408-652d-4ebc-9478-5a0d330c24c8: !Template
     answer_choices: null
     id: 0ec35408-652d-4ebc-9478-5a0d330c24c8
-    jinja: 'What drug has an effect of {{effect}}?
+    jinja: 'Read the below text and answer the question.
+
+
+      Text: {{text}}
+
+
+      Question: What drug has an effect of {{effect}}?
 
       |||
 
@@ -36,7 +42,13 @@ templates:
   61ba3622-72bc-4fd8-acfc-826bc2a93aa5: !Template
     answer_choices: null
     id: 61ba3622-72bc-4fd8-acfc-826bc2a93aa5
-    jinja: 'What effect does {{drug}} have?
+    jinja: 'Read the below text and answer the question.
+
+
+      Text: {{text}}
+
+
+      Question: What effect does {{drug}} have?
 
       |||
 
@@ -58,6 +70,10 @@ templates:
 
 
       Question: What are the drug and its effect of the above text?
+
+
+      You should answer in the "drug" and "effect" format (e.g., alcohol and high
+      blood pressure)
 
       |||
 
@@ -82,6 +98,10 @@ templates:
 
 
       Question 2: What is the effect of it?
+
+
+      You should answer in the "drug" and "effect" format (e.g., alcohol and high
+      blood pressure)
 
       |||
 

--- a/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_ade_relation/templates.yaml
+++ b/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_ade_relation/templates.yaml
@@ -20,13 +20,13 @@ templates:
       metrics:
       - Accuracy
       original_task: false
-    name: effect-to-drug
+    name: find-drug
     reference: ''
   2682a789-a435-4976-b34f-f376991c842a: !Template
     answer_choices: null
     id: 2682a789-a435-4976-b34f-f376991c842a
-    jinja: '{{drug}} has an effect of {{effect}}. Create a sentence using this drug
-      and its effect.
+    jinja: '{{drug}} has an effect of {{effect}}. Please write a short medical report
+      about this.
 
       |||
 
@@ -58,7 +58,7 @@ templates:
       metrics:
       - Accuracy
       original_task: false
-    name: drug-to-effect
+    name: find-effect
     reference: ''
   6acf3588-baa1-4ff6-87c4-4c2356855464: !Template
     answer_choices: null
@@ -83,7 +83,7 @@ templates:
       metrics:
       - Accuracy
       original_task: false
-    name: drug-and-effect
+    name: find-drug-and-effect
     reference: ''
   db68e609-ba92-40ae-b161-8b7710124142: !Template
     answer_choices: null
@@ -111,5 +111,5 @@ templates:
       metrics:
       - Accuracy
       original_task: false
-    name: drug-and-effect-two-questions
+    name: find-drug-and-effect-two-questions
     reference: ''

--- a/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_ade_relation/templates.yaml
+++ b/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_ade_relation/templates.yaml
@@ -19,7 +19,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - Accuracy
-      original_task: false
+      original_task: true
     name: find-drug
     reference: ''
   2682a789-a435-4976-b34f-f376991c842a: !Template
@@ -57,7 +57,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - Accuracy
-      original_task: false
+      original_task: true
     name: find-effect
     reference: ''
   6acf3588-baa1-4ff6-87c4-4c2356855464: !Template
@@ -82,7 +82,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - Accuracy
-      original_task: false
+      original_task: true
     name: find-drug-and-effect
     reference: ''
   db68e609-ba92-40ae-b161-8b7710124142: !Template
@@ -110,6 +110,6 @@ templates:
       choices_in_prompt: false
       metrics:
       - Accuracy
-      original_task: false
+      original_task: true
     name: find-drug-and-effect-two-questions
     reference: ''

--- a/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_ade_relation/templates.yaml
+++ b/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_ade_relation/templates.yaml
@@ -10,9 +10,10 @@ templates:
 
       {{drug}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: false
     name: effect2drug
     reference: ''
   2682a789-a435-4976-b34f-f376991c842a: !Template
@@ -25,9 +26,12 @@ templates:
 
       {{text}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      - Accuracy
+      original_task: false
     name: drug-and-effect-to-text
     reference: ''
   61ba3622-72bc-4fd8-acfc-826bc2a93aa5: !Template
@@ -39,9 +43,11 @@ templates:
 
       {{effect}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
     name: drug2effect
     reference: ''
   6acf3588-baa1-4ff6-87c4-4c2356855464: !Template
@@ -59,8 +65,11 @@ templates:
 
       {{drug}} and {{effect}}, respectively.'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      - BLEU
+      - ROUGE
       original_task: true
     name: baseline
     reference: ''
@@ -82,8 +91,11 @@ templates:
 
       The drug is {{drug}} and its effect is {{effect}}.'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      - BLEU
+      - ROUGE
+      original_task: false
     name: two-questions
     reference: ''

--- a/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_ade_relation/templates.yaml
+++ b/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_ade_relation/templates.yaml
@@ -14,7 +14,7 @@ templates:
       metrics:
       - Accuracy
       original_task: false
-    name: effect2drug
+    name: effect-to-drug
     reference: ''
   2682a789-a435-4976-b34f-f376991c842a: !Template
     answer_choices: null
@@ -28,9 +28,8 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
       - ROUGE
-      - Accuracy
+      - BLEU
       original_task: false
     name: drug-and-effect-to-text
     reference: ''
@@ -45,10 +44,9 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: false
-    name: drug2effect
+    name: drug-to-effect
     reference: ''
   6acf3588-baa1-4ff6-87c4-4c2356855464: !Template
     answer_choices: null
@@ -59,19 +57,17 @@ templates:
       Text: {{text}}
 
 
-      Question: What are the drug and its effect of the above text, respectively?
+      Question: What are the drug and its effect of the above text?
 
       |||
 
-      {{drug}} and {{effect}}, respectively.'
+      {{drug}} and {{effect}}.'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
       - Accuracy
-      - BLEU
-      - ROUGE
-      original_task: true
-    name: baseline
+      original_task: false
+    name: drug-and-effect
     reference: ''
   db68e609-ba92-40ae-b161-8b7710124142: !Template
     answer_choices: null
@@ -89,13 +85,11 @@ templates:
 
       |||
 
-      The drug is {{drug}} and its effect is {{effect}}.'
+      {{drug}} and {{effect}}.'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
       - Accuracy
-      - BLEU
-      - ROUGE
       original_task: false
-    name: two-questions
+    name: drug-and-effect-two-questions
     reference: ''

--- a/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_dosage_relation/templates.yaml
+++ b/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_dosage_relation/templates.yaml
@@ -20,13 +20,13 @@ templates:
       metrics:
       - Accuracy
       original_task: false
-    name: dosage-to-drug
+    name: find-drug
     reference: ''
   1e719388-59c9-4b0a-9ed9-dd02b6ddd0a6: !Template
     answer_choices: null
     id: 1e719388-59c9-4b0a-9ed9-dd02b6ddd0a6
-    jinja: '{{dosage}} of {{drug}} was given to a patient. What kind of symptom did
-      this patient have?
+    jinja: '{{dosage}} of {{drug}} was given to a patient. Please write a short medical
+      report about this.
 
       |||
 
@@ -65,7 +65,7 @@ templates:
       metrics:
       - Accuracy
       original_task: false
-    name: drug-and-dosage-two-questions
+    name: find-drug-and-dosage-two-questions
     reference: ''
   ca175bed-d046-40e7-9dbb-1e50fde7e603: !Template
     answer_choices: null
@@ -86,7 +86,7 @@ templates:
       metrics:
       - Accuracy
       original_task: false
-    name: drug-to-dosage
+    name: find-dosage
     reference: ''
   ce5208ac-6b4c-4a35-8738-e20232df1917: !Template
     answer_choices: null
@@ -100,5 +100,5 @@ templates:
       metrics:
       - Accuracy
       original_task: false
-    name: drug-and-dosage
+    name: find-drug-and-dosage
     reference: ''

--- a/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_dosage_relation/templates.yaml
+++ b/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_dosage_relation/templates.yaml
@@ -10,9 +10,10 @@ templates:
 
       {{drug}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: false
     name: dosage2drug
     reference: ''
   1e719388-59c9-4b0a-9ed9-dd02b6ddd0a6: !Template
@@ -25,9 +26,11 @@ templates:
 
       {{text}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
     name: drug-and-dosage-to-text
     reference: ''
   2bed0f04-8249-4248-86ea-e3a1971b2e1b: !Template
@@ -49,9 +52,12 @@ templates:
 
       The drug is {{drug}} and its dosage is {{dosage}}.'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      - BLEU
+      - ROUGE
+      original_task: false
     name: two-questions
     reference: ''
   ca175bed-d046-40e7-9dbb-1e50fde7e603: !Template
@@ -63,9 +69,10 @@ templates:
 
       {{dosage}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: false
     name: drug2dosage
     reference: ''
   ce5208ac-6b4c-4a35-8738-e20232df1917: !Template
@@ -75,8 +82,11 @@ templates:
       \ What are the drug and its dosage of the above text, respectively? \n|||\n\
       {{drug}} and {{dosage}}, respectively."
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      - BLEU
+      - ROUGE
       original_task: true
     name: baseline
     reference: ''

--- a/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_dosage_relation/templates.yaml
+++ b/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_dosage_relation/templates.yaml
@@ -14,7 +14,7 @@ templates:
       metrics:
       - Accuracy
       original_task: false
-    name: dosage2drug
+    name: dosage-to-drug
     reference: ''
   1e719388-59c9-4b0a-9ed9-dd02b6ddd0a6: !Template
     answer_choices: null
@@ -50,15 +50,13 @@ templates:
 
       |||
 
-      The drug is {{drug}} and its dosage is {{dosage}}.'
+      {{drug}} and {{dosage}}.'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
       - Accuracy
-      - BLEU
-      - ROUGE
       original_task: false
-    name: two-questions
+    name: drug-and-dosage-two-questions
     reference: ''
   ca175bed-d046-40e7-9dbb-1e50fde7e603: !Template
     answer_choices: null
@@ -73,20 +71,17 @@ templates:
       metrics:
       - Other
       original_task: false
-    name: drug2dosage
+    name: drug-to-dosage
     reference: ''
   ce5208ac-6b4c-4a35-8738-e20232df1917: !Template
     answer_choices: null
     id: ce5208ac-6b4c-4a35-8738-e20232df1917
     jinja: "Read the below text and answer the question.\n\nText: {{text}}\n\nQuestion:\
-      \ What are the drug and its dosage of the above text, respectively? \n|||\n\
-      {{drug}} and {{dosage}}, respectively."
+      \ What are the drug and its dosage of the above text? \n|||\n{{drug}} and {{dosage}}."
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
       - Accuracy
-      - BLEU
-      - ROUGE
-      original_task: true
-    name: baseline
+      original_task: false
+    name: drug-and-dosage
     reference: ''

--- a/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_dosage_relation/templates.yaml
+++ b/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_dosage_relation/templates.yaml
@@ -4,7 +4,13 @@ templates:
   1de6d411-ed0a-4d48-806e-cad009f07a65: !Template
     answer_choices: null
     id: 1de6d411-ed0a-4d48-806e-cad009f07a65
-    jinja: 'What drug has a dosage of {{dosage}}?
+    jinja: 'Read the below text and answer the question.
+
+
+      Text: {{text}}
+
+
+      Question: What drug has a dosage of {{dosage}}?
 
       |||
 
@@ -48,6 +54,9 @@ templates:
 
       Question 2: What is the dosage of it?
 
+
+      You should answer in the "drug" and "dosage" format (e.g., Aspirin and 500mg)
+
       |||
 
       {{drug}} and {{dosage}}.'
@@ -61,7 +70,13 @@ templates:
   ca175bed-d046-40e7-9dbb-1e50fde7e603: !Template
     answer_choices: null
     id: ca175bed-d046-40e7-9dbb-1e50fde7e603
-    jinja: 'What is a possible dosage of {{drug}}?
+    jinja: 'Read the below text and answer the question.
+
+
+      Text: {{text}}
+
+
+      Question: What is the dosage of {{drug}}?
 
       |||
 
@@ -69,7 +84,7 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - Other
+      - Accuracy
       original_task: false
     name: drug-to-dosage
     reference: ''
@@ -77,7 +92,9 @@ templates:
     answer_choices: null
     id: ce5208ac-6b4c-4a35-8738-e20232df1917
     jinja: "Read the below text and answer the question.\n\nText: {{text}}\n\nQuestion:\
-      \ What are the drug and its dosage of the above text? \n|||\n{{drug}} and {{dosage}}."
+      \ What are the drug and its dosage of the above text? \n\nYou should answer\
+      \ in the \"drug\" and \"dosage\" format (e.g., Aspirin and 500mg)\n|||\n{{drug}}\
+      \ and {{dosage}}."
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:

--- a/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_dosage_relation/templates.yaml
+++ b/promptsource/templates/ade_corpus_v2/Ade_corpus_v2_drug_dosage_relation/templates.yaml
@@ -19,7 +19,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - Accuracy
-      original_task: false
+      original_task: true
     name: find-drug
     reference: ''
   1e719388-59c9-4b0a-9ed9-dd02b6ddd0a6: !Template
@@ -64,7 +64,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - Accuracy
-      original_task: false
+      original_task: true
     name: find-drug-and-dosage-two-questions
     reference: ''
   ca175bed-d046-40e7-9dbb-1e50fde7e603: !Template
@@ -85,7 +85,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - Accuracy
-      original_task: false
+      original_task: true
     name: find-dosage
     reference: ''
   ce5208ac-6b4c-4a35-8738-e20232df1917: !Template
@@ -99,6 +99,6 @@ templates:
       choices_in_prompt: false
       metrics:
       - Accuracy
-      original_task: false
+      original_task: true
     name: find-drug-and-dosage
     reference: ''


### PR DESCRIPTION
I used the below three rules to add metrics:

1. If specific words have to be in the answer, the metric is accuracy.
2. If a text has to be generated in the answer, the metrics are BLEU and ROUGE.

~~3. If both 1 and 2 have to be satisfied, the metrics are accuracy, BLEU, and ROUGE.~~
