### PR TITLE
Clean guardian_authorship

### DIFF
--- a/promptsource/templates/guardian_authorship/cross_genre_1/templates.yaml
+++ b/promptsource/templates/guardian_authorship/cross_genre_1/templates.yaml
@@ -2,17 +2,21 @@ dataset: guardian_authorship
 subset: cross_genre_1
 templates:
   026e1ef2-c765-4262-b7b3-a087f38907db: !Template
-    answer_choices: null
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: 026e1ef2-c765-4262-b7b3-a087f38907db
-    jinja: "Who could have authored this article based on the writing style?\n\n{{article}}\
-      \ |||\n{{\n[\n  \"catherinebennett\",\n  \"georgemonbiot\",\n  \"hugoyoung\"\
-      ,\n  \"jonathanfreedland\",\n  \"martinkettle\",\n  \"maryriddell\",\n  \"nickcohen\"\
-      ,\n  \"peterpreston\",\n  \"pollytoynbee\",\n  \"royhattersley\",\n  \"simonhoggart\"\
-      ,\n  \"willhutton\",\n  \"zoewilliams\"\n][author]\n}}"
+    jinja: 'Who could have authored this article based on the writing style?
+
+
+      {{article}} |||
+
+      {{ answer_choices[author].capitalize() }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
     name: writing_style
     reference: ''
   12982397-c0c3-49a9-b3ac-38735908428b: !Template
@@ -22,12 +26,13 @@ templates:
       ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
       ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
       ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author]\n}}  on the topic of {{\n[\n  \"Politics\",\n  \"Society\",\n \
-      \ \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}} |||\n{{article}}"
+      \n] [author].capitalize()\n}}  on the topic of {{\n[\n  \"Politics\",\n  \"\
+      Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}} |||\n{{article}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      original_task: false
     name: article_from_author_topic
     reference: ''
   1b9fb5f9-6d2a-45ad-8ad4-dc199ee181b6: !Template
@@ -36,21 +41,81 @@ templates:
     jinja: "Generate an article on the topic of {{[\n  \"Politics\",\n  \"Society\"\
       ,\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic] }} |||\n{{article}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      original_task: false
     name: article_from_topic
     reference: ''
-  68bfa6a4-a89c-4be2-aa0b-cce1103e3ecf: !Template
-    answer_choices: null
-    id: 68bfa6a4-a89c-4be2-aa0b-cce1103e3ecf
-    jinja: "What is the topic of this article?\n\n{{article}} |||\n{{\n[\n  \"Politics\"\
-      ,\n  \"Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic]\n}}"
+  45e1aa31-6e76-4072-a6ee-ba99785999fc: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: 45e1aa31-6e76-4072-a6ee-ba99785999fc
+    jinja: 'Who is the author of the passage, which is related to {{ ["Politics",
+      "Society", "UK", "World", "Books"][topic] }}, below?
+
+
+      {{article}}
+
+      |||
+
+      {{ answer_choices[author].capitalize() }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article_with_topic_2
+    reference: ''
+  68bfa6a4-a89c-4be2-aa0b-cce1103e3ecf: !Template
+    answer_choices: Politics ||| Society ||| UK ||| World ||| Books
+    id: 68bfa6a4-a89c-4be2-aa0b-cce1103e3ecf
+    jinja: "What is the topic of this article?\n\n{{article}} \n|||\n{{answer_choices[topic]}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
       metrics: []
-      original_task: null
+      original_task: false
     name: topic
+    reference: ''
+  8d8e432e-8594-4e89-8b03-e11f0cebcf7b: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: 8d8e432e-8594-4e89-8b03-e11f0cebcf7b
+    jinja: 'Identify the author of the passage below. The answer options are {% for
+      author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.
+
+
+      {{article}}
+
+      |||
+
+      {{ answer_choices[author].capitalize() }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article_2
+    reference: ''
+  8e852323-3aba-4c57-a428-004bbef4185e: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: 8e852323-3aba-4c57-a428-004bbef4185e
+    jinja: "You are in an examination, which requires you to associate the passage\
+      \ below to the author. The topic is about {{ [\"Politics\", \"Society\", \"\
+      UK\", \"World\", \"Books\"][topic] }}, and the possible authors are one of the\
+      \ following: {% for author in answer_choices[:-1] %} {{author.capitalize()}},\
+      \ {% endfor %} {{answer_choices[-1].capitalize()}}. What is the answer?\n\n\
+      Passage: {{ article }} \n|||\n{{ answer_choices[author].capitalize() }}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article_with_topic_3
     reference: ''
   dc46136b-69d1-484e-9b5f-accfb4ba22df: !Template
     answer_choices: null
@@ -59,26 +124,48 @@ templates:
       ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
       ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
       ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author]\n}} |||\n{{article}}"
+      \n] [author].capitalize()\n}} \n|||\n{{article}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      original_task: false
     name: article_from_author
     reference: ''
   e885498a-04f9-4db9-bc01-d1324803315a: !Template
-    answer_choices: null
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: e885498a-04f9-4db9-bc01-d1324803315a
-    jinja: "Who wrote this article and what is the article's topic?\n\n{{article}}\
-      \ |||\n{{[\n  \"catherinebennett\",\n  \"georgemonbiot\",\n  \"hugoyoung\",\n\
-      \  \"jonathanfreedland\",\n  \"martinkettle\",\n  \"maryriddell\",\n  \"nickcohen\"\
-      ,\n  \"peterpreston\",\n  \"pollytoynbee\",\n  \"royhattersley\",\n  \"simonhoggart\"\
-      ,\n  \"willhutton\",\n  \"zoewilliams\"\n][author]}} wrote this article on the\
-      \ topic of {{[\n  \"Politics\",\n  \"Society\",\n  \"UK\",\n  \"World\",\n \
-      \ \"Books\"\n][topic]}}"
+    jinja: "Who wrote this article?\n\n{{article}} \n\n|||\n\n{{ answer_choices[author].capitalize()\
+      \ }}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: who_what_article
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article
+    reference: ''
+  f6ff1e76-4148-450c-ba0c-157a5b4c2383: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: f6ff1e76-4148-450c-ba0c-157a5b4c2383
+    jinja: 'Who is the author of the passage below? Choose from the following list:
+      {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor %}
+      {{answer_choices[-1].capitalize()}}. Hint: The topic is related to {{ ["Politics",
+      "Society", "UK", "World", "Books"][topic] }}.
+
+
+      {{article}}
+
+      |||
+
+      {{ answer_choices[author].capitalize() }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article_with_topic
     reference: ''

--- a/promptsource/templates/guardian_authorship/cross_genre_1/templates.yaml
+++ b/promptsource/templates/guardian_authorship/cross_genre_1/templates.yaml
@@ -6,7 +6,9 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: 026e1ef2-c765-4262-b7b3-a087f38907db
-    jinja: 'Who could have authored this article based on the writing style?
+    jinja: 'Who could have authored this article based on the writing style? The answer
+      options are {% for author in answer_choices[:-1] %} {{author.capitalize()}},
+      {% endfor %} {{answer_choices[-1].capitalize()}}.
 
 
       {{article}} |||
@@ -27,7 +29,7 @@ templates:
       ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
       ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
       \n] [author].capitalize()\n}}  on the topic of {{\n[\n  \"Politics\",\n  \"\
-      Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}} |||\n{{article}}"
+      Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}}. |||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -52,8 +54,10 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: 45e1aa31-6e76-4072-a6ee-ba99785999fc
-    jinja: 'Who is the author of the passage, which is related to {{ ["Politics",
-      "Society", "UK", "World", "Books"][topic] }}, below?
+    jinja: 'Given the answer options of {% for author in answer_choices[:-1] %} {{author.capitalize()}},
+      {% endfor %} and {{answer_choices[-1].capitalize()}}, identify the author of
+      the passage, which is related to {{ ["Politics", "Society", "UK", "World", "Books"][topic]
+      }}, below.
 
 
       {{article}}
@@ -71,7 +75,9 @@ templates:
   68bfa6a4-a89c-4be2-aa0b-cce1103e3ecf: !Template
     answer_choices: Politics ||| Society ||| UK ||| World ||| Books
     id: 68bfa6a4-a89c-4be2-aa0b-cce1103e3ecf
-    jinja: "What is the topic of this article?\n\n{{article}} \n|||\n{{answer_choices[topic]}}"
+    jinja: "What is the topic of this article? The answer options are {% for topic\
+      \ in answer_choices[:-1] %} {{topic.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.\n\
+      \n{{article}} \n|||\n{{answer_choices[topic]}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics: []
@@ -83,8 +89,9 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: 8d8e432e-8594-4e89-8b03-e11f0cebcf7b
-    jinja: 'Identify the author of the passage below. The answer options are {% for
-      author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.
+    jinja: 'Identify the author of the passage below by choosing from the author list
+      of {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor
+      %} {{answer_choices[-1].capitalize()}}.
 
 
       {{article}}
@@ -124,7 +131,7 @@ templates:
       ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
       ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
       ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author].capitalize()\n}} \n|||\n{{article}}"
+      \n] [author].capitalize()\n}} .\n|||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -137,8 +144,9 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: e885498a-04f9-4db9-bc01-d1324803315a
-    jinja: "Who wrote this article?\n\n{{article}} \n\n|||\n\n{{ answer_choices[author].capitalize()\
-      \ }}"
+    jinja: "Who wrote this article? The answer options are {% for author in answer_choices[:-1]\
+      \ %} {{author.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.\n\
+      \n{{article}} \n\n|||\n\n{{ answer_choices[author].capitalize() }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -151,17 +159,11 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: f6ff1e76-4148-450c-ba0c-157a5b4c2383
-    jinja: 'Who is the author of the passage below? Choose from the following list:
-      {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor %}
-      {{answer_choices[-1].capitalize()}}. Hint: The topic is related to {{ ["Politics",
-      "Society", "UK", "World", "Books"][topic] }}.
-
-
-      {{article}}
-
-      |||
-
-      {{ answer_choices[author].capitalize() }}'
+    jinja: "Who is the author of the passage below? Choose from the following list:\
+      \ {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor\
+      \ %} {{answer_choices[-1].capitalize()}}. \n\nHint: The topic is related to\
+      \ {{ [\"Politics\", \"Society\", \"UK\", \"World\", \"Books\"][topic] }}.\n\n\
+      {{article}}\n|||\n{{ answer_choices[author].capitalize() }}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:

