### PR TITLE
Cleaned humicroedit

### DIFF
--- a/promptsource/templates/humicroedit/subtask-1/templates.yaml
+++ b/promptsource/templates/humicroedit/subtask-1/templates.yaml
@@ -1,27 +1,6 @@
 dataset: humicroedit
 subset: subtask-1
 templates:
-  43af1016-6d25-434d-b9b0-893706cda5d6: !Template
-    answer_choices: null
-    id: 43af1016-6d25-434d-b9b0-893706cda5d6
-    jinja: 'Please give a score between 0 and 3 denoting the funniness of the following
-      sentence. Your score should be something like {{"1.5"}}, where {{"0.0 means
-      not funny and 3.0 means funny"}}.
-
-
-      {{ original.replace(original[original.index("<"):original.index(">")+1], edit)
-      }}
-
-      |||
-
-      {{ (((5 * meanGrade) | round) / 5) }}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Other
-      original_task: true
-    name: example_score_edited_sent_affirmative
-    reference: ''
   692750f4-b4a2-4344-bc4d-e05daef47c25: !Template
     answer_choices: null
     id: 692750f4-b4a2-4344-bc4d-e05daef47c25
@@ -105,23 +84,6 @@ templates:
       original_task: true
     name: score_original_sent_edit_word_low_high
     reference: ''
-  93bd417d-a17f-460b-800c-5881ce752d98: !Template
-    answer_choices: null
-    id: 93bd417d-a17f-460b-800c-5881ce752d98
-    jinja: 'Rate on a scale from {{"0.0"}} (not funny) to {{"3.0"}} (hilarious) how
-      funny the sentence "{{ original.replace(original[original.index("<"):original.index(">")+1],
-      edit) }}" is.
-
-      |||
-
-      {{ (((5 * meanGrade) | round) / 5) }}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Other
-      original_task: true
-    name: rate_edited_sent
-    reference: ''
   a08cab27-06fb-4c96-b6b1-eb0533fe9b25: !Template
     answer_choices: null
     id: a08cab27-06fb-4c96-b6b1-eb0533fe9b25
@@ -171,26 +133,4 @@ templates:
       - Other
       original_task: true
     name: best_shot_rate_original_sent_edited_sent
-    reference: ''
-  c1511cfc-8ba8-4d10-98b7-1e576cf02588: !Template
-    answer_choices: null
-    id: c1511cfc-8ba8-4d10-98b7-1e576cf02588
-    jinja: 'I need to assign a score from {{"0.0"}} (not funny) to {{"3.0"}} (very
-      funny) that denotes how funny the following sentence is. What score should I
-      assign?
-
-
-      Sentence: {{ original.replace(original[original.index("<"):original.index(">")+1],
-      edit) }}
-
-
-      |||
-
-      {{ (((5 * meanGrade) | round) / 5) }}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: true
-      metrics:
-      - Other
-      original_task: true
-    name: assign_score_edited_sent
     reference: ''

--- a/promptsource/templates/humicroedit/subtask-1/templates.yaml
+++ b/promptsource/templates/humicroedit/subtask-1/templates.yaml
@@ -1,42 +1,6 @@
 dataset: humicroedit
 subset: subtask-1
 templates:
-  27c7a53c-d5b8-410d-affc-95ff59a89c03: !Template
-    answer_choices: null
-    id: 27c7a53c-d5b8-410d-affc-95ff59a89c03
-    jinja: 'Please rate how funny the sentence is from {{"0.0"}} to {{"3.0"}}.
-
-      Sentence: {{ original.replace(original[original.index("<"):original.index(">")+1],
-      edit) }}
-
-      |||
-
-      {{ (((5 * meanGrade) | round) / 5) }}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Other
-      original_task: true
-    name: rate_edited_sent_2
-    reference: ''
-  2d0e8f25-5680-4079-9a59-7b06329bd65a: !Template
-    answer_choices: null
-    id: 2d0e8f25-5680-4079-9a59-7b06329bd65a
-    jinja: 'Please rate how funny it is to replace "{{ original[original.index("<")+1:original.index("/>")]
-      }}" with "{{ edit }}" in the sentence "{{ original.replace(original[original.index("<"):original.index(">")+1],
-      original[original.index("<")+1:original.index("/>")]) }} " from {{"0.0"}} to
-      {{"3.0"}}.
-
-      |||
-
-      {{ (((5 * meanGrade) | round) / 5) }}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Other
-      original_task: true
-    name: rate_original_sent_edit_word
-    reference: ''
   43af1016-6d25-434d-b9b0-893706cda5d6: !Template
     answer_choices: null
     id: 43af1016-6d25-434d-b9b0-893706cda5d6
