### PR TITLE
QA_zre cleaning and added templates

### DIFF
--- a/promptsource/templates/qa_zre/templates.yaml
+++ b/promptsource/templates/qa_zre/templates.yaml
@@ -3,10 +3,9 @@ templates:
   2d6b6ec6-4cba-4a07-a0d1-f6b7cb103281: !Template
     answer_choices: null
     id: 2d6b6ec6-4cba-4a07-a0d1-f6b7cb103281
-    jinja: 'Extract the appropriate relation from the following question
+    jinja: 'The following question is asking about a specific relation. What is this relation?
 
-
-      {{question}} |||
+      Question: {{question}} |||
 
       {{relation}}'
     metadata: !TemplateMetadata
@@ -19,14 +18,29 @@ templates:
   5a970b88-53a0-4148-b45e-7ac410df263f: !Template
     answer_choices: null
     id: 5a970b88-53a0-4148-b45e-7ac410df263f
-    jinja: "{% if answers|length > 0 %}\nWhat is a possible question that can be generated\
-      \ from the following context and answer(s)?\n\n{{context}} \n\n{{answers|join(\"\
-      , \")}} |||\n{{question|replace(\"XXX\",subject)}} \n\n{% endif %} "
+    jinja: 'Based on the context below, please answer the question: "{{question.replace("XXX",subject)}}".
+     If the context is not sufficient to answer, please write "unanswerable" instead.
+
+     Context: {{context}}
+
+      |||
+
+      {% if answers|length > 0 %}
+
+      {{answers|choice}}
+
+      {% else %}
+
+      unanswerable
+
+      {% endif %}
+    '
     metadata: !TemplateMetadata
       choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: possible_qn_with_answer
+      metrics:
+      - Other
+      original_task: true
+    name: based_on_context
     reference: ''
   6368de04-070a-4f67-a8bf-fd6d2c07d401: !Template
     answer_choices: null
@@ -40,22 +54,23 @@ templates:
 
       {{subject}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: false
     name: subject
     reference: ''
   8f76743d-6486-4ae1-8bc8-ae644e3c54aa: !Template
     answer_choices: null
     id: 8f76743d-6486-4ae1-8bc8-ae644e3c54aa
-    jinja: 'Extract the appropriate relation from the following question
+    jinja: 'Extract the appropriate relation from the following question about {{subject}}
 
 
       {{question|replace("XXX",subject)}} |||
 
       {{relation}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
+      choices_in_prompt: false
       metrics:
         - Accuracy
       original_task: false
@@ -66,20 +81,117 @@ templates:
     id: b2195890-a3c5-4e33-be4a-5e53af75e6dd
     jinja: '
 
+      You will find below a context and a question. Please answer the question or write "unanswerable" if the question
+      cannot be answered using the context.
+
+      Context: {{context}}
+
+      Question: {{question.replace("XXX",subject)}} |||
+
       {% if answers|length > 0 %}
 
+      {{answers|choice}}
 
-      {{context}}
+      {% else %}
 
-      {{question.replace("XXX",subject)}} |||
-
-      {{answers|join(", ")}}
-
+      unanswerable
 
       {% endif %} '
+
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: true
-    name: qa
+    name: qa_including_unanswerable
+    reference: ''
+  b2195890-a3c5-4e33-be4a-5e53af75e7dd: !Template
+    answer_choices: null
+    id: b2195890-a3c5-4e33-be4a-5e53af75e7dd
+    jinja: '
+      Question: {{question.replace("XXX",subject)}}
+
+      Context: {{context}}
+
+      Please answer the question above using a passage present in the context. If no passage is a good answer for the
+      question, please write "unanswerable" instead.
+
+      |||
+
+      {% if answers|length > 0 %}
+
+      {{answers|choice}}
+
+      {% else %}
+
+      unanswerable
+
+      {% endif %} '
+
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: using_a_passage
+    reference: ''
+  b2195890-a3c5-4e33-be4a-5e53af75e8dd: !Template
+    answer_choices: null
+    id: b2195890-a3c5-4e33-be4a-5e53af75e8dd
+    jinja: '
+      Question: {{question.replace("XXX",subject)}}
+
+      Context: {{context}}
+
+      Please copy the span in the context that best answers the question. If there is no such span, please output
+      "unanswerable" instead.
+
+      |||
+
+      {% if answers|length > 0 %}
+
+      {{answers|choice}}
+
+      {% else %}
+
+      unanswerable
+
+      {% endif %} '
+
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: copy_the_span
+    reference: ''
+  b2195890-a3c5-4e33-be4a-5e53af75e9dd: !Template
+    answer_choices: null
+    id: b2195890-a3c5-4e33-be4a-5e53af75e9dd
+    jinja: '
+      Question: {{question.replace("XXX",subject)}}
+
+      Context: {{context}}
+
+      The following context may contain an answer to the question. If it does, please copy the span that best
+      answers it. If it does not, mention that the question is "unanswerable" using the context.
+
+      |||
+
+      {% if answers|length > 0 %}
+
+      {{answers|choice}}
+
+      {% else %}
+
+      unanswerable
+
+      {% endif %} '
+
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: may_contain
     reference: ''

--- a/promptsource/templates/qa_zre/templates.yaml
+++ b/promptsource/templates/qa_zre/templates.yaml
@@ -10,10 +10,11 @@ templates:
 
       {{relation}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
       original_task: false
-    name: relation
+    name: extract_relation
     reference: https://www.aclweb.org/anthology/K17-1034.pdf
   5a970b88-53a0-4148-b45e-7ac410df263f: !Template
     answer_choices: null
@@ -55,7 +56,8 @@ templates:
       {{relation}}'
     metadata: !TemplateMetadata
       choices_in_prompt: null
-      metrics: []
+      metrics:
+        - Accuracy
       original_task: false
     name: relation2
     reference: ''


### PR DESCRIPTION
Some notes on this dataset / PR:

- I added 4 templates that fit the original task and modified an existing one to better fit it.

- Removed the template on generating the question because:
1. It was generative and very open-ended
2. It was not defined for null answers

- I kept the 2 templates on relation, though I think those are not very natural. Happy to remove them depending on other people's thoughts: 
An example:
Prompt:
"The following question is asking about a specific relation. What is this
relation?
Question: Who did XXX serve for?"
Expected result: "military branch"

- The original task has potentially multiple answer spans. The instructions (5.) suggest that we should use choice, but this will make evaluation difficult as the metric is on all possible spans.
