### PR TITLE
Add metrics to the tmu_gfm dataset

### DIFF
--- a/promptsource/templates/tmu_gfm_dataset/templates.yaml
+++ b/promptsource/templates/tmu_gfm_dataset/templates.yaml
@@ -19,7 +19,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - Other
-      original_task: false
+      original_task: true
     name: fluency
     reference: The metric is a regression task metric.
   2b712291-0629-4499-86cc-566ee7376271: !Template
@@ -41,7 +41,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - Other
-      original_task: false
+      original_task: true
     name: grammar
     reference: The metric is a regression task metric.
   30a17c4d-2bee-450c-b921-9b748ae87c93: !Template
@@ -83,7 +83,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - Other
-      original_task: false
+      original_task: true
     name: meaning
     reference: The metric is a regression task metric.
   c8347303-bfcd-4fe5-b085-dee46045850c: !Template
@@ -111,7 +111,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - Other
-      original_task: false
+      original_task: true
     name: grammar-fluency-meaning
     reference: The metric is a regression task metric.
   ebb2956b-25eb-4a66-ba23-569ccf9b8675: !Template

--- a/promptsource/templates/tmu_gfm_dataset/templates.yaml
+++ b/promptsource/templates/tmu_gfm_dataset/templates.yaml
@@ -21,7 +21,7 @@ templates:
       - Other
       original_task: false
     name: fluency
-    reference: ''
+    reference: The metric is a regression task metric.
   2b712291-0629-4499-86cc-566ee7376271: !Template
     answer_choices: null
     id: 2b712291-0629-4499-86cc-566ee7376271
@@ -43,7 +43,7 @@ templates:
       - Other
       original_task: false
     name: grammar
-    reference: ''
+    reference: The metric is a regression task metric.
   30a17c4d-2bee-450c-b921-9b748ae87c93: !Template
     answer_choices: null
     id: 30a17c4d-2bee-450c-b921-9b748ae87c93
@@ -85,7 +85,7 @@ templates:
       - Other
       original_task: false
     name: meaning
-    reference: ''
+    reference: The metric is a regression task metric.
   c8347303-bfcd-4fe5-b085-dee46045850c: !Template
     answer_choices: null
     id: c8347303-bfcd-4fe5-b085-dee46045850c
@@ -112,7 +112,7 @@ templates:
       - Other
       original_task: true
     name: grammar-fluency-meaning
-    reference: ''
+    reference: The metric is a regression task metric.
   ebb2956b-25eb-4a66-ba23-569ccf9b8675: !Template
     answer_choices: Sentence A ||| Sentence B
     id: ebb2956b-25eb-4a66-ba23-569ccf9b8675

--- a/promptsource/templates/tmu_gfm_dataset/templates.yaml
+++ b/promptsource/templates/tmu_gfm_dataset/templates.yaml
@@ -117,8 +117,8 @@ templates:
   ebb2956b-25eb-4a66-ba23-569ccf9b8675: !Template
     answer_choices: Sentence A ||| Sentence B
     id: ebb2956b-25eb-4a66-ba23-569ccf9b8675
-    jinja: 'Which one of the following two sentences is written better? Please answer
-      with either "Sentence A" or "Sentence B".
+    jinja: 'Which one of the following two sentences is written better? Your answer
+      should be either "Sentence A" or "Sentence B".
 
       {% if range(0,2) | choice %}
 

--- a/promptsource/templates/tmu_gfm_dataset/templates.yaml
+++ b/promptsource/templates/tmu_gfm_dataset/templates.yaml
@@ -110,7 +110,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - Other
-      original_task: true
+      original_task: false
     name: grammar-fluency-meaning
     reference: The metric is a regression task metric.
   ebb2956b-25eb-4a66-ba23-569ccf9b8675: !Template

--- a/promptsource/templates/tmu_gfm_dataset/templates.yaml
+++ b/promptsource/templates/tmu_gfm_dataset/templates.yaml
@@ -100,7 +100,8 @@ templates:
 
       Question: Sentence B is an improved version of Sentence A. How would you rate
       the improvement on a scale from 0 to 4, with respect to grammaticality,  fluency,
-      and meaning preservation, respectively?
+      and meaning preservation, respectively? Please give an answer with three numbers
+      separated by commas.
 
       |||
 
@@ -116,7 +117,8 @@ templates:
   ebb2956b-25eb-4a66-ba23-569ccf9b8675: !Template
     answer_choices: Sentence A ||| Sentence B
     id: ebb2956b-25eb-4a66-ba23-569ccf9b8675
-    jinja: 'Which one of the following two sentences is written better?
+    jinja: 'Which one of the following two sentences is written better? Please answer
+      with either "Sentence A" or "Sentence B".
 
       {% if range(0,2) | choice %}
 

--- a/promptsource/templates/tmu_gfm_dataset/templates.yaml
+++ b/promptsource/templates/tmu_gfm_dataset/templates.yaml
@@ -16,8 +16,9 @@ templates:
 
       {{ (((10*ave_f) | round )/10) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: false
     name: fluency
     reference: ''
@@ -37,8 +38,9 @@ templates:
 
       {{ (((10*ave_g) | round )/10) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: false
     name: grammar
     reference: ''
@@ -55,8 +57,10 @@ templates:
 
       {{output}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: false
     name: correct-sentence
     reference: ''
@@ -76,8 +80,9 @@ templates:
 
       {{ (((10*ave_m) | round )/10) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: false
     name: meaning
     reference: ''
@@ -102,13 +107,14 @@ templates:
       {{ (((10*ave_g) | round )/10) }}, {{ (((10*ave_f) | round )/10) }}, and {{ (((10*ave_m)
       | round )/10) }}.'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: true
     name: grammar-fluency-meaning
     reference: ''
   ebb2956b-25eb-4a66-ba23-569ccf9b8675: !Template
-    answer_choices: null
+    answer_choices: Sentence A ||| Sentence B
     id: ebb2956b-25eb-4a66-ba23-569ccf9b8675
     jinja: 'Which one of the following two sentences is written better?
 
@@ -136,8 +142,9 @@ templates:
 
       {% endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: false
     name: choose-better
     reference: ''


### PR DESCRIPTION
I used the below three rules to add metrics:

1. If specific words have to be in the answer, the metric is accuracy.

2. If a text has to be generated in the answer, the metrics are BLEU and ROUGE.
~~3. If both 1 and 2 have to be satisfied, the metrics are accuracy, BLEU, and ROUGE.~~

As for the regression tasks, since there isn't a metric for a regression task (e.g., MSE, MAE, etc.), I marked them as "Other".