--- a/promptsource/templates/guardian_authorship/cross_genre_1/templates.yaml
+++ b/promptsource/templates/guardian_authorship/cross_genre_1/templates.yaml
@@ -2,20 +2,20 @@ dataset: guardian_authorship
 subset: cross_genre_1
 templates:
   026e1ef2-c765-4262-b7b3-a087f38907db: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: 026e1ef2-c765-4262-b7b3-a087f38907db
     jinja: 'Who could have authored this article based on the writing style? The answer
-      options are {% for author in answer_choices[:-1] %} {{author.capitalize()}},
-      {% endfor %} {{answer_choices[-1].capitalize()}}.
+      options are {{ answer_choices | join(", ") }}.
 
 
       {{article}} |||
 
-      {{ answer_choices[author].capitalize() }}'
+      {{ answer_choices[author] }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: true
@@ -24,12 +24,13 @@ templates:
   12982397-c0c3-49a9-b3ac-38735908428b: !Template
     answer_choices: null
     id: 12982397-c0c3-49a9-b3ac-38735908428b
-    jinja: "Generate an article based on the writing style of  {{\n[\n  \"catherinebennett\"\
-      ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
-      ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
-      ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author].capitalize()\n}}  on the topic of {{\n[\n  \"Politics\",\n  \"\
-      Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}}. |||\n{{article}}"
+    jinja: "Generate an article based on the writing style of {{\n[\n  \"Catherine\
+      \ Bennett\",\n  \"George Monbiot\",\n  \"Hugo Young\",\n  \"Jonathan Freedland\"\
+      ,\n  \"Martin Kettle\",\n  \"Mary Riddell\",\n  \"Nick Cohen\",\n  \"Peter Preston\"\
+      ,\n  \"Polly Toynbee\",\n  \"Roy Hattersley\",\n  \"Simon Hoggart\",\n  \"Will\
+      \ Hutton\",\n  \"Zoe Williams\"\n] [author]\n}} on the topic of {{\n[\n  \"\
+      Politics\",\n  \"Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n\
+      }}. |||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -42,7 +43,7 @@ templates:
     answer_choices: null
     id: 1b9fb5f9-6d2a-45ad-8ad4-dc199ee181b6
     jinja: "Generate an article on the topic of {{[\n  \"Politics\",\n  \"Society\"\
-      ,\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic] }} |||\n{{article}}"
+      ,\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic] }}. |||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -52,23 +53,23 @@ templates:
     name: article_from_topic
     reference: ''
   45e1aa31-6e76-4072-a6ee-ba99785999fc: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: 45e1aa31-6e76-4072-a6ee-ba99785999fc
-    jinja: 'Given the answer options of {% for author in answer_choices[:-1] %} {{author.capitalize()}},
-      {% endfor %} and {{answer_choices[-1].capitalize()}}, identify the author of
-      the passage, which is related to {{ ["Politics", "Society", "UK", "World", "Books"][topic]
-      }}, below.
+    jinja: 'Given the answer options of {{answer_choices[:-1] | join(", ")}} and {{answer_choices[-1]}},
+      identify the author of the passage, which is related to {{ ["Politics", "Society",
+      "UK", "World", "Books"][topic] }}, below.
 
 
       {{article}}
 
       |||
 
