### PR TITLE
clean google_wellformed_query templates

### DIFF
--- a/promptsource/templates/google_wellformed_query/templates.yaml
+++ b/promptsource/templates/google_wellformed_query/templates.yaml
@@ -1,5 +1,23 @@
 dataset: google_wellformed_query
 templates:
+  23336a6b-af7d-49ec-9d8b-364bc9e83dfe: !Template
+    answer_choices: yes ||| no
+    id: 23336a6b-af7d-49ec-9d8b-364bc9e83dfe
+    jinja: 'After you type "{{content}}" on Google Search, you can get the information
+      you want. Do you agree? Answer {{ answer_choices[0] }} or {{ answer_choices[1]
+      }}.
+
+      |||
+
+      {% if 0.5 < rating %}{{ answer_choices[0] }}{% else %}{{ answer_choices[1] }}{%
+      endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: is_wellformed_for_search_6
+    reference: ''
   7462caa6-9fb3-43ed-a883-85f8940ba23d: !Template
     answer_choices: null
     id: 7462caa6-9fb3-43ed-a883-85f8940ba23d
@@ -34,6 +52,49 @@ templates:
       original_task: true
     name: is_wellformed_2
     reference: ''
+  868d696c-428c-4915-b786-719361394143: !Template
+    answer_choices: yes ||| no
+    id: 868d696c-428c-4915-b786-719361394143
+    jinja: 'Is asking search engines "{{content}}" good for finding information?
+
+      |||
+
+      {% if 0.5 < rating %}{{ answer_choices[0] }}{% else %}{{ answer_choices[1] }}{%
+      endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: is_wellformed_for_search_5
+    reference: ''
+  964515de-c6d4-45a1-8f17-d3e17c0c1caf: !Template
+    answer_choices: yes ||| no
+    id: 964515de-c6d4-45a1-8f17-d3e17c0c1caf
+    jinja: "Answer {{ answer_choices[0] }} or {{ answer_choices[1] }} for the following\
+      \ question. \nIs \"{{content}}\" a good search query on Google?\n|||\n{% if\
+      \ 0.5 < rating %}{{ answer_choices[0] }}{% else %}{{ answer_choices[1] }}{%\
+      \ endif %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: is_wellformed_for_search_4
+    reference: ''
+  97eed413-3efd-45d2-9bb4-5774df4522a8: !Template
+    answer_choices: yes ||| no
+    id: 97eed413-3efd-45d2-9bb4-5774df4522a8
+    jinja: "It is Zoey's first time using a search engine. She wants to find information\
+      \ with the query \"{{content}}\". Is the query good? \n|||\n{% if 0.5 < rating\
+      \ %}{{ answer_choices[0] }}{% else %}{{ answer_choices[1] }}{% endif %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: is_wellformed_for_search_7
+    reference: ''
   9816d5bf-c4db-42ed-8ac8-2be45fa8a0bb: !Template
     answer_choices: yes ||| no
     id: 9816d5bf-c4db-42ed-8ac8-2be45fa8a0bb
@@ -66,6 +127,20 @@ templates:
       - Accuracy
       original_task: true
     name: is_wellformed_for_search_3
+    reference: ''
+  9ce08cae-8744-48bf-8896-f0c10a3efbd0: !Template
+    answer_choices: yes ||| no
+    id: 9ce08cae-8744-48bf-8896-f0c10a3efbd0
+    jinja: "Query: \"{{content}}\"\nQuestion: Is this a wellformed query for search\
+      \ engines like Google or Bing? \nSelect your answer from the following choices:\
+      \ {{ answer_choices[0] }}, {{ answer_choices[1] }}\n|||\n{% if 0.5 < rating\
+      \ %}{{ answer_choices[0] }}{% else %}{{ answer_choices[1] }}{% endif %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: is_wellformed_for_search_8
     reference: ''
   9f3cc358-3746-405e-b5e9-5fc0dedc0b5d: !Template
     answer_choices: yes ||| no

--- a/promptsource/templates/google_wellformed_query/templates.yaml
+++ b/promptsource/templates/google_wellformed_query/templates.yaml
@@ -1,23 +1,5 @@
 dataset: google_wellformed_query
 templates:
-  23336a6b-af7d-49ec-9d8b-364bc9e83dfe: !Template
-    answer_choices: yes ||| no
-    id: 23336a6b-af7d-49ec-9d8b-364bc9e83dfe
-    jinja: 'After you type "{{content}}" on Google Search, you can get the information
-      you want. Do you agree? Answer {{ answer_choices[0] }} or {{ answer_choices[1]
-      }}.
-
-      |||
-
-      {% if 0.5 < rating %}{{ answer_choices[0] }}{% else %}{{ answer_choices[1] }}{%
-      endif %}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: true
-      metrics:
-      - Accuracy
-      original_task: true
-    name: is_wellformed_for_search_6
-    reference: ''
   7462caa6-9fb3-43ed-a883-85f8940ba23d: !Template
     answer_choices: null
     id: 7462caa6-9fb3-43ed-a883-85f8940ba23d
@@ -26,7 +8,7 @@ templates:
 
       |||
 
-      {{ rating }}'
+      {{ rating  | round(0) }}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -37,9 +19,9 @@ templates:
   80e4797c-2454-4f27-8032-a8191cd3602d: !Template
     answer_choices: yes ||| no
     id: 80e4797c-2454-4f27-8032-a8191cd3602d
-    jinja: 'John believes that the query "{{content}}" resembles a well-formed natural
-      language question. Answer {{ answer_choices[0] }} if you agree with John and
-      {{ answer_choices[1] }} if you disagree.
+    jinja: 'John believes that the query "{{content}}" resembles a natural language
+      question. Answer {{ answer_choices[0] }} if you agree with John and {{ answer_choices[1]
+      }} if you disagree.
 
       |||
 
@@ -50,7 +32,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: is_wellformed_2
+    name: is_wellformed_affirmative
     reference: ''
   868d696c-428c-4915-b786-719361394143: !Template
     answer_choices: yes ||| no
@@ -66,39 +48,12 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: is_wellformed_for_search_5
-    reference: ''
-  964515de-c6d4-45a1-8f17-d3e17c0c1caf: !Template
-    answer_choices: yes ||| no
-    id: 964515de-c6d4-45a1-8f17-d3e17c0c1caf
-    jinja: "Answer {{ answer_choices[0] }} or {{ answer_choices[1] }} for the following\
-      \ question. \nIs \"{{content}}\" a good search query on Google?\n|||\n{% if\
-      \ 0.5 < rating %}{{ answer_choices[0] }}{% else %}{{ answer_choices[1] }}{%\
-      \ endif %}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: true
-      metrics:
-      - Accuracy
-      original_task: true
-    name: is_wellformed_for_search_4
-    reference: ''
-  97eed413-3efd-45d2-9bb4-5774df4522a8: !Template
-    answer_choices: yes ||| no
-    id: 97eed413-3efd-45d2-9bb4-5774df4522a8
-    jinja: "It is Zoey's first time using a search engine. She wants to find information\
-      \ with the query \"{{content}}\". Is the query good? \n|||\n{% if 0.5 < rating\
-      \ %}{{ answer_choices[0] }}{% else %}{{ answer_choices[1] }}{% endif %}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Accuracy
-      original_task: true
-    name: is_wellformed_for_search_7
+    name: is_wellformed_finding_for_search
     reference: ''
   9816d5bf-c4db-42ed-8ac8-2be45fa8a0bb: !Template
     answer_choices: yes ||| no
     id: 9816d5bf-c4db-42ed-8ac8-2be45fa8a0bb
-    jinja: 'Would "{{content}}" be a good query for a search engine?
+    jinja: 'Would "{{content}}" be a useful query to type in a search engine?
 
       |||
 
@@ -109,38 +64,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: is_wellformed_for_search
-    reference: ''
-  9b138603-611a-432d-aa6e-f51a473cf85d: !Template
-    answer_choices: yes ||| no
-    id: 9b138603-611a-432d-aa6e-f51a473cf85d
-    jinja: 'Do you think a search engine would return valid results for this query:
-      "{{content}}"?
-
-      |||
-
-      {% if 0.5 < rating %}{{ answer_choices[0] }}{% else %}{{ answer_choices[1] }}{%
-      endif %}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Accuracy
-      original_task: true
-    name: is_wellformed_for_search_3
-    reference: ''
-  9ce08cae-8744-48bf-8896-f0c10a3efbd0: !Template
-    answer_choices: yes ||| no
-    id: 9ce08cae-8744-48bf-8896-f0c10a3efbd0
-    jinja: "Query: \"{{content}}\"\nQuestion: Is this a wellformed query for search\
-      \ engines like Google or Bing? \nSelect your answer from the following choices:\
-      \ {{ answer_choices[0] }}, {{ answer_choices[1] }}\n|||\n{% if 0.5 < rating\
-      \ %}{{ answer_choices[0] }}{% else %}{{ answer_choices[1] }}{% endif %}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: true
-      metrics:
-      - Accuracy
-      original_task: true
-    name: is_wellformed_for_search_8
+    name: is_wellformed_type_for_search
     reference: ''
   9f3cc358-3746-405e-b5e9-5fc0dedc0b5d: !Template
     answer_choices: yes ||| no
@@ -157,12 +81,12 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: is_wellformed_for_search_2
+    name: is_wellformed_know_for_search
     reference: ''
   e1c64d17-c623-4a30-b899-5c6a4e44e3d7: !Template
     answer_choices: yes ||| no
     id: e1c64d17-c623-4a30-b899-5c6a4e44e3d7
-    jinja: '"{{content}}" is a well formed query, {{answer_choices[0]}} or {{answer_choices[1]}}?
+    jinja: '"{{content}}" is an informative query, {{answer_choices[0]}} or {{answer_choices[1]}}?
 
       |||
 
@@ -173,5 +97,5 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: is_wellformed
+    name: is_wellformed_interrogative
     reference: Well-formed query

--- a/promptsource/templates/google_wellformed_query/templates.yaml
+++ b/promptsource/templates/google_wellformed_query/templates.yaml
@@ -3,67 +3,100 @@ templates:
   7462caa6-9fb3-43ed-a883-85f8940ba23d: !Template
     answer_choices: null
     id: 7462caa6-9fb3-43ed-a883-85f8940ba23d
-    jinja: When I submitted "{{content}}" to a search engine, I obtained really bad
-      results, is that a surprise?|||{% if 0.5 < rating %}yes{% else %}no{% endif
-      %}
+    jinja: 'How would you rate how well-formed is the query "{{content}}"? Give a
+      value between 0 and 1.
+
+      |||
+
+      {{ rating }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: wellformed_5
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: false
+    name: wellformed_rating
     reference: ''
   80e4797c-2454-4f27-8032-a8191cd3602d: !Template
-    answer_choices: null
+    answer_choices: yes ||| no
     id: 80e4797c-2454-4f27-8032-a8191cd3602d
-    jinja: '"{{content}}" would work well as a search query, right?|||{% if 0.5 <
-      rating %}yes{% else %}no{% endif %}'
+    jinja: 'John believes that the query "{{content}}" resembles a well-formed natural
+      language question. Answer {{ answer_choices[0] }} if you agree with John and
+      {{ answer_choices[1] }} if you disagree.
+
+      |||
+
+      {% if 0.5 < rating %}{{ answer_choices[0] }}{% else %}{{ answer_choices[1] }}{%
+      endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: wellformed_4
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: is_wellformed_2
     reference: ''
   9816d5bf-c4db-42ed-8ac8-2be45fa8a0bb: !Template
-    answer_choices: null
+    answer_choices: yes ||| no
     id: 9816d5bf-c4db-42ed-8ac8-2be45fa8a0bb
-    jinja: Would "{{content}}" be a good query for a search engine?|||{% if 0.5 <
-      rating %}yes{% else %}no{% endif %}
+    jinja: 'Would "{{content}}" be a good query for a search engine?
+
+      |||
+
+      {% if 0.5 < rating %}{{ answer_choices[0] }}{% else %}{{ answer_choices[1] }}{%
+      endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: wellformed_1
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: is_wellformed_for_search
     reference: ''
   9b138603-611a-432d-aa6e-f51a473cf85d: !Template
-    answer_choices: null
+    answer_choices: yes ||| no
     id: 9b138603-611a-432d-aa6e-f51a473cf85d
     jinja: 'Do you think a search engine would return valid results for this query:
-      "{{content}}"?|||{% if 0.5 < rating %}yes{% else %}no{% endif %}'
+      "{{content}}"?
+
+      |||
+
+      {% if 0.5 < rating %}{{ answer_choices[0] }}{% else %}{{ answer_choices[1] }}{%
+      endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: wellformed_3
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: is_wellformed_for_search_3
     reference: ''
   9f3cc358-3746-405e-b5e9-5fc0dedc0b5d: !Template
-    answer_choices: null
+    answer_choices: yes ||| no
     id: 9f3cc358-3746-405e-b5e9-5fc0dedc0b5d
-    jinja: Given this query "{{content}}", would a search engine know what to look
-      for?|||{% if 0.5 < rating %}yes{% else %}no{% endif %}
+    jinja: 'Given this query "{{content}}", would a search engine know what to look
+      for? {{answer_choices[0]}} or {{answer_choices[1]}}?
+
+      |||
+
+      {% if 0.5 < rating %}{{ answer_choices[0] }}{% else %}{{ answer_choices[1] }}{%
+      endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: wellformed_2
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: is_wellformed_for_search_2
     reference: ''
   e1c64d17-c623-4a30-b899-5c6a4e44e3d7: !Template
-    answer_choices: null
+    answer_choices: yes ||| no
     id: e1c64d17-c623-4a30-b899-5c6a4e44e3d7
-    jinja: '"{{content}}" is a well formed query, yes or no?|||{% if 0.5 < rating
-      %}yes{% else %}no{% endif %}'
+    jinja: '"{{content}}" is a well formed query, {{answer_choices[0]}} or {{answer_choices[1]}}?
+
+      |||
+
+      {% if 0.5 < rating %}{{answer_choices[0]}}{% else %}{{answer_choices[1]}}{%
+      endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: wellformed_0
-    reference: ''
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: is_wellformed
+    reference: Well-formed query

--- a/promptsource/templates/google_wellformed_query/templates.yaml
+++ b/promptsource/templates/google_wellformed_query/templates.yaml
@@ -3,8 +3,9 @@ templates:
   7462caa6-9fb3-43ed-a883-85f8940ba23d: !Template
     answer_choices: null
     id: 7462caa6-9fb3-43ed-a883-85f8940ba23d
-    jinja: 'How would you rate how well-formed is the query "{{content}}"? Give a
-      value between 0 and 1.
+    jinja: 'How would you rate how well-formed is the query "{{content}}"? "Well-formed"
+      means that a natural language system would be able to perform an accurate interpretation.
+      Give a value between 0 and 1.
 
       |||
 


### PR DESCRIPTION
Fixed the following issues:
- [X] indicate original tasks (and ensure ≥ 10 original tasks)
- [X] rename templates with more meaningful titles
- [X] indicate answer choices in prompt
- [X] remove one borderline negation template
- [X] add one template that asks for rating (regression task) instead of yes / no (classification task)
- [X] add metrics
- [X] add answer choices