@@ -56,7 +20,7 @@ templates:
       metrics:
       - Other
       original_task: true
-    name: score_edited_sent
+    name: example_score_edited_sent_affirmative
     reference: ''
   692750f4-b4a2-4344-bc4d-e05daef47c25: !Template
     answer_choices: null
@@ -125,28 +89,6 @@ templates:
       original_task: true
     name: score_original_sent_edit_word
     reference: ''
-  8ae3f3c4-deb2-4a82-8a50-5f726b781e2a: !Template
-    answer_choices: null
-    id: 8ae3f3c4-deb2-4a82-8a50-5f726b781e2a
-    jinja: 'Please rate how funny the editd sentence is from {{"0.0"}} to {{"3.0"}}
-      compared to the original sentence.
-
-      Original: {{ original.replace(original[original.index("<"):original.index(">")+1],
-      original[original.index("<")+1:original.index("/>")]) }}
-
-      Edited: {{ original.replace(original[original.index("<"):original.index(">")+1],
-      edit) }}
-
-      |||
-
-      {{ (((5 * meanGrade) | round) / 5) }}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Other
-      original_task: true
-    name: rate_original_sent_edited_sent_2
-    reference: ''
   90ac629a-f670-4c43-bbf8-a9ef9021c0b3: !Template
     answer_choices: null
     id: 90ac629a-f670-4c43-bbf8-a9ef9021c0b3
@@ -154,21 +96,21 @@ templates:
       \ it is to replace \"{{ original[original.index(\"<\")+1:original.index(\"/>\"\
       )] }}\" with \"{{ edit }}\" in the sentence \"{{ original.replace(original[original.index(\"\
       <\"):original.index(\">\")+1], original[original.index(\"<\")+1:original.index(\"\
-      />\")]) }} \". \nWhat score should I assign?\n||| \n{{ (((5 * meanGrade) | round)\
-      \ / 5) }}"
+      />\")]) }} \". \nWhat score should I assign? A low score means not funny whereas\
+      \ a high score means very funny.\n||| \n{{ (((5 * meanGrade) | round) / 5) }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
       - Other
       original_task: true
-    name: score_original_sent_edit_word_2
+    name: score_original_sent_edit_word_low_high
     reference: ''
   93bd417d-a17f-460b-800c-5881ce752d98: !Template
     answer_choices: null
     id: 93bd417d-a17f-460b-800c-5881ce752d98
-    jinja: 'Rate on a scale from {{"0.0"}} to {{"3.0"}} how funny the sentence "{{
-      original.replace(original[original.index("<"):original.index(">")+1], edit)
-      }}" is.
+    jinja: 'Rate on a scale from {{"0.0"}} (not funny) to {{"3.0"}} (hilarious) how
+      funny the sentence "{{ original.replace(original[original.index("<"):original.index(">")+1],
+      edit) }}" is.
 
       |||
 
@@ -183,8 +125,7 @@ templates:
   a08cab27-06fb-4c96-b6b1-eb0533fe9b25: !Template
     answer_choices: null
     id: a08cab27-06fb-4c96-b6b1-eb0533fe9b25
-    jinja: 'Please give a score denoting the funniness of the following edited sentence
-      compared to the original sentence.
+    jinja: 'How funny is the following edited sentence compared to the original sentence?
 
       Original: {{ original.replace(original[original.index("<"):original.index(">")+1],
       original[original.index("<")+1:original.index("/>")]) }}
@@ -192,7 +133,7 @@ templates:
       Edited: {{ original.replace(original[original.index("<"):original.index(">")+1],
       edit) }}
 