-      {{ answer_choices[author].capitalize() }}'
+      {{ answer_choices[author] }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: true
@@ -77,30 +78,30 @@ templates:
   68bfa6a4-a89c-4be2-aa0b-cce1103e3ecf: !Template
     answer_choices: Politics ||| Society ||| UK ||| World ||| Books
     id: 68bfa6a4-a89c-4be2-aa0b-cce1103e3ecf
-    jinja: "What is the topic of this article? The answer options are {% for topic\
-      \ in answer_choices[:-1] %} {{topic.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.\n\
-      \n{{article}} \n|||\n{{answer_choices[topic]}}"
+    jinja: "What is the topic of this article? The answer options are {{answer_choices|join(\"\
+      , \")}}.\n\n{{article}} \n|||\n{{answer_choices[topic]}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: false
     name: topic
     reference: ''
   8d8e432e-8594-4e89-8b03-e11f0cebcf7b: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: 8d8e432e-8594-4e89-8b03-e11f0cebcf7b
     jinja: 'Identify the author of the passage below by choosing from the author list
-      of {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor
-      %} {{answer_choices[-1].capitalize()}}.
+      of {{answer_choices|join(", ")}}.
 
 
       {{article}}
 
       |||
 
-      {{ answer_choices[author].capitalize() }}'
+      {{ answer_choices[author] }}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -109,16 +110,16 @@ templates:
     name: who_wrote_article_affirmative
     reference: ''
   8e852323-3aba-4c57-a428-004bbef4185e: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: 8e852323-3aba-4c57-a428-004bbef4185e
     jinja: "You are in an examination, which requires you to associate the passage\
       \ below to the author. The topic is about {{ [\"Politics\", \"Society\", \"\
       UK\", \"World\", \"Books\"][topic] }}, and the possible authors are one of the\
-      \ following: {% for author in answer_choices[:-1] %} {{author.capitalize()}},\
-      \ {% endfor %} {{answer_choices[-1].capitalize()}}. What is the answer?\n\n\
-      Passage: {{ article }} \n|||\n{{ answer_choices[author].capitalize() }}"
+      \ following: {{answer_choices | join(\", \")}}. What is the answer?\n\nPassage:\
+      \ {{ article }} \n|||\n{{ answer_choices[author] }}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -129,11 +130,11 @@ templates:
   dc46136b-69d1-484e-9b5f-accfb4ba22df: !Template
     answer_choices: null
     id: dc46136b-69d1-484e-9b5f-accfb4ba22df
-    jinja: "Generate an article based on the writing style of {{\n[\n  \"catherinebennett\"\
-      ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
-      ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
-      ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author].capitalize()\n}} .\n|||\n{{article}}"
+    jinja: "Generate an article based on the writing style of {{\n[\n  \"Catherine\
+      \ Bennett\",\n  \"George Monbiot\",\n  \"Hugo Young\",\n  \"Jonathan Freedland\"\
+      ,\n  \"Martin Kettle\",\n  \"Mary Riddell\",\n  \"Nick Cohen\",\n  \"Peter Preston\"\
+      ,\n  \"Polly Toynbee\",\n  \"Roy Hattersley\",\n  \"Simon Hoggart\",\n  \"Will\
+      \ Hutton\",\n  \"Zoe Williams\"\n] [author]\n}} .\n|||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -143,30 +144,30 @@ templates:
     name: article_from_author
     reference: ''
   e885498a-04f9-4db9-bc01-d1324803315a: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: e885498a-04f9-4db9-bc01-d1324803315a
-    jinja: "Who wrote this article? The answer options are {% for author in answer_choices[:-1]\
-      \ %} {{author.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.\n\
-      \n{{article}} \n\n|||\n\n{{ answer_choices[author].capitalize() }}"
+    jinja: "Who wrote this article? The answer options are {{answer_choices|join(\"\
+      , \")}}.\n\n{{article}} \n\n|||\n\n{{ answer_choices[author] }}"
     metadata: !TemplateMetadata
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: true
     name: who_wrote_article
     reference: ''
   f6ff1e76-4148-450c-ba0c-157a5b4c2383: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: f6ff1e76-4148-450c-ba0c-157a5b4c2383
     jinja: "Who is the author of the passage below? Choose from the following list:\
-      \ {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor\
-      \ %} {{answer_choices[-1].capitalize()}}. \n\nHint: The topic is related to\
-      \ {{ [\"Politics\", \"Society\", \"UK\", \"World\", \"Books\"][topic] }}.\n\n\
-      {{article}}\n|||\n{{ answer_choices[author].capitalize() }}"
+      \ {{ answer_choices | join(\", \")}}. \n\nHint: The topic is related to {{ [\"\
+      Politics\", \"Society\", \"UK\", \"World\", \"Books\"][topic] }}.\n\n{{article}}\n\
+      |||\n{{ answer_choices[author] }}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:

--- a/promptsource/templates/guardian_authorship/cross_genre_1/templates.yaml
+++ b/promptsource/templates/guardian_authorship/cross_genre_1/templates.yaml
@@ -34,6 +34,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - BLEU
+      - ROUGE
       original_task: false
     name: article_from_author_topic
     reference: ''
@@ -46,6 +47,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - BLEU
+      - ROUGE
       original_task: false
     name: article_from_topic
     reference: ''
@@ -70,7 +72,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: who_wrote_article_with_topic_2
+    name: who_wrote_article_with_topic_affirmative
     reference: ''
   68bfa6a4-a89c-4be2-aa0b-cce1103e3ecf: !Template
     answer_choices: Politics ||| Society ||| UK ||| World ||| Books
@@ -104,7 +106,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: who_wrote_article_2
+    name: who_wrote_article_affirmative
     reference: ''
   8e852323-3aba-4c57-a428-004bbef4185e: !Template
     answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
@@ -122,7 +124,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: who_wrote_article_with_topic_3
+    name: who_wrote_article_with_topic_exam
     reference: ''
   dc46136b-69d1-484e-9b5f-accfb4ba22df: !Template
     answer_choices: null
@@ -136,6 +138,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - BLEU
+      - ROUGE
       original_task: false
     name: article_from_author
     reference: ''
@@ -169,5 +172,5 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: who_wrote_article_with_topic
+    name: who_wrote_article_with_topic_hint
     reference: ''

--- a/promptsource/templates/guardian_authorship/cross_topic_1/templates.yaml
+++ b/promptsource/templates/guardian_authorship/cross_topic_1/templates.yaml
@@ -34,6 +34,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - BLEU
+      - ROUGE
       original_task: false
     name: article_from_author_topic
     reference: ''
@@ -46,6 +47,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - BLEU
+      - ROUGE
       original_task: false
     name: article_from_topic
     reference: ''
@@ -70,7 +72,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: who_wrote_article_with_topic_2
+    name: who_wrote_article_with_topic_affirmative
     reference: ''
   cde2012f-4c80-4aa0-90f6-2db7138b534e: !Template
     answer_choices: Politics ||| Society ||| UK ||| World ||| Books
@@ -104,7 +106,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: who_wrote_article_2
+    name: who_wrote_article_affirmative
     reference: ''
   e8066eb0-f476-4f7a-9c5a-eb90dceefc3d: !Template
     answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
@@ -122,7 +124,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: who_wrote_article_with_topic_3
+    name: who_wrote_article_with_topic_exam
     reference: ''
   ec933b25-e4a2-49f6-b9a0-1675d3541e27: !Template
     answer_choices: null
@@ -136,6 +138,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - BLEU
+      - ROUGE
       original_task: false
     name: article_from_author
     reference: ''
@@ -169,5 +172,5 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: who_wrote_article_with_topic
+    name: who_wrote_article_with_topic_hint
     reference: ''

--- a/promptsource/templates/guardian_authorship/cross_topic_1/templates.yaml
+++ b/promptsource/templates/guardian_authorship/cross_topic_1/templates.yaml
@@ -2,20 +2,20 @@ dataset: guardian_authorship
 subset: cross_topic_1
 templates:
   18cea428-59ae-4db1-b2ee-6c44fb39dc71: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: 18cea428-59ae-4db1-b2ee-6c44fb39dc71
     jinja: 'Who could have authored this article based on the writing style? The answer
-      options are {% for author in answer_choices[:-1] %} {{author.capitalize()}},
-      {% endfor %} {{answer_choices[-1].capitalize()}}.
+      options are {{ answer_choices | join(", ") }}.
 
 
       {{article}} |||
 
-      {{ answer_choices[author].capitalize() }}'
+      {{ answer_choices[author] }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: true
@@ -24,12 +24,13 @@ templates:
   3b4cc95c-f88c-4b51-add5-32ffdebfdfc6: !Template
     answer_choices: null
     id: 3b4cc95c-f88c-4b51-add5-32ffdebfdfc6
-    jinja: "Generate an article based on the writing style of  {{\n[\n  \"catherinebennett\"\
-      ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
-      ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
-      ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author].capitalize()\n}}  on the topic of {{\n[\n  \"Politics\",\n  \"\
-      Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}}. |||\n{{article}}"
+    jinja: "Generate an article based on the writing style of {{\n[\n  \"Catherine\
+      \ Bennett\",\n  \"George Monbiot\",\n  \"Hugo Young\",\n  \"Jonathan Freedland\"\
+      ,\n  \"Martin Kettle\",\n  \"Mary Riddell\",\n  \"Nick Cohen\",\n  \"Peter Preston\"\
+      ,\n  \"Polly Toynbee\",\n  \"Roy Hattersley\",\n  \"Simon Hoggart\",\n  \"Will\
+      \ Hutton\",\n  \"Zoe Williams\"\n] [author]\n}} on the topic of {{\n[\n  \"\
+      Politics\",\n  \"Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n\
+      }}. |||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -42,7 +43,7 @@ templates:
     answer_choices: null
     id: a19222b2-6edd-479b-a30c-96d2497216e5
     jinja: "Generate an article on the topic of {{[\n  \"Politics\",\n  \"Society\"\
-      ,\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic] }} |||\n{{article}}"
+      ,\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic] }}. |||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -52,23 +53,23 @@ templates:
     name: article_from_topic
     reference: ''
   b6a0012c-f10b-464e-9531-8a9d56057d0f: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: b6a0012c-f10b-464e-9531-8a9d56057d0f
-    jinja: 'Given the answer options of {% for author in answer_choices[:-1] %} {{author.capitalize()}},
-      {% endfor %} and {{answer_choices[-1].capitalize()}}, identify the author of
-      the passage, which is related to {{ ["Politics", "Society", "UK", "World", "Books"][topic]
-      }}, below.
+    jinja: 'Given the answer options of {{answer_choices[:-1] | join(", ")}} and {{answer_choices[-1]}},
+      identify the author of the passage, which is related to {{ ["Politics", "Society",
+      "UK", "World", "Books"][topic] }}, below.
 
 
       {{article}}
 
       |||
 
-      {{ answer_choices[author].capitalize() }}'
+      {{ answer_choices[author] }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: true
@@ -77,30 +78,30 @@ templates:
   cde2012f-4c80-4aa0-90f6-2db7138b534e: !Template
     answer_choices: Politics ||| Society ||| UK ||| World ||| Books
     id: cde2012f-4c80-4aa0-90f6-2db7138b534e
-    jinja: "What is the topic of this article? The answer options are {% for topic\
-      \ in answer_choices[:-1] %} {{topic.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.\n\
-      \n{{article}} \n|||\n{{answer_choices[topic]}}"
+    jinja: "What is the topic of this article? The answer options are {{answer_choices|join(\"\
+      , \")}}.\n\n{{article}} \n|||\n{{answer_choices[topic]}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: false
     name: topic
     reference: ''
   d617f1c6-114f-4fd7-81d4-7b7e12f353b0: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: d617f1c6-114f-4fd7-81d4-7b7e12f353b0
     jinja: 'Identify the author of the passage below by choosing from the author list
-      of {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor
-      %} {{answer_choices[-1].capitalize()}}.
+      of {{answer_choices|join(", ")}}.
 
 
       {{article}}
 
       |||
 
-      {{ answer_choices[author].capitalize() }}'
+      {{ answer_choices[author] }}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -109,16 +110,16 @@ templates:
     name: who_wrote_article_affirmative
     reference: ''
   e8066eb0-f476-4f7a-9c5a-eb90dceefc3d: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: e8066eb0-f476-4f7a-9c5a-eb90dceefc3d
     jinja: "You are in an examination, which requires you to associate the passage\
       \ below to the author. The topic is about {{ [\"Politics\", \"Society\", \"\
       UK\", \"World\", \"Books\"][topic] }}, and the possible authors are one of the\
-      \ following: {% for author in answer_choices[:-1] %} {{author.capitalize()}},\
-      \ {% endfor %} {{answer_choices[-1].capitalize()}}. What is the answer?\n\n\
-      Passage: {{ article }} \n|||\n{{ answer_choices[author].capitalize() }}"
+      \ following: {{answer_choices | join(\", \")}}. What is the answer?\n\nPassage:\
+      \ {{ article }} \n|||\n{{ answer_choices[author] }}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -129,11 +130,11 @@ templates:
   ec933b25-e4a2-49f6-b9a0-1675d3541e27: !Template
     answer_choices: null
     id: ec933b25-e4a2-49f6-b9a0-1675d3541e27
-    jinja: "Generate an article based on the writing style of {{\n[\n  \"catherinebennett\"\
-      ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
-      ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
-      ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author].capitalize()\n}} .\n|||\n{{article}}"
+    jinja: "Generate an article based on the writing style of {{\n[\n  \"Catherine\
+      \ Bennett\",\n  \"George Monbiot\",\n  \"Hugo Young\",\n  \"Jonathan Freedland\"\
+      ,\n  \"Martin Kettle\",\n  \"Mary Riddell\",\n  \"Nick Cohen\",\n  \"Peter Preston\"\
+      ,\n  \"Polly Toynbee\",\n  \"Roy Hattersley\",\n  \"Simon Hoggart\",\n  \"Will\
+      \ Hutton\",\n  \"Zoe Williams\"\n] [author]\n}} .\n|||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -143,30 +144,30 @@ templates:
     name: article_from_author
     reference: ''
   f22055a0-478e-4ace-9d0b-82986ad77919: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: f22055a0-478e-4ace-9d0b-82986ad77919
-    jinja: "Who wrote this article? The answer options are {% for author in answer_choices[:-1]\
-      \ %} {{author.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.\n\
-      \n{{article}} \n\n|||\n\n{{ answer_choices[author].capitalize() }}"
+    jinja: "Who wrote this article? The answer options are {{answer_choices|join(\"\
+      , \")}}.\n\n{{article}} \n\n|||\n\n{{ answer_choices[author] }}"
     metadata: !TemplateMetadata
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: true
     name: who_wrote_article
     reference: ''
   f289839f-7fdb-49d7-ab66-dacd6e583e04: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: f289839f-7fdb-49d7-ab66-dacd6e583e04
     jinja: "Who is the author of the passage below? Choose from the following list:\
-      \ {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor\
-      \ %} {{answer_choices[-1].capitalize()}}. \n\nHint: The topic is related to\
-      \ {{ [\"Politics\", \"Society\", \"UK\", \"World\", \"Books\"][topic] }}.\n\n\
-      {{article}}\n|||\n{{ answer_choices[author].capitalize() }}"
+      \ {{ answer_choices | join(\", \")}}. \n\nHint: The topic is related to {{ [\"\
+      Politics\", \"Society\", \"UK\", \"World\", \"Books\"][topic] }}.\n\n{{article}}\n\
+      |||\n{{ answer_choices[author] }}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:

--- a/promptsource/templates/guardian_authorship/cross_topic_1/templates.yaml
+++ b/promptsource/templates/guardian_authorship/cross_topic_1/templates.yaml
@@ -6,7 +6,9 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: 18cea428-59ae-4db1-b2ee-6c44fb39dc71
-    jinja: 'Who could have authored this article based on the writing style?
+    jinja: 'Who could have authored this article based on the writing style? The answer
+      options are {% for author in answer_choices[:-1] %} {{author.capitalize()}},
+      {% endfor %} {{answer_choices[-1].capitalize()}}.
 
 
       {{article}} |||
@@ -27,7 +29,7 @@ templates:
       ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
       ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
       \n] [author].capitalize()\n}}  on the topic of {{\n[\n  \"Politics\",\n  \"\
-      Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}} |||\n{{article}}"
+      Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}}. |||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -52,8 +54,10 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: b6a0012c-f10b-464e-9531-8a9d56057d0f
-    jinja: 'Who is the author of the passage, which is related to {{ ["Politics",
-      "Society", "UK", "World", "Books"][topic] }}, below?
+    jinja: 'Given the answer options of {% for author in answer_choices[:-1] %} {{author.capitalize()}},
+      {% endfor %} and {{answer_choices[-1].capitalize()}}, identify the author of
+      the passage, which is related to {{ ["Politics", "Society", "UK", "World", "Books"][topic]
+      }}, below.
 
 
       {{article}}
@@ -71,7 +75,9 @@ templates:
   cde2012f-4c80-4aa0-90f6-2db7138b534e: !Template
     answer_choices: Politics ||| Society ||| UK ||| World ||| Books
     id: cde2012f-4c80-4aa0-90f6-2db7138b534e
-    jinja: "What is the topic of this article?\n\n{{article}} \n|||\n{{answer_choices[topic]}}"
+    jinja: "What is the topic of this article? The answer options are {% for topic\
+      \ in answer_choices[:-1] %} {{topic.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.\n\
+      \n{{article}} \n|||\n{{answer_choices[topic]}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics: []
@@ -83,8 +89,9 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: d617f1c6-114f-4fd7-81d4-7b7e12f353b0
-    jinja: 'Identify the author of the passage below. The answer options are {% for
-      author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.
+    jinja: 'Identify the author of the passage below by choosing from the author list
+      of {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor
+      %} {{answer_choices[-1].capitalize()}}.
 
 
       {{article}}
@@ -124,7 +131,7 @@ templates:
       ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
       ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
       ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author].capitalize()\n}} \n|||\n{{article}}"
