### PR TITLE
Clean Hlgd Templates

### DIFF
--- a/promptsource/templates/hlgd/templates.yaml
+++ b/promptsource/templates/hlgd/templates.yaml
@@ -3,7 +3,7 @@ templates:
   06c785aa-2c21-4842-a27c-64c86c98c052: !Template
     answer_choices: yes ||| no
     id: 06c785aa-2c21-4842-a27c-64c86c98c052
-    jinja: "On {{date_a}} , the article \"{{headline_a}}\" is published.\nOn {{date_b}},\
+    jinja: "On {{date_a}}, the article \"{{headline_a}}\" is published.\nOn {{date_b}},\
       \ the article \"{{headline_b}}\" is published. \nAre they related to the same\
       \ event? Answer {{ answer_choices[0] }} or {{ answer_choices[1] }}.\n|||\n{%\
       \ if label %}\n{{ answer_choices[0] }}\n{% else %}\n{{ answer_choices[1] }}\n\
@@ -13,7 +13,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: is_same_event_with_time_2
+    name: is_same_event_with_time_interrogative_related
     reference: ''
   147ad380-5ce4-4900-b5ec-f01a63bb3653: !Template
     answer_choices: yes ||| no
@@ -26,7 +26,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: is_same_event
+    name: is_same_event_interrogative_talk
     reference: ''
   2a2a9754-b6cd-40a7-a920-b75d9116d431: !Template
     answer_choices: yes ||| no
@@ -51,17 +51,18 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: is_same_event_6
+    name: is_same_event_read
     reference: ''
   36154717-e2bc-4414-bfe6-8ed70ebf292d: !Template
     answer_choices: null
     id: 36154717-e2bc-4414-bfe6-8ed70ebf292d
-    jinja: "{% if label %}\nGiven the headline: \"{{headline_a}}\", what would be\
-      \ another headline for the same event? \n|||\n{{headline_b}}\n{% endif %}"
+    jinja: "Given the headline: \"{{headline_a}}\", what would be another headline\
+      \ for the same event? \n|||\n{% if label %}\n{{headline_b}}\n{% endif %}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
       - BLEU
+      - ROUGE
       original_task: false
     name: generate_another_headline
     reference: ''
@@ -78,7 +79,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: is_same_event_4
+    name: is_same_event_describe_rel
     reference: ''
   4d97b99c-e438-403e-a864-ffbbc193bf63: !Template
     answer_choices: yes ||| no
@@ -91,7 +92,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: is_same_event_3
+    name: is_same_event_refer
     reference: ''
   7588a4a1-bff3-4543-aaa3-e3b679b6b97b: !Template
     answer_choices: agree ||| disagree
@@ -115,7 +116,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: is_same_event_2
+    name: is_same_event_discuss
     reference: ''
   811556ef-26cb-4aae-b59d-8b06fdc546a5: !Template
     answer_choices: yes ||| no
@@ -139,7 +140,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: is_same_event_7
+    name: is_same_event_replace
     reference: ''
   f680d28f-ba41-4a30-a099-88be61751e7f: !Template
     answer_choices: yes ||| no
@@ -165,12 +166,12 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: is_same_event_5
+    name: is_same_event_editor_asks
     reference: ''
   feccc382-21c7-464f-b322-b03dde3adfd2: !Template
     answer_choices: yes ||| no
     id: feccc382-21c7-464f-b322-b03dde3adfd2
-    jinja: "On {{date_a}} , the article \"{{headline_a}}\" is published.\nOn {{date_b}},\
+    jinja: "On {{date_a}}, the article \"{{headline_a}}\" is published.\nOn {{date_b}},\
       \ the article \"{{headline_b}}\" is published. \nAnswer {{ answer_choices[0]\
       \ }} if the second article's headline is a paraphrase of the first; otherwise,\
       \ answer {{ answer_choices[1] }}.\n|||\n{% if label %}\n{{ answer_choices[0]\
@@ -180,7 +181,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: is_same_event_with_time_3
+    name: is_same_event_with_time_affirmative
     reference: ''
   ff3d165e-3c52-42f4-96e0-df125605a379: !Template
     answer_choices: yes ||| no
@@ -205,5 +206,5 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: is_same_event_with_time
+    name: is_same_event_with_time_interrogative_talk
     reference: ''


### PR DESCRIPTION
Fixed the following issues:

- [X] indicate original tasks (and ensure ≥ 10 original tasks)
- [X] rename templates with more meaningful titles
- [X] indicate answer choices in prompt if exists
- [X] add metrics
- [X] add answer choices

Discussion:
I remove one prompt template that takes news headline as input and returns the time when it's published as output. This prompt seems to investigate the model's memorization ability (association of a piece of news with timeline) instead of NLU ability.