-      Your score should be something like {{"1.5"}}, where {{"0.0 means not funny
+      Your answer should be something like {{"1.5"}}, where {{"0.0 means not funny
       and 3.0 means funny"}}.
 
       |||
@@ -203,13 +144,13 @@ templates:
       metrics:
       - Other
       original_task: true
-    name: score_original_sent_edited_sent_2
+    name: example_score_original_sent_edited_sent_interrogative
     reference: ''
   ac6a9fa1-0f23-4ee9-9bec-c6f9f8daf7a9: !Template
     answer_choices: null
     id: ac6a9fa1-0f23-4ee9-9bec-c6f9f8daf7a9
-    jinja: 'I need to assign a score from {{"0.0 to 3.0"}} that denotes how funny
-      the following edited sentence is compared to the original sentence:
+    jinja: 'Give your best shot to rate how funny the following edited sentence is
+      compared to the original sentence:
 
       Original: {{ original.replace(original[original.index("<"):original.index(">")+1],
       original[original.index("<")+1:original.index("/>")]) }}
@@ -217,7 +158,9 @@ templates:
       Edited: {{ original.replace(original[original.index("<"):original.index(">")+1],
       edit) }}
 
-      What score should I assign?
+      Use a scale of {{"0.0"}}, which denotes not funny, to {{"3.0"}}, which means
+      really hilarious.
+
 
       |||
 
@@ -227,82 +170,27 @@ templates:
       metrics:
       - Other
       original_task: true
-    name: score_original_sent_edited_sent
+    name: best_shot_rate_original_sent_edited_sent
     reference: ''
   c1511cfc-8ba8-4d10-98b7-1e576cf02588: !Template
     answer_choices: null
     id: c1511cfc-8ba8-4d10-98b7-1e576cf02588
-    jinja: 'I need to assign a score from {{"0.0 to 3.0"}} that denotes how funny
-      the following sentence is :
+    jinja: 'I need to assign a score from {{"0.0"}} (not funny) to {{"3.0"}} (very
+      funny) that denotes how funny the following sentence is. What score should I
+      assign?
 
-      {{ original.replace(original[original.index("<"):original.index(">")+1], edit)
-      }}
 
-      What score should I assign?
+      Sentence: {{ original.replace(original[original.index("<"):original.index(">")+1],
+      edit) }}
+
 
       |||
 
       {{ (((5 * meanGrade) | round) / 5) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Other
       original_task: true
     name: assign_score_edited_sent
-    reference: ''
-  c53bbbcb-6bbb-4279-bd55-e3c4f7baa828: !Template
-    answer_choices: null
-    id: c53bbbcb-6bbb-4279-bd55-e3c4f7baa828
-    jinja: 'Rate on a scale from {{"0.0"}} to {{"3.0"}} how funny the edited sentence
-      "{{ original.replace(original[original.index("<"):original.index(">")+1], edit)
-      }}" is compared to the sentence "{{ original.replace(original[original.index("<"):original.index(">")+1],
-      original[original.index("<")+1:original.index("/>")]) }}".
-
-      |||
-
-      {{ (((5 * meanGrade) | round) / 5) }}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Other
-      original_task: true
-    name: rate_original_sent_edited_sent
-    reference: ''
-  ce115e3d-f63c-4030-8c13-bd77721ef0f5: !Template
-    answer_choices: null
-    id: ce115e3d-f63c-4030-8c13-bd77721ef0f5
-    jinja: 'I need to know how funny the sentence is, and I am expecting a value between
-      0 (not funny) and 3 (very funny):
-
-      {{ original.replace(original[original.index("<"):original.index(">")+1], edit)
-      }}
-
-
-      |||
-
-      {{ (((5 * meanGrade) | round) / 5) }}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Other
-      original_task: true
-    name: know_funniness_edited_sent
-    reference: ''
-  fee13ce1-e03e-4dd2-9d7d-08c8fd8b74c7: !Template
-    answer_choices: null
-    id: fee13ce1-e03e-4dd2-9d7d-08c8fd8b74c7
-    jinja: 'Rate on a scale from {{"0.0"}} to {{"3.0"}} how funny it is to replace
-      "{{ original[original.index("<")+1:original.index("/>")] }}" with "{{ edit }}"
-      in the sentence "{{ original.replace(original[original.index("<"):original.index(">")+1],
-      original[original.index("<")+1:original.index("/>")]) }} ".
-
-      |||
-
-      {{ (((5 * meanGrade) | round) / 5) }}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Other
-      original_task: true
-    name: rate_sent_edit_word
     reference: ''

--- a/promptsource/templates/humicroedit/subtask-1/templates.yaml
+++ b/promptsource/templates/humicroedit/subtask-1/templates.yaml
@@ -6,17 +6,18 @@ templates:
     id: 27c7a53c-d5b8-410d-affc-95ff59a89c03
     jinja: 'Please rate how funny the sentence is from {{"0.0"}} to {{"3.0"}}.
 