+      \n] [author].capitalize()\n}} .\n|||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -137,8 +144,9 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: f22055a0-478e-4ace-9d0b-82986ad77919
-    jinja: "Who wrote this article?\n\n{{article}} \n\n|||\n\n{{ answer_choices[author].capitalize()\
-      \ }}"
+    jinja: "Who wrote this article? The answer options are {% for author in answer_choices[:-1]\
+      \ %} {{author.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.\n\
+      \n{{article}} \n\n|||\n\n{{ answer_choices[author].capitalize() }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -151,17 +159,11 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: f289839f-7fdb-49d7-ab66-dacd6e583e04
-    jinja: 'Who is the author of the passage below? Choose from the following list:
-      {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor %}
-      {{answer_choices[-1].capitalize()}}. Hint: The topic is related to {{ ["Politics",
-      "Society", "UK", "World", "Books"][topic] }}.
-
-
-      {{article}}
-
-      |||
-
-      {{ answer_choices[author].capitalize() }}'
+    jinja: "Who is the author of the passage below? Choose from the following list:\
+      \ {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor\
+      \ %} {{answer_choices[-1].capitalize()}}. \n\nHint: The topic is related to\
+      \ {{ [\"Politics\", \"Society\", \"UK\", \"World\", \"Books\"][topic] }}.\n\n\
+      {{article}}\n|||\n{{ answer_choices[author].capitalize() }}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:

--- a/promptsource/templates/guardian_authorship/cross_topic_1/templates.yaml
+++ b/promptsource/templates/guardian_authorship/cross_topic_1/templates.yaml
@@ -2,20 +2,22 @@ dataset: guardian_authorship
 subset: cross_topic_1
 templates:
   18cea428-59ae-4db1-b2ee-6c44fb39dc71: !Template
-    answer_choices: null
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: 18cea428-59ae-4db1-b2ee-6c44fb39dc71
-    jinja: "Who wrote this article and what is the article's topic?\n\n{{article}}\
-      \ |||\n{{[\n  \"catherinebennett\",\n  \"georgemonbiot\",\n  \"hugoyoung\",\n\
-      \  \"jonathanfreedland\",\n  \"martinkettle\",\n  \"maryriddell\",\n  \"nickcohen\"\
-      ,\n  \"peterpreston\",\n  \"pollytoynbee\",\n  \"royhattersley\",\n  \"simonhoggart\"\
-      ,\n  \"willhutton\",\n  \"zoewilliams\"\n][author]}} wrote this article on the\
-      \ topic of {{[\n  \"Politics\",\n  \"Society\",\n  \"UK\",\n  \"World\",\n \
-      \ \"Books\"\n][topic]}}"
+    jinja: 'Who could have authored this article based on the writing style?
+
+
+      {{article}} |||
+
+      {{ answer_choices[author].capitalize() }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: who_what_article
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: writing_style
     reference: ''
   3b4cc95c-f88c-4b51-add5-32ffdebfdfc6: !Template
     answer_choices: null
@@ -24,61 +26,146 @@ templates:
       ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
       ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
       ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author]\n}}  on the topic of {{\n[\n  \"Politics\",\n  \"Society\",\n \
-      \ \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}} |||\n{{article}}"
+      \n] [author].capitalize()\n}}  on the topic of {{\n[\n  \"Politics\",\n  \"\
+      Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}} |||\n{{article}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      original_task: false
     name: article_from_author_topic
     reference: ''
   a19222b2-6edd-479b-a30c-96d2497216e5: !Template
     answer_choices: null
     id: a19222b2-6edd-479b-a30c-96d2497216e5
-    jinja: "What is the topic of this article?\n\n{{article}} |||\n{{\n[\n  \"Politics\"\
-      ,\n  \"Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic]\n}}"
+    jinja: "Generate an article on the topic of {{[\n  \"Politics\",\n  \"Society\"\
+      ,\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic] }} |||\n{{article}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      original_task: false
+    name: article_from_topic
+    reference: ''
+  b6a0012c-f10b-464e-9531-8a9d56057d0f: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: b6a0012c-f10b-464e-9531-8a9d56057d0f
+    jinja: 'Who is the author of the passage, which is related to {{ ["Politics",
+      "Society", "UK", "World", "Books"][topic] }}, below?
+
+
+      {{article}}
+
+      |||
+
+      {{ answer_choices[author].capitalize() }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article_with_topic_2
+    reference: ''
+  cde2012f-4c80-4aa0-90f6-2db7138b534e: !Template
+    answer_choices: Politics ||| Society ||| UK ||| World ||| Books
+    id: cde2012f-4c80-4aa0-90f6-2db7138b534e
+    jinja: "What is the topic of this article?\n\n{{article}} \n|||\n{{answer_choices[topic]}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
       metrics: []
-      original_task: null
+      original_task: false
     name: topic
     reference: ''
   d617f1c6-114f-4fd7-81d4-7b7e12f353b0: !Template
-    answer_choices: null
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: d617f1c6-114f-4fd7-81d4-7b7e12f353b0
-    jinja: "Who could have authored this article based on the writing style?\n\n{{article}}\
-      \ |||\n{{\n[\n  \"catherinebennett\",\n  \"georgemonbiot\",\n  \"hugoyoung\"\
-      ,\n  \"jonathanfreedland\",\n  \"martinkettle\",\n  \"maryriddell\",\n  \"nickcohen\"\
-      ,\n  \"peterpreston\",\n  \"pollytoynbee\",\n  \"royhattersley\",\n  \"simonhoggart\"\
-      ,\n  \"willhutton\",\n  \"zoewilliams\"\n][author]\n}}"
+    jinja: 'Identify the author of the passage below. The answer options are {% for
+      author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.
+
+
+      {{article}}
+
+      |||
+
+      {{ answer_choices[author].capitalize() }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: writing_style
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article_2
     reference: ''
-  f22055a0-478e-4ace-9d0b-82986ad77919: !Template
+  e8066eb0-f476-4f7a-9c5a-eb90dceefc3d: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: e8066eb0-f476-4f7a-9c5a-eb90dceefc3d
+    jinja: "You are in an examination, which requires you to associate the passage\
+      \ below to the author. The topic is about {{ [\"Politics\", \"Society\", \"\
+      UK\", \"World\", \"Books\"][topic] }}, and the possible authors are one of the\
+      \ following: {% for author in answer_choices[:-1] %} {{author.capitalize()}},\
+      \ {% endfor %} {{answer_choices[-1].capitalize()}}. What is the answer?\n\n\
+      Passage: {{ article }} \n|||\n{{ answer_choices[author].capitalize() }}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article_with_topic_3
+    reference: ''
+  ec933b25-e4a2-49f6-b9a0-1675d3541e27: !Template
     answer_choices: null
-    id: f22055a0-478e-4ace-9d0b-82986ad77919
+    id: ec933b25-e4a2-49f6-b9a0-1675d3541e27
     jinja: "Generate an article based on the writing style of {{\n[\n  \"catherinebennett\"\
       ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
       ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
       ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author]\n}} |||\n{{article}}"
+      \n] [author].capitalize()\n}} \n|||\n{{article}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      original_task: false
     name: article_from_author
     reference: ''
-  f289839f-7fdb-49d7-ab66-dacd6e583e04: !Template
-    answer_choices: null
-    id: f289839f-7fdb-49d7-ab66-dacd6e583e04
-    jinja: "Generate an article on the topic of {{[\n  \"Politics\",\n  \"Society\"\
-      ,\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic] }} |||\n{{article}}"
+  f22055a0-478e-4ace-9d0b-82986ad77919: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: f22055a0-478e-4ace-9d0b-82986ad77919
+    jinja: "Who wrote this article?\n\n{{article}} \n\n|||\n\n{{ answer_choices[author].capitalize()\
+      \ }}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: article_from_topic
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article
+    reference: ''
+  f289839f-7fdb-49d7-ab66-dacd6e583e04: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: f289839f-7fdb-49d7-ab66-dacd6e583e04
+    jinja: 'Who is the author of the passage below? Choose from the following list:
+      {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor %}
+      {{answer_choices[-1].capitalize()}}. Hint: The topic is related to {{ ["Politics",
+      "Society", "UK", "World", "Books"][topic] }}.
+
+
+      {{article}}
+
+      |||
+
+      {{ answer_choices[author].capitalize() }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article_with_topic
     reference: ''

--- a/promptsource/templates/guardian_authorship/cross_topic_4/templates.yaml
+++ b/promptsource/templates/guardian_authorship/cross_topic_4/templates.yaml
@@ -2,20 +2,20 @@ dataset: guardian_authorship
 subset: cross_topic_4
 templates:
   3951d79c-408b-4895-8226-3033d8784d2c: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: 3951d79c-408b-4895-8226-3033d8784d2c
     jinja: 'Who could have authored this article based on the writing style? The answer
-      options are {% for author in answer_choices[:-1] %} {{author.capitalize()}},
-      {% endfor %} {{answer_choices[-1].capitalize()}}.
+      options are {{ answer_choices | join(", ") }}.
 
 
       {{article}} |||
 
-      {{ answer_choices[author].capitalize() }}'
+      {{ answer_choices[author] }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: true
@@ -24,12 +24,13 @@ templates:
   4998d29d-7042-439b-8346-c4f93bd11cbc: !Template
     answer_choices: null
     id: 4998d29d-7042-439b-8346-c4f93bd11cbc
-    jinja: "Generate an article based on the writing style of  {{\n[\n  \"catherinebennett\"\
-      ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
-      ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
-      ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author].capitalize()\n}}  on the topic of {{\n[\n  \"Politics\",\n  \"\
-      Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}}. |||\n{{article}}"
+    jinja: "Generate an article based on the writing style of {{\n[\n  \"Catherine\
+      \ Bennett\",\n  \"George Monbiot\",\n  \"Hugo Young\",\n  \"Jonathan Freedland\"\
+      ,\n  \"Martin Kettle\",\n  \"Mary Riddell\",\n  \"Nick Cohen\",\n  \"Peter Preston\"\
+      ,\n  \"Polly Toynbee\",\n  \"Roy Hattersley\",\n  \"Simon Hoggart\",\n  \"Will\
+      \ Hutton\",\n  \"Zoe Williams\"\n] [author]\n}} on the topic of {{\n[\n  \"\
+      Politics\",\n  \"Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n\
+      }}. |||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -42,7 +43,7 @@ templates:
     answer_choices: null
     id: 4c3d501e-1ccf-4ce4-b6c6-9af13f0f5429
     jinja: "Generate an article on the topic of {{[\n  \"Politics\",\n  \"Society\"\
-      ,\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic] }} |||\n{{article}}"
+      ,\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic] }}. |||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -52,23 +53,23 @@ templates:
     name: article_from_topic
     reference: ''
   4ef96141-81c1-488c-92b9-5d35a3a12afa: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: 4ef96141-81c1-488c-92b9-5d35a3a12afa
-    jinja: 'Given the answer options of {% for author in answer_choices[:-1] %} {{author.capitalize()}},
-      {% endfor %} and {{answer_choices[-1].capitalize()}}, identify the author of
-      the passage, which is related to {{ ["Politics", "Society", "UK", "World", "Books"][topic]
-      }}, below.
+    jinja: 'Given the answer options of {{answer_choices[:-1] | join(", ")}} and {{answer_choices[-1]}},
+      identify the author of the passage, which is related to {{ ["Politics", "Society",
+      "UK", "World", "Books"][topic] }}, below.
 
 
       {{article}}
 
       |||
 
-      {{ answer_choices[author].capitalize() }}'
+      {{ answer_choices[author] }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: true
@@ -77,30 +78,30 @@ templates:
   54e1f0ac-1e17-43bb-85ee-3f852fcccb10: !Template
     answer_choices: Politics ||| Society ||| UK ||| World ||| Books
     id: 54e1f0ac-1e17-43bb-85ee-3f852fcccb10
-    jinja: "What is the topic of this article? The answer options are {% for topic\
-      \ in answer_choices[:-1] %} {{topic.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.\n\
-      \n{{article}} \n|||\n{{answer_choices[topic]}}"
+    jinja: "What is the topic of this article? The answer options are {{answer_choices|join(\"\
+      , \")}}.\n\n{{article}} \n|||\n{{answer_choices[topic]}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: false
     name: topic
     reference: ''
   66de6739-738e-4397-8c15-49ea1e1a6c6c: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: 66de6739-738e-4397-8c15-49ea1e1a6c6c
     jinja: 'Identify the author of the passage below by choosing from the author list
-      of {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor
-      %} {{answer_choices[-1].capitalize()}}.
+      of {{answer_choices|join(", ")}}.
 
 
       {{article}}
 
       |||
 
-      {{ answer_choices[author].capitalize() }}'
+      {{ answer_choices[author] }}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -109,16 +110,16 @@ templates:
     name: who_wrote_article_affirmative
     reference: ''
   93d06e87-f328-415d-8fda-f4732165736d: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: 93d06e87-f328-415d-8fda-f4732165736d
     jinja: "You are in an examination, which requires you to associate the passage\
       \ below to the author. The topic is about {{ [\"Politics\", \"Society\", \"\
       UK\", \"World\", \"Books\"][topic] }}, and the possible authors are one of the\
-      \ following: {% for author in answer_choices[:-1] %} {{author.capitalize()}},\
-      \ {% endfor %} {{answer_choices[-1].capitalize()}}. What is the answer?\n\n\
-      Passage: {{ article }} \n|||\n{{ answer_choices[author].capitalize() }}"
+      \ following: {{answer_choices | join(\", \")}}. What is the answer?\n\nPassage:\
+      \ {{ article }} \n|||\n{{ answer_choices[author] }}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -129,11 +130,11 @@ templates:
   b092f3f0-467c-4268-b450-b3c416824d56: !Template
     answer_choices: null
     id: b092f3f0-467c-4268-b450-b3c416824d56
-    jinja: "Generate an article based on the writing style of {{\n[\n  \"catherinebennett\"\
-      ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
-      ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
-      ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author].capitalize()\n}} .\n|||\n{{article}}"
+    jinja: "Generate an article based on the writing style of {{\n[\n  \"Catherine\
+      \ Bennett\",\n  \"George Monbiot\",\n  \"Hugo Young\",\n  \"Jonathan Freedland\"\
+      ,\n  \"Martin Kettle\",\n  \"Mary Riddell\",\n  \"Nick Cohen\",\n  \"Peter Preston\"\
+      ,\n  \"Polly Toynbee\",\n  \"Roy Hattersley\",\n  \"Simon Hoggart\",\n  \"Will\
+      \ Hutton\",\n  \"Zoe Williams\"\n] [author]\n}} .\n|||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -143,30 +144,30 @@ templates:
     name: article_from_author
     reference: ''
   b89bb96c-e3c7-4e8a-beab-658800526864: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: b89bb96c-e3c7-4e8a-beab-658800526864
-    jinja: "Who wrote this article? The answer options are {% for author in answer_choices[:-1]\
-      \ %} {{author.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.\n\
-      \n{{article}} \n\n|||\n\n{{ answer_choices[author].capitalize() }}"
+    jinja: "Who wrote this article? The answer options are {{answer_choices|join(\"\
+      , \")}}.\n\n{{article}} \n\n|||\n\n{{ answer_choices[author] }}"
     metadata: !TemplateMetadata
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: true
     name: who_wrote_article
     reference: ''
   d16d1263-17e7-411a-b28a-207a95d79afc: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: d16d1263-17e7-411a-b28a-207a95d79afc
     jinja: "Who is the author of the passage below? Choose from the following list:\
-      \ {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor\
-      \ %} {{answer_choices[-1].capitalize()}}. \n\nHint: The topic is related to\
-      \ {{ [\"Politics\", \"Society\", \"UK\", \"World\", \"Books\"][topic] }}.\n\n\
-      {{article}}\n|||\n{{ answer_choices[author].capitalize() }}"
+      \ {{ answer_choices | join(\", \")}}. \n\nHint: The topic is related to {{ [\"\
+      Politics\", \"Society\", \"UK\", \"World\", \"Books\"][topic] }}.\n\n{{article}}\n\
+      |||\n{{ answer_choices[author] }}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:

--- a/promptsource/templates/guardian_authorship/cross_topic_4/templates.yaml
+++ b/promptsource/templates/guardian_authorship/cross_topic_4/templates.yaml
@@ -34,6 +34,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - BLEU
+      - ROUGE
       original_task: false
     name: article_from_author_topic
     reference: ''
@@ -46,6 +47,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - BLEU
+      - ROUGE
       original_task: false
     name: article_from_topic
     reference: ''
@@ -70,7 +72,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: who_wrote_article_with_topic_2
+    name: who_wrote_article_with_topic_affirmative
     reference: ''
   54e1f0ac-1e17-43bb-85ee-3f852fcccb10: !Template
     answer_choices: Politics ||| Society ||| UK ||| World ||| Books
@@ -104,7 +106,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: who_wrote_article_2
+    name: who_wrote_article_affirmative
     reference: ''
   93d06e87-f328-415d-8fda-f4732165736d: !Template
     answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
@@ -122,7 +124,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: who_wrote_article_with_topic_3
+    name: who_wrote_article_with_topic_exam
     reference: ''
   b092f3f0-467c-4268-b450-b3c416824d56: !Template
     answer_choices: null
@@ -136,6 +138,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - BLEU
+      - ROUGE
       original_task: false
     name: article_from_author
     reference: ''
@@ -169,5 +172,5 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: who_wrote_article_with_topic
+    name: who_wrote_article_with_topic_hint
     reference: ''

--- a/promptsource/templates/guardian_authorship/cross_topic_4/templates.yaml
+++ b/promptsource/templates/guardian_authorship/cross_topic_4/templates.yaml
@@ -6,7 +6,9 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: 3951d79c-408b-4895-8226-3033d8784d2c
-    jinja: 'Who could have authored this article based on the writing style?
+    jinja: 'Who could have authored this article based on the writing style? The answer
+      options are {% for author in answer_choices[:-1] %} {{author.capitalize()}},
+      {% endfor %} {{answer_choices[-1].capitalize()}}.
 
 
       {{article}} |||
@@ -27,7 +29,7 @@ templates:
       ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
       ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
       \n] [author].capitalize()\n}}  on the topic of {{\n[\n  \"Politics\",\n  \"\
-      Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}} |||\n{{article}}"
+      Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}}. |||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -52,8 +54,10 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: 4ef96141-81c1-488c-92b9-5d35a3a12afa
-    jinja: 'Who is the author of the passage, which is related to {{ ["Politics",
-      "Society", "UK", "World", "Books"][topic] }}, below?
+    jinja: 'Given the answer options of {% for author in answer_choices[:-1] %} {{author.capitalize()}},
+      {% endfor %} and {{answer_choices[-1].capitalize()}}, identify the author of
+      the passage, which is related to {{ ["Politics", "Society", "UK", "World", "Books"][topic]
+      }}, below.
 
 
       {{article}}
@@ -71,7 +75,9 @@ templates:
   54e1f0ac-1e17-43bb-85ee-3f852fcccb10: !Template
     answer_choices: Politics ||| Society ||| UK ||| World ||| Books
     id: 54e1f0ac-1e17-43bb-85ee-3f852fcccb10
-    jinja: "What is the topic of this article?\n\n{{article}} \n|||\n{{answer_choices[topic]}}"
+    jinja: "What is the topic of this article? The answer options are {% for topic\
+      \ in answer_choices[:-1] %} {{topic.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.\n\
+      \n{{article}} \n|||\n{{answer_choices[topic]}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics: []
@@ -83,8 +89,9 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: 66de6739-738e-4397-8c15-49ea1e1a6c6c
-    jinja: 'Identify the author of the passage below. The answer options are {% for
-      author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.
+    jinja: 'Identify the author of the passage below by choosing from the author list
+      of {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor
+      %} {{answer_choices[-1].capitalize()}}.
 
 
       {{article}}
@@ -124,7 +131,7 @@ templates:
       ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
       ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
       ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author].capitalize()\n}} \n|||\n{{article}}"