-      {{ original.replace(original[original.index("<"):original.index(">")+1], edit)
-      }}
+      Sentence: {{ original.replace(original[original.index("<"):original.index(">")+1],
+      edit) }}
 
       |||
 
       {{ (((5 * meanGrade) | round) / 5) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: only_edited_sent_rate
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: rate_edited_sent_2
     reference: ''
   2d0e8f25-5680-4079-9a59-7b06329bd65a: !Template
     answer_choices: null
@@ -30,30 +31,32 @@ templates:
 
       {{ (((5 * meanGrade) | round) / 5) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: original_sent_edit_word_rate
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: rate_original_sent_edit_word
     reference: ''
   43af1016-6d25-434d-b9b0-893706cda5d6: !Template
     answer_choices: null
     id: 43af1016-6d25-434d-b9b0-893706cda5d6
-    jinja: 'Please give a score denoting the funniness of the following sentence.
+    jinja: 'Please give a score between 0 and 3 denoting the funniness of the following
+      sentence. Your score should be something like {{"1.5"}}, where {{"0.0 means
+      not funny and 3.0 means funny"}}.
+
 
       {{ original.replace(original[original.index("<"):original.index(">")+1], edit)
       }}
-
-      Your score should be something like {{"1.5"}}, where {{"0.0 means not funny,
-      1.0 means slightly funny, 2.0 means moderately funny and 3.0 means funny"}}.
 
       |||
 
       {{ (((5 * meanGrade) | round) / 5) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: only_edited_sent_examples
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: score_edited_sent
     reference: ''
   692750f4-b4a2-4344-bc4d-e05daef47c25: !Template
     answer_choices: null
@@ -62,19 +65,20 @@ templates:
       }}" with "{{ edit }}" in the sentence "{{ original.replace(original[original.index("<"):original.index(">")+1],
       original[original.index("<")+1:original.index("/>")]) }} ".
 
+
       Question: Can you give me a number from {{"0.0 to 3.0"}} that denotes how funny
       it is, where {{"0.0"}} means not funny and {{"3.0"}} means funny?
 
-      Answer:
 
       |||
 
       {{ (((5 * meanGrade) | round) / 5) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: original_sent_edit_word_funniness
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: know_funniness_original_sent_edit_word
     reference: ''
   6c6c7354-fcd5-4b0d-8672-671c639c25f5: !Template
     answer_choices: null
@@ -91,35 +95,35 @@ templates:
       Question: Can you give me a number from {{"0.0 to 3.0"}} that denotes how funny
       it is, where {{"0.0"}} means not funny and {{"3.0"}} means funny?
 
-      Answer:
-
       |||
 
       {{ (((5 * meanGrade) | round) / 5) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: original_sent_edited_sent_funniness
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: know_funniness_original_sent_edited_sent
     reference: ''
   759a11e7-5933-41a1-b803-f352eb385d28: !Template
     answer_choices: null
     id: 759a11e7-5933-41a1-b803-f352eb385d28
-    jinja: 'Please give a score denoting the funniness of replacing "{{ original[original.index("<")+1:original.index("/>")]
+    jinja: 'Please give a score between 0 (not funny) and 3 (very funny) denoting
+      the funniness of replacing "{{ original[original.index("<")+1:original.index("/>")]
       }}" with "{{ edit }}" in the sentence "{{ original.replace(original[original.index("<"):original.index(">")+1],
       original[original.index("<")+1:original.index("/>")]) }} ".
 
-      Your score should be something like {{"1.5"}}, where {{"0.0 means not funny,
-      1.0 means slightly funny, 2.0 means moderately funny and 3.0 means funny"}}.
 
       |||
 
+
       {{ (((5 * meanGrade) | round) / 5) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: original_sent_edit_word_examples
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: score_original_sent_edit_word
     reference: ''
   8ae3f3c4-deb2-4a82-8a50-5f726b781e2a: !Template
     answer_choices: null
@@ -137,10 +141,11 @@ templates:
 
       {{ (((5 * meanGrade) | round) / 5) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: original_sent_edited_sent_rate
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: rate_original_sent_edited_sent_2
     reference: ''
   90ac629a-f670-4c43-bbf8-a9ef9021c0b3: !Template
     answer_choices: null
@@ -152,10 +157,11 @@ templates:
       />\")]) }} \". \nWhat score should I assign?\n||| \n{{ (((5 * meanGrade) | round)\
       \ / 5) }}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: original_sent_edit_word_score
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: score_original_sent_edit_word_2
     reference: ''
   93bd417d-a17f-460b-800c-5881ce752d98: !Template
     answer_choices: null
@@ -168,10 +174,11 @@ templates:
 
       {{ (((5 * meanGrade) | round) / 5) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: only_edited_sent_rank
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: rate_edited_sent
     reference: ''
   a08cab27-06fb-4c96-b6b1-eb0533fe9b25: !Template
     answer_choices: null
@@ -185,17 +192,18 @@ templates:
       Edited: {{ original.replace(original[original.index("<"):original.index(">")+1],
       edit) }}
 
-      Your score should be something like {{"1.5"}}, where {{"0.0 means not funny,
-      1.0 means slightly funny, 2.0 means moderately funny and 3.0 means funny"}}.
+      Your score should be something like {{"1.5"}}, where {{"0.0 means not funny
+      and 3.0 means funny"}}.
 
       |||
 
       {{ (((5 * meanGrade) | round) / 5) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: original_sent_edited_sent_examples
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: score_original_sent_edited_sent_2
     reference: ''
   ac6a9fa1-0f23-4ee9-9bec-c6f9f8daf7a9: !Template
     answer_choices: null
@@ -215,10 +223,11 @@ templates:
 
       {{ (((5 * meanGrade) | round) / 5) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: original_sent_edited_sent_score
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: score_original_sent_edited_sent
     reference: ''
   c1511cfc-8ba8-4d10-98b7-1e576cf02588: !Template
     answer_choices: null
@@ -235,10 +244,11 @@ templates:
 
       {{ (((5 * meanGrade) | round) / 5) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: only_edited_sent_score
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: assign_score_edited_sent
     reference: ''
   c53bbbcb-6bbb-4279-bd55-e3c4f7baa828: !Template
     answer_choices: null
@@ -252,32 +262,31 @@ templates:
 
       {{ (((5 * meanGrade) | round) / 5) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: original_sent_edited_sent_rank
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: rate_original_sent_edited_sent
     reference: ''
   ce115e3d-f63c-4030-8c13-bd77721ef0f5: !Template
     answer_choices: null
     id: ce115e3d-f63c-4030-8c13-bd77721ef0f5
-    jinja: 'I need to know how funny the sentence is:
+    jinja: 'I need to know how funny the sentence is, and I am expecting a value between
+      0 (not funny) and 3 (very funny):
 
       {{ original.replace(original[original.index("<"):original.index(">")+1], edit)
       }}
 
-      Question: Can you give me a number from {{"0.0 to 3.0"}} that denotes how funny
-      it is, where {{"0.0"}} means not funny and {{"3.0"}} means funny?
-
-      Answer:
 
       |||
 
       {{ (((5 * meanGrade) | round) / 5) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: only_edited_sent_funniness
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: know_funniness_edited_sent
     reference: ''
   fee13ce1-e03e-4dd2-9d7d-08c8fd8b74c7: !Template
     answer_choices: null
@@ -291,8 +300,9 @@ templates:
 
       {{ (((5 * meanGrade) | round) / 5) }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: original_sent_edit_word_rank
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: rate_sent_edit_word
     reference: ''

--- a/promptsource/templates/humicroedit/subtask-2/templates.yaml
+++ b/promptsource/templates/humicroedit/subtask-2/templates.yaml
@@ -8,7 +8,7 @@ templates:
       original1[original1.index("<")+1:original1.index("/>")]) }}", is it more humorous
       to replace "{{ original1[original1.index("<")+1:original1.index("/>")] }}" with
       "{{ edit1 }}", or to replace "{{ original2[original2.index("<")+1:original2.index("/>")]
-      }}" with "{{ edit2 }}", or are both equally humorous?
+      }}" with "{{ edit2 }}", or are both equally hilarious?
 
       {{ answer_choices[1] }}. replace "{{ original1[original1.index("<")+1:original1.index("/>")]
       }}" with "{{ edit1 }}"
@@ -16,7 +16,7 @@ templates:
       {{ answer_choices[2] }}. replace "{{ original2[original2.index("<")+1:original2.index("/>")]
       }}" with "{{ edit2 }}"
 
-      {{ answer_choices[0] }}. both equally humorous
+      {{ answer_choices[0] }}. both equally hilarious
 
       |||
 
@@ -36,7 +36,8 @@ templates:
       />\")]) }}.\nEdited sentence A: {{ original1.replace(original1[original1.index(\"\
       <\"):original1.index(\">\")+1], edit1) }}.\nEdited sentence B: {{ original2.replace(original2[original2.index(\"\
       <\"):original2.index(\">\")+1], edit2) }}.\nThere are two edited sentences based\
-      \ on the original sentence, which is more humorous or equally humorous? \n{{answer_choices[1]}}.\
+      \ on the original sentence, which is more humorous ({{answer_choices[1]}} or\
+      \ {{answer_choices[2]}}) or are they equally humorous? \n{{answer_choices[1]}}.\
       \ Edited sentence A\n{{answer_choices[2]}}. Edited sentence B\n{{answer_choices[0]}}.\
       \ Equal\n|||\n{{ answer_choices[label] }}"
     metadata: !TemplateMetadata
@@ -66,7 +67,8 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - Accuracy
+      - BLEU
+      - ROUGE
       original_task: true
     name: only_edited_sentences_text
     reference: ''
@@ -79,7 +81,7 @@ templates:
       }}" with "{{ edit1 }}", and the second is to replace "{{ original2[original2.index("<")+1:original2.index("/>")]
       }}" with "{{ edit2 }}".
 
-      Which strategy is more humorous or equally humorous?
+      Is the first strategy more humorous or the second, or are they equally funny?
 
       {{ answer_choices[1] }}. The first strategy
 
@@ -130,7 +132,7 @@ templates:
     answer_choices: equal ||| A ||| B
     id: 88054771-74d2-481f-91f1-c078a2bda5b9
     jinja: 'Which of the following sentences is more humorous? If they are equally
-      humorous, please answer "{{ answer_choices[0] }}".
+      funny, please answer "{{ answer_choices[0] }}".
 
       {{ answer_choices[1] }}. {{ original1.replace(original1[original1.index("<"):original1.index(">")+1],
       edit1) }}
@@ -187,7 +189,7 @@ templates:
       {{ edit1 }}\".\nThe second is to replace \"{{ original2[original2.index(\"<\"\
       )+1:original2.index(\"/>\")] }}\" with \"{{ edit2 }}\".\nWhich strategy is more\
       \ humorous (respond with \"{{answer_choices[1]}}\" or \"{{answer_choices[2]}}\"\
-      ) or equally humorous (if so, respond with \"{{answer_choices[0]}}\")? \n|||\n\
+      ) or equally funny (if so, respond with \"{{answer_choices[0]}}\")? \n|||\n\
       {{ answer_choices[label] }}"
     metadata: !TemplateMetadata
       choices_in_prompt: true

--- a/promptsource/templates/humicroedit/subtask-2/templates.yaml
+++ b/promptsource/templates/humicroedit/subtask-2/templates.yaml
@@ -10,23 +10,22 @@ templates:
       "{{ edit1 }}", or to replace "{{ original2[original2.index("<")+1:original2.index("/>")]
       }}" with "{{ edit2 }}", or are both equally humorous?
 
-      A. replace "{{ original1[original1.index("<")+1:original1.index("/>")] }}" with
-      "{{ edit1 }}"
+      {{ answer_choices[1] }}. replace "{{ original1[original1.index("<")+1:original1.index("/>")]
+      }}" with "{{ edit1 }}"
 
-      B. replace "{{ original2[original2.index("<")+1:original2.index("/>")] }}" with
-      "{{ edit2 }}"
+      {{ answer_choices[2] }}. replace "{{ original2[original2.index("<")+1:original2.index("/>")]
+      }}" with "{{ edit2 }}"
 
-      C. both equally humorous
-
-      The answer is
+      {{ answer_choices[0] }}. both equally humorous
 
       |||
 
       {{ answer_choices[label] }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
     name: original_sent_edit_words_qa_id
     reference: ''
   49c71a8a-97af-465c-af04-36f08884e568: !Template
@@ -37,20 +36,21 @@ templates:
       />\")]) }}.\nEdited sentence A: {{ original1.replace(original1[original1.index(\"\
       <\"):original1.index(\">\")+1], edit1) }}.\nEdited sentence B: {{ original2.replace(original2[original2.index(\"\
       <\"):original2.index(\">\")+1], edit2) }}.\nThere are two edited sentences based\
-      \ on the original sentence, which is more humorous or equally humorous? \nA.\
-      \ Edited sentence A\nB. Edited sentence B\nC. Equal\nThe answer is\n|||\n{{\
-      \ answer_choices[label] }}"
+      \ on the original sentence, which is more humorous or equally humorous? \n{{answer_choices[1]}}.\
+      \ Edited sentence A\n{{answer_choices[2]}}. Edited sentence B\n{{answer_choices[0]}}.\
+      \ Equal\n|||\n{{ answer_choices[label] }}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
     name: original_sent_edited_sentences_qa_id
     reference: ''
   67dc6d7e-dcbc-4444-9cde-6a8f8a0d2aa4: !Template
     answer_choices: null
     id: 67dc6d7e-dcbc-4444-9cde-6a8f8a0d2aa4
     jinja: 'Which of the following sentences is more humorous? If they are equally
-      humorous, please answer "equal".
+      humorous, please answer "equal". Otherwise, type the sentence into the answer.
 
       - {{ original1.replace(original1[original1.index("<"):original1.index(">")+1],
       edit1) }}
@@ -64,9 +64,10 @@ templates:
       edit1), original2.replace(original2[original2.index("<"):original2.index(">")+1],
       edit2)][label] }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
     name: only_edited_sentences_text
     reference: ''
   6d576e77-df98-47cd-b92e-c87a56190be4: !Template
@@ -80,21 +81,20 @@ templates:
 
       Which strategy is more humorous or equally humorous?
 
-      A. The first strategy
+      {{ answer_choices[1] }}. The first strategy
 
-      B. The second strategy
+      {{ answer_choices[2] }}. The second strategy
 
-      C. Equal
-
-      The answer is
+      {{ answer_choices[0] }}. Both are equally funny
 
       |||
 
       {{ answer_choices[label] }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
     name: original_sent_edit_words_qa_strategy_id
     reference: ''
   794ee65f-df0a-4448-8eac-20f757a8918d: !Template
@@ -110,42 +110,42 @@ templates:
 
       Which sentence is more humorous?
 
-      A. Sentence 1
+      {{ answer_choices[1] }}. Sentence 1
 
-      B. Sentence 2
+      {{ answer_choices[2] }}. Sentence 2
 
-      C. Equal
-
-      The answer is
+      {{ answer_choices[0] }}. Equal
 
       |||
 
       {{ answer_choices[label] }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
     name: only_edited_sentences_QA_id
     reference: ''
   88054771-74d2-481f-91f1-c078a2bda5b9: !Template
     answer_choices: equal ||| A ||| B
     id: 88054771-74d2-481f-91f1-c078a2bda5b9
     jinja: 'Which of the following sentences is more humorous? If they are equally
-      humorous, please answer "equal".
+      humorous, please answer "{{ answer_choices[0] }}".
 
-      A. {{ original1.replace(original1[original1.index("<"):original1.index(">")+1],
+      {{ answer_choices[1] }}. {{ original1.replace(original1[original1.index("<"):original1.index(">")+1],
       edit1) }}
 
-      B. {{ original2.replace(original2[original2.index("<"):original2.index(">")+1],
+      {{ answer_choices[2] }}. {{ original2.replace(original2[original2.index("<"):original2.index(">")+1],
       edit2) }}
 
       |||
 
       {{ answer_choices[label] }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
     name: only_edited_sentences_id
     reference: ''
   8e5f09ae-27bc-4b34-b20e-6bc6672a2c1a: !Template
@@ -161,62 +161,56 @@ templates:
 
       Which sentence is more humorous?
 
-      - Sentence 1
+      - {{ answer_choices[1] }}
 
-      - Sentence 2
+      - {{ answer_choices[2] }}
 
-      - Equal
-
-      The answer is
+      - {{ answer_choices[0] }}
 
       |||
 
       {{ answer_choices[label] }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
     name: only_edited_sentences_QA_text
     reference: ''
   b9e3fe90-d328-44a8-bb6e-212f600a2050: !Template
-    answer_choices: Equal ||| Fisrt ||| Second
+    answer_choices: Equal ||| First ||| Second
     id: b9e3fe90-d328-44a8-bb6e-212f600a2050
-    jinja: 'Given an original sentence "{{ original1.replace(original1[original1.index("<"):original1.index(">")+1],
-      original1[original1.index("<")+1:original1.index("/>")]) }}", we have two replacement
-      strategies:
-
-      The first is to replace "{{ original1[original1.index("<")+1:original1.index("/>")]
-      }}" with "{{ edit1 }}".
-
-      The second is to replace "{{ original2[original2.index("<")+1:original2.index("/>")]
-      }}" with "{{ edit2 }}".
-
-      Which strategy is more humorous or equally humorous?
-
-      |||
-
-      {{ answer_choices[label] }}'
+    jinja: "Given an original sentence \"{{ original1.replace(original1[original1.index(\"\
+      <\"):original1.index(\">\")+1], original1[original1.index(\"<\")+1:original1.index(\"\
+      />\")]) }}\", we have two replacement strategies:\nThe first is to replace \"\
+      {{ original1[original1.index(\"<\")+1:original1.index(\"/>\")] }}\" with \"\
+      {{ edit1 }}\".\nThe second is to replace \"{{ original2[original2.index(\"<\"\
+      )+1:original2.index(\"/>\")] }}\" with \"{{ edit2 }}\".\nWhich strategy is more\
+      \ humorous (respond with \"{{answer_choices[1]}}\" or \"{{answer_choices[2]}}\"\
+      ) or equally humorous (if so, respond with \"{{answer_choices[0]}}\")? \n|||\n\
+      {{ answer_choices[label] }}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
     name: original_sent_edit_words_qa_strategy
     reference: ''
   ec92a63f-7d82-48f0-a9e4-8e99dd5a0bb0: !Template
-    answer_choices: Equal ||| First ||| Second
+    answer_choices: Equally funny ||| First ||| Second
     id: ec92a63f-7d82-48f0-a9e4-8e99dd5a0bb0
-    jinja: 'Given an original sentence "{{ original1.replace(original1[original1.index("<"):original1.index(">")+1],
-      original1[original1.index("<")+1:original1.index("/>")]) }}", we have two edited
-      sentences. The first is "{{ original1.replace(original1[original1.index("<"):original1.index(">")+1],
-      edit1) }}", and the second is "{{ original2.replace(original2[original2.index("<"):original2.index(">")+1],
-      edit2) }}". Which edited sentence is more humorous or equally humorous?
-
-      |||
-
-      {{ answer_choices[label] }}'
+    jinja: "Given an original sentence \"{{ original1.replace(original1[original1.index(\"\
+      <\"):original1.index(\">\")+1], original1[original1.index(\"<\")+1:original1.index(\"\
+      />\")]) }}\", we have two edited sentences. The first is \"{{ original1.replace(original1[original1.index(\"\
+      <\"):original1.index(\">\")+1], edit1) }}\", and the second is \"{{ original2.replace(original2[original2.index(\"\
+      <\"):original2.index(\">\")+1], edit2) }}\". \n\nWhich edited sentence is more\
+      \ humorous (answer with \"{{answer_choices[1]}}\" or \"{{answer_choices[2]}}\"\
+      ) or equally humorous (if so, answer 'Equally funny')?\n|||\n{{ answer_choices[label]\
+      \ }}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
     name: original_sent_edited_sentences_qa
     reference: ''

--- a/promptsource/templates/humicroedit/subtask-2/templates.yaml
+++ b/promptsource/templates/humicroedit/subtask-2/templates.yaml
@@ -47,31 +47,6 @@ templates:
       original_task: true
     name: original_sent_edited_sentences_qa_id
     reference: ''
-  67dc6d7e-dcbc-4444-9cde-6a8f8a0d2aa4: !Template
-    answer_choices: null
-    id: 67dc6d7e-dcbc-4444-9cde-6a8f8a0d2aa4
-    jinja: 'Which of the following sentences is more humorous? If they are equally
-      humorous, please answer "equal". Otherwise, type the sentence into the answer.
-
-      - {{ original1.replace(original1[original1.index("<"):original1.index(">")+1],
-      edit1) }}
-
-      - {{ original2.replace(original2[original2.index("<"):original2.index(">")+1],
-      edit2) }}
-
-      |||
-
-      {{ ["equal", original1.replace(original1[original1.index("<"):original1.index(">")+1],
-      edit1), original2.replace(original2[original2.index("<"):original2.index(">")+1],
-      edit2)][label] }}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - BLEU
-      - ROUGE
-      original_task: true
-    name: only_edited_sentences_text
-    reference: ''
   6d576e77-df98-47cd-b92e-c87a56190be4: !Template
     answer_choices: C ||| A ||| B
     id: 6d576e77-df98-47cd-b92e-c87a56190be4


### PR DESCRIPTION
On top of just cleaning the existing prompts, here are some decisions I've made:
- [X] In subtask 1, I judge if the task follows the original task based on its usage of regression metrics (in this case, "Other). 
- [X] In subtask 1, I remove some templates that have minimal changes in surface-form wordings.
- [X] In subtask 2, if the prompt requires the model to type out the full sentence (even though it is a multiple choice answer), I would indicate that answer choices not in template. This is in prompt `only_edited_sentences_text`. In this case, I set the metrics as BLEU and ROUGE.
- [X] rename templates.

Discussion
For the regression tasks in subtask 1, I do not put a tick for the "Choices in Template?" even though I include the text of "0.0 (not funny) to 3.0 (very funny)" because to me, those are not answer *choices*.