+      \n] [author].capitalize()\n}} .\n|||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -137,8 +144,9 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: b89bb96c-e3c7-4e8a-beab-658800526864
-    jinja: "Who wrote this article?\n\n{{article}} \n\n|||\n\n{{ answer_choices[author].capitalize()\
-      \ }}"
+    jinja: "Who wrote this article? The answer options are {% for author in answer_choices[:-1]\
+      \ %} {{author.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.\n\
+      \n{{article}} \n\n|||\n\n{{ answer_choices[author].capitalize() }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -151,17 +159,11 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: d16d1263-17e7-411a-b28a-207a95d79afc
-    jinja: 'Who is the author of the passage below? Choose from the following list:
-      {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor %}
-      {{answer_choices[-1].capitalize()}}. Hint: The topic is related to {{ ["Politics",
-      "Society", "UK", "World", "Books"][topic] }}.
-
-
-      {{article}}
-
-      |||
-
-      {{ answer_choices[author].capitalize() }}'
+    jinja: "Who is the author of the passage below? Choose from the following list:\
+      \ {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor\
+      \ %} {{answer_choices[-1].capitalize()}}. \n\nHint: The topic is related to\
+      \ {{ [\"Politics\", \"Society\", \"UK\", \"World\", \"Books\"][topic] }}.\n\n\
+      {{article}}\n|||\n{{ answer_choices[author].capitalize() }}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:

--- a/promptsource/templates/guardian_authorship/cross_topic_4/templates.yaml
+++ b/promptsource/templates/guardian_authorship/cross_topic_4/templates.yaml
@@ -2,83 +2,170 @@ dataset: guardian_authorship
 subset: cross_topic_4
 templates:
   3951d79c-408b-4895-8226-3033d8784d2c: !Template
-    answer_choices: null
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: 3951d79c-408b-4895-8226-3033d8784d2c
-    jinja: "Who wrote this article and what is the article's topic?\n\n{{article}}\
-      \ |||\n{{[\n  \"catherinebennett\",\n  \"georgemonbiot\",\n  \"hugoyoung\",\n\
-      \  \"jonathanfreedland\",\n  \"martinkettle\",\n  \"maryriddell\",\n  \"nickcohen\"\
-      ,\n  \"peterpreston\",\n  \"pollytoynbee\",\n  \"royhattersley\",\n  \"simonhoggart\"\
-      ,\n  \"willhutton\",\n  \"zoewilliams\"\n][author]}} wrote this article on the\
-      \ topic of {{[\n  \"Politics\",\n  \"Society\",\n  \"UK\",\n  \"World\",\n \
-      \ \"Books\"\n][topic]}}"
+    jinja: 'Who could have authored this article based on the writing style?
+
+
+      {{article}} |||
+
+      {{ answer_choices[author].capitalize() }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: who_what_article
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: writing_style
     reference: ''
   4998d29d-7042-439b-8346-c4f93bd11cbc: !Template
     answer_choices: null
     id: 4998d29d-7042-439b-8346-c4f93bd11cbc
-    jinja: "Who could have authored this article based on the writing style?\n\n{{article}}\
-      \ |||\n{{\n[\n  \"catherinebennett\",\n  \"georgemonbiot\",\n  \"hugoyoung\"\
-      ,\n  \"jonathanfreedland\",\n  \"martinkettle\",\n  \"maryriddell\",\n  \"nickcohen\"\
-      ,\n  \"peterpreston\",\n  \"pollytoynbee\",\n  \"royhattersley\",\n  \"simonhoggart\"\
-      ,\n  \"willhutton\",\n  \"zoewilliams\"\n][author]\n}}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: writing_style
-    reference: ''
-  4ef96141-81c1-488c-92b9-5d35a3a12afa: !Template
-    answer_choices: null
-    id: 4ef96141-81c1-488c-92b9-5d35a3a12afa
-    jinja: "Generate an article based on the writing style of {{\n[\n  \"catherinebennett\"\
-      ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
-      ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
-      ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author]\n}} |||\n{{article}}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: article_from_author
-    reference: ''
-  54e1f0ac-1e17-43bb-85ee-3f852fcccb10: !Template
-    answer_choices: null
-    id: 54e1f0ac-1e17-43bb-85ee-3f852fcccb10
-    jinja: "What is the topic of this article?\n\n{{article}} |||\n{{\n[\n  \"Politics\"\
-      ,\n  \"Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic]\n}}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: topic
-    reference: ''
-  93d06e87-f328-415d-8fda-f4732165736d: !Template
-    answer_choices: null
-    id: 93d06e87-f328-415d-8fda-f4732165736d
     jinja: "Generate an article based on the writing style of  {{\n[\n  \"catherinebennett\"\
       ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
       ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
       ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author]\n}}  on the topic of {{\n[\n  \"Politics\",\n  \"Society\",\n \
-      \ \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}} |||\n{{article}}"
+      \n] [author].capitalize()\n}}  on the topic of {{\n[\n  \"Politics\",\n  \"\
+      Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}} |||\n{{article}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      original_task: false
     name: article_from_author_topic
     reference: ''
-  b89bb96c-e3c7-4e8a-beab-658800526864: !Template
+  4c3d501e-1ccf-4ce4-b6c6-9af13f0f5429: !Template
     answer_choices: null
-    id: b89bb96c-e3c7-4e8a-beab-658800526864
+    id: 4c3d501e-1ccf-4ce4-b6c6-9af13f0f5429
     jinja: "Generate an article on the topic of {{[\n  \"Politics\",\n  \"Society\"\
       ,\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic] }} |||\n{{article}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      original_task: false
     name: article_from_topic
+    reference: ''
+  4ef96141-81c1-488c-92b9-5d35a3a12afa: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: 4ef96141-81c1-488c-92b9-5d35a3a12afa
+    jinja: 'Who is the author of the passage, which is related to {{ ["Politics",
+      "Society", "UK", "World", "Books"][topic] }}, below?
+
+
+      {{article}}
+
+      |||
+
+      {{ answer_choices[author].capitalize() }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article_with_topic_2
+    reference: ''
+  54e1f0ac-1e17-43bb-85ee-3f852fcccb10: !Template
+    answer_choices: Politics ||| Society ||| UK ||| World ||| Books
+    id: 54e1f0ac-1e17-43bb-85ee-3f852fcccb10
+    jinja: "What is the topic of this article?\n\n{{article}} \n|||\n{{answer_choices[topic]}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics: []
+      original_task: false
+    name: topic
+    reference: ''
+  66de6739-738e-4397-8c15-49ea1e1a6c6c: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: 66de6739-738e-4397-8c15-49ea1e1a6c6c
+    jinja: 'Identify the author of the passage below. The answer options are {% for
+      author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.
+
+
+      {{article}}
+
+      |||
+
+      {{ answer_choices[author].capitalize() }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article_2
+    reference: ''
+  93d06e87-f328-415d-8fda-f4732165736d: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: 93d06e87-f328-415d-8fda-f4732165736d
+    jinja: "You are in an examination, which requires you to associate the passage\
+      \ below to the author. The topic is about {{ [\"Politics\", \"Society\", \"\
+      UK\", \"World\", \"Books\"][topic] }}, and the possible authors are one of the\
+      \ following: {% for author in answer_choices[:-1] %} {{author.capitalize()}},\
+      \ {% endfor %} {{answer_choices[-1].capitalize()}}. What is the answer?\n\n\
+      Passage: {{ article }} \n|||\n{{ answer_choices[author].capitalize() }}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article_with_topic_3
+    reference: ''
+  b092f3f0-467c-4268-b450-b3c416824d56: !Template
+    answer_choices: null
+    id: b092f3f0-467c-4268-b450-b3c416824d56
+    jinja: "Generate an article based on the writing style of {{\n[\n  \"catherinebennett\"\
+      ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
+      ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
+      ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
+      \n] [author].capitalize()\n}} \n|||\n{{article}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      original_task: false
+    name: article_from_author
+    reference: ''
+  b89bb96c-e3c7-4e8a-beab-658800526864: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: b89bb96c-e3c7-4e8a-beab-658800526864
+    jinja: "Who wrote this article?\n\n{{article}} \n\n|||\n\n{{ answer_choices[author].capitalize()\
+      \ }}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article
+    reference: ''
+  d16d1263-17e7-411a-b28a-207a95d79afc: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: d16d1263-17e7-411a-b28a-207a95d79afc
+    jinja: 'Who is the author of the passage below? Choose from the following list:
+      {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor %}
+      {{answer_choices[-1].capitalize()}}. Hint: The topic is related to {{ ["Politics",
+      "Society", "UK", "World", "Books"][topic] }}.
+
+
+      {{article}}
+
+      |||
+
+      {{ answer_choices[author].capitalize() }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article_with_topic
     reference: ''

--- a/promptsource/templates/guardian_authorship/cross_topic_7/templates.yaml
+++ b/promptsource/templates/guardian_authorship/cross_topic_7/templates.yaml
@@ -2,20 +2,20 @@ dataset: guardian_authorship
 subset: cross_topic_7
 templates:
   53685e15-3901-41e0-a431-042333fedc5d: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: 53685e15-3901-41e0-a431-042333fedc5d
     jinja: 'Who could have authored this article based on the writing style? The answer
-      options are {% for author in answer_choices[:-1] %} {{author.capitalize()}},
-      {% endfor %} {{answer_choices[-1].capitalize()}}.
+      options are {{ answer_choices | join(", ") }}.
 
 
       {{article}} |||
 
-      {{ answer_choices[author].capitalize() }}'
+      {{ answer_choices[author] }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: true
@@ -24,12 +24,13 @@ templates:
   6752a104-6037-4c8d-9cc3-7b88b97e5142: !Template
     answer_choices: null
     id: 6752a104-6037-4c8d-9cc3-7b88b97e5142
-    jinja: "Generate an article based on the writing style of  {{\n[\n  \"catherinebennett\"\
-      ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
-      ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
-      ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author].capitalize()\n}}  on the topic of {{\n[\n  \"Politics\",\n  \"\
-      Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}}. |||\n{{article}}"
+    jinja: "Generate an article based on the writing style of {{\n[\n  \"Catherine\
+      \ Bennett\",\n  \"George Monbiot\",\n  \"Hugo Young\",\n  \"Jonathan Freedland\"\
+      ,\n  \"Martin Kettle\",\n  \"Mary Riddell\",\n  \"Nick Cohen\",\n  \"Peter Preston\"\
+      ,\n  \"Polly Toynbee\",\n  \"Roy Hattersley\",\n  \"Simon Hoggart\",\n  \"Will\
+      \ Hutton\",\n  \"Zoe Williams\"\n] [author]\n}} on the topic of {{\n[\n  \"\
+      Politics\",\n  \"Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n\
+      }}. |||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -42,7 +43,7 @@ templates:
     answer_choices: null
     id: 794dff9a-dd24-4e67-9cb9-c67773b3d09d
     jinja: "Generate an article on the topic of {{[\n  \"Politics\",\n  \"Society\"\
-      ,\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic] }} |||\n{{article}}"
+      ,\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic] }}. |||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -52,23 +53,23 @@ templates:
     name: article_from_topic
     reference: ''
   96a5ad6e-0d4e-4fc8-9429-79ef7e444e96: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: 96a5ad6e-0d4e-4fc8-9429-79ef7e444e96
-    jinja: 'Given the answer options of {% for author in answer_choices[:-1] %} {{author.capitalize()}},
-      {% endfor %} and {{answer_choices[-1].capitalize()}}, identify the author of
-      the passage, which is related to {{ ["Politics", "Society", "UK", "World", "Books"][topic]
-      }}, below.
+    jinja: 'Given the answer options of {{answer_choices[:-1] | join(", ")}} and {{answer_choices[-1]}},
+      identify the author of the passage, which is related to {{ ["Politics", "Society",
+      "UK", "World", "Books"][topic] }}, below.
 
 
       {{article}}
 
       |||
 
-      {{ answer_choices[author].capitalize() }}'
+      {{ answer_choices[author] }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: true
@@ -77,30 +78,30 @@ templates:
   9dcd1f54-5178-41a1-945e-96105b470e32: !Template
     answer_choices: Politics ||| Society ||| UK ||| World ||| Books
     id: 9dcd1f54-5178-41a1-945e-96105b470e32
-    jinja: "What is the topic of this article? The answer options are {% for topic\
-      \ in answer_choices[:-1] %} {{topic.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.\n\
-      \n{{article}} \n|||\n{{answer_choices[topic]}}"
+    jinja: "What is the topic of this article? The answer options are {{answer_choices|join(\"\
+      , \")}}.\n\n{{article}} \n|||\n{{answer_choices[topic]}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: false
     name: topic
     reference: ''
   9ffa7dc2-c8e5-4794-8d2c-671b68b007fc: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: 9ffa7dc2-c8e5-4794-8d2c-671b68b007fc
     jinja: 'Identify the author of the passage below by choosing from the author list
-      of {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor
-      %} {{answer_choices[-1].capitalize()}}.
+      of {{answer_choices|join(", ")}}.
 
 
       {{article}}
 
       |||
 
-      {{ answer_choices[author].capitalize() }}'
+      {{ answer_choices[author] }}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -109,16 +110,16 @@ templates:
     name: who_wrote_article_affirmative
     reference: ''
   adce32b8-d92a-4b29-908e-93fe86051dca: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: adce32b8-d92a-4b29-908e-93fe86051dca
     jinja: "You are in an examination, which requires you to associate the passage\
       \ below to the author. The topic is about {{ [\"Politics\", \"Society\", \"\
       UK\", \"World\", \"Books\"][topic] }}, and the possible authors are one of the\
-      \ following: {% for author in answer_choices[:-1] %} {{author.capitalize()}},\
-      \ {% endfor %} {{answer_choices[-1].capitalize()}}. What is the answer?\n\n\
-      Passage: {{ article }} \n|||\n{{ answer_choices[author].capitalize() }}"
+      \ following: {{answer_choices | join(\", \")}}. What is the answer?\n\nPassage:\
+      \ {{ article }} \n|||\n{{ answer_choices[author] }}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -129,11 +130,11 @@ templates:
   d89e8c33-35c4-4c0c-a6c9-52460ed20f7f: !Template
     answer_choices: null
     id: d89e8c33-35c4-4c0c-a6c9-52460ed20f7f
-    jinja: "Generate an article based on the writing style of {{\n[\n  \"catherinebennett\"\
-      ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
-      ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
-      ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author].capitalize()\n}} .\n|||\n{{article}}"
+    jinja: "Generate an article based on the writing style of {{\n[\n  \"Catherine\
+      \ Bennett\",\n  \"George Monbiot\",\n  \"Hugo Young\",\n  \"Jonathan Freedland\"\
+      ,\n  \"Martin Kettle\",\n  \"Mary Riddell\",\n  \"Nick Cohen\",\n  \"Peter Preston\"\
+      ,\n  \"Polly Toynbee\",\n  \"Roy Hattersley\",\n  \"Simon Hoggart\",\n  \"Will\
+      \ Hutton\",\n  \"Zoe Williams\"\n] [author]\n}} .\n|||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -143,30 +144,30 @@ templates:
     name: article_from_author
     reference: ''
   db77ee6b-d077-4831-82ca-596c9b5d3f39: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: db77ee6b-d077-4831-82ca-596c9b5d3f39
-    jinja: "Who wrote this article? The answer options are {% for author in answer_choices[:-1]\
-      \ %} {{author.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.\n\
-      \n{{article}} \n\n|||\n\n{{ answer_choices[author].capitalize() }}"
+    jinja: "Who wrote this article? The answer options are {{answer_choices|join(\"\
+      , \")}}.\n\n{{article}} \n\n|||\n\n{{ answer_choices[author] }}"
     metadata: !TemplateMetadata
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: true
     name: who_wrote_article
     reference: ''
   e6b9c224-1632-40da-8c69-76986da7015d: !Template
-    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
-      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
-      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    answer_choices: Catherine Bennett ||| George Monbiot ||| Hugo Young ||| Jonathan
+      Freedland ||| Martin Kettle ||| Mary Riddell ||| Nick Cohen ||| Peter Preston
+      ||| Polly Toynbee ||| Roy Hattersley ||| Simon Hoggart ||| Will Hutton ||| Zoe
+      Williams
     id: e6b9c224-1632-40da-8c69-76986da7015d
     jinja: "Who is the author of the passage below? Choose from the following list:\
-      \ {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor\
-      \ %} {{answer_choices[-1].capitalize()}}. \n\nHint: The topic is related to\
-      \ {{ [\"Politics\", \"Society\", \"UK\", \"World\", \"Books\"][topic] }}.\n\n\
-      {{article}}\n|||\n{{ answer_choices[author].capitalize() }}"
+      \ {{ answer_choices | join(\", \")}}. \n\nHint: The topic is related to {{ [\"\
+      Politics\", \"Society\", \"UK\", \"World\", \"Books\"][topic] }}.\n\n{{article}}\n\
+      |||\n{{ answer_choices[author] }}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:

--- a/promptsource/templates/guardian_authorship/cross_topic_7/templates.yaml
+++ b/promptsource/templates/guardian_authorship/cross_topic_7/templates.yaml
@@ -34,6 +34,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - BLEU
+      - ROUGE
       original_task: false
     name: article_from_author_topic
     reference: ''
@@ -46,6 +47,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - BLEU
+      - ROUGE
       original_task: false
     name: article_from_topic
     reference: ''
@@ -70,7 +72,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: who_wrote_article_with_topic_2
+    name: who_wrote_article_with_topic_affirmative
     reference: ''
   9dcd1f54-5178-41a1-945e-96105b470e32: !Template
     answer_choices: Politics ||| Society ||| UK ||| World ||| Books
@@ -104,7 +106,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: who_wrote_article_2
+    name: who_wrote_article_affirmative
     reference: ''
   adce32b8-d92a-4b29-908e-93fe86051dca: !Template
     answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
@@ -122,7 +124,7 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: who_wrote_article_with_topic_3
+    name: who_wrote_article_with_topic_exam
     reference: ''
   d89e8c33-35c4-4c0c-a6c9-52460ed20f7f: !Template
     answer_choices: null
@@ -136,6 +138,7 @@ templates:
       choices_in_prompt: false
       metrics:
       - BLEU
+      - ROUGE
       original_task: false
     name: article_from_author
     reference: ''
@@ -169,5 +172,5 @@ templates:
       metrics:
       - Accuracy
       original_task: true
-    name: who_wrote_article_with_topic
+    name: who_wrote_article_with_topic_hint
     reference: ''

--- a/promptsource/templates/guardian_authorship/cross_topic_7/templates.yaml
+++ b/promptsource/templates/guardian_authorship/cross_topic_7/templates.yaml
@@ -1,84 +1,171 @@
 dataset: guardian_authorship
 subset: cross_topic_7
 templates:
+  53685e15-3901-41e0-a431-042333fedc5d: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: 53685e15-3901-41e0-a431-042333fedc5d
+    jinja: 'Who could have authored this article based on the writing style?
+
+
+      {{article}} |||
+
+      {{ answer_choices[author].capitalize() }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: writing_style
+    reference: ''
   6752a104-6037-4c8d-9cc3-7b88b97e5142: !Template
     answer_choices: null
     id: 6752a104-6037-4c8d-9cc3-7b88b97e5142
-    jinja: "Who wrote this article and what is the article's topic?\n\n{{article}}\
-      \ |||\n{{[\n  \"catherinebennett\",\n  \"georgemonbiot\",\n  \"hugoyoung\",\n\
-      \  \"jonathanfreedland\",\n  \"martinkettle\",\n  \"maryriddell\",\n  \"nickcohen\"\
-      ,\n  \"peterpreston\",\n  \"pollytoynbee\",\n  \"royhattersley\",\n  \"simonhoggart\"\
-      ,\n  \"willhutton\",\n  \"zoewilliams\"\n][author]}} wrote this article on the\
-      \ topic of {{[\n  \"Politics\",\n  \"Society\",\n  \"UK\",\n  \"World\",\n \
-      \ \"Books\"\n][topic]}}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: who_what_article
-    reference: ''
-  794dff9a-dd24-4e67-9cb9-c67773b3d09d: !Template
-    answer_choices: null
-    id: 794dff9a-dd24-4e67-9cb9-c67773b3d09d
-    jinja: "Generate an article based on the writing style of {{\n[\n  \"catherinebennett\"\
-      ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
-      ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
-      ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author]\n}} |||\n{{article}}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: article_from_author
-    reference: ''
-  96a5ad6e-0d4e-4fc8-9429-79ef7e444e96: !Template
-    answer_choices: null
-    id: 96a5ad6e-0d4e-4fc8-9429-79ef7e444e96
-    jinja: "What is the topic of this article?\n\n{{article}} |||\n{{\n[\n  \"Politics\"\
-      ,\n  \"Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic]\n}}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: topic
-    reference: ''
-  9ffa7dc2-c8e5-4794-8d2c-671b68b007fc: !Template
-    answer_choices: null
-    id: 9ffa7dc2-c8e5-4794-8d2c-671b68b007fc
     jinja: "Generate an article based on the writing style of  {{\n[\n  \"catherinebennett\"\
       ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
       ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
       ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author]\n}}  on the topic of {{\n[\n  \"Politics\",\n  \"Society\",\n \
-      \ \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}} |||\n{{article}}"
+      \n] [author].capitalize()\n}}  on the topic of {{\n[\n  \"Politics\",\n  \"\
+      Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}} |||\n{{article}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      original_task: false
     name: article_from_author_topic
+    reference: ''
+  794dff9a-dd24-4e67-9cb9-c67773b3d09d: !Template
+    answer_choices: null
+    id: 794dff9a-dd24-4e67-9cb9-c67773b3d09d
+    jinja: "Generate an article on the topic of {{[\n  \"Politics\",\n  \"Society\"\
+      ,\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic] }} |||\n{{article}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      original_task: false
+    name: article_from_topic
+    reference: ''
+  96a5ad6e-0d4e-4fc8-9429-79ef7e444e96: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: 96a5ad6e-0d4e-4fc8-9429-79ef7e444e96
+    jinja: 'Who is the author of the passage, which is related to {{ ["Politics",
+      "Society", "UK", "World", "Books"][topic] }}, below?
+
+
+      {{article}}
+
+      |||
+
+      {{ answer_choices[author].capitalize() }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article_with_topic_2
+    reference: ''
+  9dcd1f54-5178-41a1-945e-96105b470e32: !Template
+    answer_choices: Politics ||| Society ||| UK ||| World ||| Books
+    id: 9dcd1f54-5178-41a1-945e-96105b470e32
+    jinja: "What is the topic of this article?\n\n{{article}} \n|||\n{{answer_choices[topic]}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics: []
+      original_task: false
+    name: topic
+    reference: ''
+  9ffa7dc2-c8e5-4794-8d2c-671b68b007fc: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: 9ffa7dc2-c8e5-4794-8d2c-671b68b007fc
+    jinja: 'Identify the author of the passage below. The answer options are {% for
+      author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.
+
+
+      {{article}}
+
+      |||
+
+      {{ answer_choices[author].capitalize() }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article_2
+    reference: ''
+  adce32b8-d92a-4b29-908e-93fe86051dca: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: adce32b8-d92a-4b29-908e-93fe86051dca
+    jinja: "You are in an examination, which requires you to associate the passage\
+      \ below to the author. The topic is about {{ [\"Politics\", \"Society\", \"\
+      UK\", \"World\", \"Books\"][topic] }}, and the possible authors are one of the\
+      \ following: {% for author in answer_choices[:-1] %} {{author.capitalize()}},\
+      \ {% endfor %} {{answer_choices[-1].capitalize()}}. What is the answer?\n\n\
+      Passage: {{ article }} \n|||\n{{ answer_choices[author].capitalize() }}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article_with_topic_3
     reference: ''
   d89e8c33-35c4-4c0c-a6c9-52460ed20f7f: !Template
     answer_choices: null
     id: d89e8c33-35c4-4c0c-a6c9-52460ed20f7f
-    jinja: "Who could have authored this article based on the writing style?\n\n{{article}}\
-      \ |||\n{{\n[\n  \"catherinebennett\",\n  \"georgemonbiot\",\n  \"hugoyoung\"\
-      ,\n  \"jonathanfreedland\",\n  \"martinkettle\",\n  \"maryriddell\",\n  \"nickcohen\"\
-      ,\n  \"peterpreston\",\n  \"pollytoynbee\",\n  \"royhattersley\",\n  \"simonhoggart\"\
-      ,\n  \"willhutton\",\n  \"zoewilliams\"\n][author]\n}}"
+    jinja: "Generate an article based on the writing style of {{\n[\n  \"catherinebennett\"\
+      ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
+      ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
+      ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
+      \n] [author].capitalize()\n}} \n|||\n{{article}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: writing_style
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      original_task: false
+    name: article_from_author
+    reference: ''
+  db77ee6b-d077-4831-82ca-596c9b5d3f39: !Template
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
+    id: db77ee6b-d077-4831-82ca-596c9b5d3f39
+    jinja: "Who wrote this article?\n\n{{article}} \n\n|||\n\n{{ answer_choices[author].capitalize()\
+      \ }}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article
     reference: ''
   e6b9c224-1632-40da-8c69-76986da7015d: !Template
-    answer_choices: null
+    answer_choices: catherinebennett ||| georgemonbiot ||| hugoyoung ||| jonathanfreedland
+      ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
+      ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: e6b9c224-1632-40da-8c69-76986da7015d
-    jinja: "Generate an article on the topic of {{[\n  \"Politics\",\n  \"Society\"\
-      ,\n  \"UK\",\n  \"World\",\n  \"Books\"\n][topic] }} |||\n{{article}}"
+    jinja: 'Who is the author of the passage below? Choose from the following list:
+      {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor %}
+      {{answer_choices[-1].capitalize()}}. Hint: The topic is related to {{ ["Politics",
+      "Society", "UK", "World", "Books"][topic] }}.
+
+
+      {{article}}
+
+      |||
+
+      {{ answer_choices[author].capitalize() }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: article_from_topic
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: who_wrote_article_with_topic
     reference: ''

--- a/promptsource/templates/guardian_authorship/cross_topic_7/templates.yaml
+++ b/promptsource/templates/guardian_authorship/cross_topic_7/templates.yaml
@@ -6,7 +6,9 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: 53685e15-3901-41e0-a431-042333fedc5d
-    jinja: 'Who could have authored this article based on the writing style?
+    jinja: 'Who could have authored this article based on the writing style? The answer
+      options are {% for author in answer_choices[:-1] %} {{author.capitalize()}},
+      {% endfor %} {{answer_choices[-1].capitalize()}}.
 
 
       {{article}} |||
@@ -27,7 +29,7 @@ templates:
       ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
       ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
       \n] [author].capitalize()\n}}  on the topic of {{\n[\n  \"Politics\",\n  \"\
-      Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}} |||\n{{article}}"
+      Society\",\n  \"UK\",\n  \"World\",\n  \"Books\"\n] [topic]\n}}. |||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -52,8 +54,10 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: 96a5ad6e-0d4e-4fc8-9429-79ef7e444e96
-    jinja: 'Who is the author of the passage, which is related to {{ ["Politics",
-      "Society", "UK", "World", "Books"][topic] }}, below?
+    jinja: 'Given the answer options of {% for author in answer_choices[:-1] %} {{author.capitalize()}},
+      {% endfor %} and {{answer_choices[-1].capitalize()}}, identify the author of
+      the passage, which is related to {{ ["Politics", "Society", "UK", "World", "Books"][topic]
+      }}, below.
 
 
       {{article}}
@@ -71,7 +75,9 @@ templates:
   9dcd1f54-5178-41a1-945e-96105b470e32: !Template
     answer_choices: Politics ||| Society ||| UK ||| World ||| Books
     id: 9dcd1f54-5178-41a1-945e-96105b470e32
-    jinja: "What is the topic of this article?\n\n{{article}} \n|||\n{{answer_choices[topic]}}"
+    jinja: "What is the topic of this article? The answer options are {% for topic\
+      \ in answer_choices[:-1] %} {{topic.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.\n\
+      \n{{article}} \n|||\n{{answer_choices[topic]}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics: []
@@ -83,8 +89,9 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: 9ffa7dc2-c8e5-4794-8d2c-671b68b007fc
-    jinja: 'Identify the author of the passage below. The answer options are {% for
-      author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.
+    jinja: 'Identify the author of the passage below by choosing from the author list
+      of {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor
+      %} {{answer_choices[-1].capitalize()}}.
 
 
       {{article}}
@@ -124,7 +131,7 @@ templates:
       ,\n  \"georgemonbiot\",\n  \"hugoyoung\",\n  \"jonathanfreedland\",\n  \"martinkettle\"\
       ,\n  \"maryriddell\",\n  \"nickcohen\",\n  \"peterpreston\",\n  \"pollytoynbee\"\
       ,\n  \"royhattersley\",\n  \"simonhoggart\",\n  \"willhutton\",\n  \"zoewilliams\"\
-      \n] [author].capitalize()\n}} \n|||\n{{article}}"
+      \n] [author].capitalize()\n}} .\n|||\n{{article}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -137,8 +144,9 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: db77ee6b-d077-4831-82ca-596c9b5d3f39
-    jinja: "Who wrote this article?\n\n{{article}} \n\n|||\n\n{{ answer_choices[author].capitalize()\
-      \ }}"
+    jinja: "Who wrote this article? The answer options are {% for author in answer_choices[:-1]\
+      \ %} {{author.capitalize()}}, {% endfor %} {{answer_choices[-1].capitalize()}}.\n\
+      \n{{article}} \n\n|||\n\n{{ answer_choices[author].capitalize() }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -151,17 +159,11 @@ templates:
       ||| martinkettle ||| maryriddell ||| nickcohen ||| peterpreston ||| pollytoynbee
       ||| royhattersley ||| simonhoggart ||| willhutton ||| zoewilliams
     id: e6b9c224-1632-40da-8c69-76986da7015d
-    jinja: 'Who is the author of the passage below? Choose from the following list:
-      {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor %}
-      {{answer_choices[-1].capitalize()}}. Hint: The topic is related to {{ ["Politics",
-      "Society", "UK", "World", "Books"][topic] }}.
-
-
-      {{article}}
-
-      |||
-
-      {{ answer_choices[author].capitalize() }}'
+    jinja: "Who is the author of the passage below? Choose from the following list:\
+      \ {% for author in answer_choices[:-1] %} {{author.capitalize()}}, {% endfor\
+      \ %} {{answer_choices[-1].capitalize()}}. \n\nHint: The topic is related to\
+      \ {{ [\"Politics\", \"Society\", \"UK\", \"World\", \"Books\"][topic] }}.\n\n\
+      {{article}}\n|||\n{{ answer_choices[author].capitalize() }}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:


### PR DESCRIPTION
Tasks:
- [X] add original tasks (≥ 5 original tasks)
- [X] add metrics
- [X] add answer choices to the field and into the prompts.
- [X] indicate answer choices in prompt if exists

Discussion:
~~Does it make sense to prompt without answer choices in the prompt? For instance, see prompt "who_wrote_article".~~ 

Edit: Reread the instructions and found my answer from instruction step 11.