### PR TITLE
Fever::clean-and-new-prompt

### DIFF
--- a/promptsource/templates/fever/v1.0/templates.yaml
+++ b/promptsource/templates/fever/v1.0/templates.yaml
@@ -19,7 +19,7 @@ templates:
     jinja: "I've heard that {{claim}} Is this correct?\n|||\n{{\n{\"SUPPORTS\": \"\
       Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: true
+      choices_in_prompt: false
       metrics:
       - Accuracy
       original_task: false
@@ -45,7 +45,7 @@ templates:
     jinja: "Is this statement correct? {{claim}} ||| \n{{\n{\"SUPPORTS\": \"Yes\"\
       ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: true
+      choices_in_prompt: false
       metrics:
       - Accuracy
       original_task: false
@@ -82,7 +82,7 @@ templates:
     jinja: "\"{{claim}}\", I have heard. Correct?\n|||\n{{\n{\"SUPPORTS\": \"Yes\"\
       ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: true
+      choices_in_prompt: false
       metrics:
       - Accuracy
       original_task: false

--- a/promptsource/templates/fever/v1.0/templates.yaml
+++ b/promptsource/templates/fever/v1.0/templates.yaml
@@ -2,10 +2,11 @@ dataset: fever
 subset: v1.0
 templates:
   0870481e-e5d1-43a1-821e-b11c6bfd2483: !Template
-    answer_choices: Yes|||No
+    answer_choices: Yes|||No|||Not sure
     id: 0870481e-e5d1-43a1-821e-b11c6bfd2483
-    jinja: "{{claim}} Is this true?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
-      : \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
+    jinja: "{{claim}} Is this true?\n|||\n{% if label != \"\" %}\n{{\n{\"SUPPORTS\"\
+      : \"Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"Not sure\"\n}[label]\n\
+      }}\n{% endif %}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -13,37 +14,26 @@ templates:
       original_task: false
     name: cbqa_fever_postprompt
     reference: CBQA fever, prompt after claim
-  17967f69-187f-4c98-9c32-624736e04412: !Template
-    answer_choices: Yes|||No
-    id: 17967f69-187f-4c98-9c32-624736e04412
-    jinja: "I've heard that {{claim}} Is this correct?\n|||\n{{\n{\"SUPPORTS\": \"\
-      Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Accuracy
-      original_task: false
-    name: cbqa_fever_dialog_style_surrounded
-    reference: CBQA fever, like a conversation, with prompts surrounding claim
   51c55af8-1996-4cb2-88a1-ca7ddb8f9e11: !Template
     answer_choices: Yes|||No|||Not Sure
     id: 51c55af8-1996-4cb2-88a1-ca7ddb8f9e11
     jinja: "I've heard that {{claim}} Is this correct? Yes, No or Not Sure?\n|||\n\
-      {{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\
-      Not Sure\"\n}[label]\n}}"
+      {% if label != \"\" %}\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\": \"No\",\n\
+      \"NOT ENOUGH INFO\": \"Not Sure\"\n}[label]\n}}\n{% endif %}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
       - Accuracy
-      original_task: true
+      original_task: false
     name: cbqa_fever_dialog_style_surrounded_all_class
     reference: CBQA fever, like a conversation, with prompts surrounding claim, all
       class included.
   6cc8f145-3fb4-43a9-aaf1-8c25dd6e2cdf: !Template
-    answer_choices: Yes|||No
+    answer_choices: Yes|||No|||Unsure
     id: 6cc8f145-3fb4-43a9-aaf1-8c25dd6e2cdf
-    jinja: "Is this statement correct? {{claim}} ||| \n{{\n{\"SUPPORTS\": \"Yes\"\
-      ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
+    jinja: "Is this statement correct? {{claim}} ||| \n{% if label != \"\" %}\n{{\n\
+      {\"SUPPORTS\": \"Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"Unsure\"\
+      \n}[label]\n}}\n{% endif %}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -52,10 +42,11 @@ templates:
     name: cbqa_fever_preprompt
     reference: Closed-book QA from only the claim, prompt before the content
   948f41ab-e6bb-4de6-af3e-7f0b5d5f39a8: !Template
-    answer_choices: Yes|||No
+    answer_choices: Yes|||No|||Maybe
     id: 948f41ab-e6bb-4de6-af3e-7f0b5d5f39a8
-    jinja: "\"{{claim}}\" Yes or no?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
-      : \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
+    jinja: "\"{{claim}}\" Yes, no, maybe?\n|||\n{% if label != \"\" %}\n{{\n{\"SUPPORTS\"\
+      : \"Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"Maybe\"\n}[label]\n\
+      }}\n{% endif %}\n"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -67,24 +58,12 @@ templates:
     answer_choices: Yes|||No|||Not Sure
     id: b1d8f035-c3af-41a8-b0b8-1604f9dc00ff
     jinja: "\"{{claim}}\", I have heard. Is this Correct? Yes, No or Not Sure?\n|||\n\
-      {{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\
-      Not Sure\"\n}[label]\n}}"
+      {% if label != \"\" %}\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\": \"No\",\n\
+      \"NOT ENOUGH INFO\": \"Not Sure\"\n}[label]\n}}\n{% endif %}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
       - Accuracy
-      original_task: true
+      original_task: false
     name: cbqa_fever_dialog_style_postprompt_all_class
     reference: CBQA fever, like a conversation, prompt after output. Includes 3 class.
-  b888ac7f-7482-4b5b-b94d-1ee096eefee5: !Template
-    answer_choices: Yes|||No
-    id: b888ac7f-7482-4b5b-b94d-1ee096eefee5
-    jinja: "\"{{claim}}\", I have heard. Correct?\n|||\n{{\n{\"SUPPORTS\": \"Yes\"\
-      ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Accuracy
-      original_task: false
-    name: cbqa_fever_dialog_style_postprompt
-    reference: CBQA fever, like a conversation, prompt after output

--- a/promptsource/templates/fever/v1.0/templates.yaml
+++ b/promptsource/templates/fever/v1.0/templates.yaml
@@ -2,57 +2,89 @@ dataset: fever
 subset: v1.0
 templates:
   0870481e-e5d1-43a1-821e-b11c6bfd2483: !Template
-    answer_choices: null
+    answer_choices: Yes|||No
     id: 0870481e-e5d1-43a1-821e-b11c6bfd2483
     jinja: "{{claim}} Is this true?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
       : \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
       original_task: false
     name: cbqa_fever_postprompt
     reference: CBQA fever, prompt after claim
   17967f69-187f-4c98-9c32-624736e04412: !Template
-    answer_choices: null
+    answer_choices: Yes|||No
     id: 17967f69-187f-4c98-9c32-624736e04412
     jinja: "I've heard that {{claim}} Is this correct?\n|||\n{{\n{\"SUPPORTS\": \"\
       Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: false
     name: cbqa_fever_dialog_style_surrounded
     reference: CBQA fever, like a conversation, with prompts surrounding claim
+  51c55af8-1996-4cb2-88a1-ca7ddb8f9e11: !Template
+    answer_choices: Yes|||No|||Not Sure
+    id: 51c55af8-1996-4cb2-88a1-ca7ddb8f9e11
+    jinja: "I've heard that {{claim}} Is this correct? Yes, No or Not Sure?\n|||\n\
+      {{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\
+      Not Sure\"\n}[label]\n}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: cbqa_fever_dialog_style_surrounded_all_class
+    reference: CBQA fever, like a conversation, with prompts surrounding claim, all
+      class included.
   6cc8f145-3fb4-43a9-aaf1-8c25dd6e2cdf: !Template
-    answer_choices: null
+    answer_choices: Yes|||No
     id: 6cc8f145-3fb4-43a9-aaf1-8c25dd6e2cdf
     jinja: "Is this statement correct? {{claim}} ||| \n{{\n{\"SUPPORTS\": \"Yes\"\
       ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: false
     name: cbqa_fever_preprompt
     reference: Closed-book QA from only the claim, prompt before the content
   948f41ab-e6bb-4de6-af3e-7f0b5d5f39a8: !Template
-    answer_choices: null
+    answer_choices: Yes|||No
     id: 948f41ab-e6bb-4de6-af3e-7f0b5d5f39a8
     jinja: "\"{{claim}}\" Yes or no?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
       : \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
       original_task: false
     name: cbqa_fever_short
     reference: CBQA fever, minimal
+  b1d8f035-c3af-41a8-b0b8-1604f9dc00ff: !Template
+    answer_choices: Yes|||No|||Not Sure
+    id: b1d8f035-c3af-41a8-b0b8-1604f9dc00ff
+    jinja: "\"{{claim}}\", I have heard. Is this Correct? Yes, No or Not Sure?\n|||\n\
+      {{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\
+      Not Sure\"\n}[label]\n}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: cbqa_fever_dialog_style_postprompt_all_class
+    reference: CBQA fever, like a conversation, prompt after output. Includes 3 class.
   b888ac7f-7482-4b5b-b94d-1ee096eefee5: !Template
-    answer_choices: null
+    answer_choices: Yes|||No
     id: b888ac7f-7482-4b5b-b94d-1ee096eefee5
     jinja: "\"{{claim}}\", I have heard. Correct?\n|||\n{{\n{\"SUPPORTS\": \"Yes\"\
       ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: false
     name: cbqa_fever_dialog_style_postprompt
     reference: CBQA fever, like a conversation, prompt after output

--- a/promptsource/templates/fever/v2.0/templates.yaml
+++ b/promptsource/templates/fever/v2.0/templates.yaml
@@ -7,7 +7,7 @@ templates:
     jinja: "I've heard that {{claim}} Is this correct?\n|||\n{{\n{\"SUPPORTS\": \"\
       Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: true
+      choices_in_prompt: false
       metrics:
       - Accuracy
       original_task: false
@@ -19,7 +19,7 @@ templates:
     jinja: "{{claim}} Is this true?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
       : \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: true
+      choices_in_prompt: false
       metrics:
       - Accuracy
       original_task: false
@@ -31,7 +31,7 @@ templates:
     jinja: "\"{{claim}}\", I have heard. Correct?\n|||\n{{\n{\"SUPPORTS\": \"Yes\"\
       ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: true
+      choices_in_prompt: false
       metrics:
       - Accuracy
       original_task: false
@@ -43,7 +43,7 @@ templates:
     jinja: "Is this statement correct? {{claim}} ||| \n{{\n{\"SUPPORTS\": \"Yes\"\
       ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: true
+      choices_in_prompt: false
       metrics:
       - Accuracy
       original_task: false
@@ -82,7 +82,7 @@ templates:
     jinja: "\"{{claim}}\" Yes or no?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
       : \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: true
+      choices_in_prompt: false
       metrics:
       - Accuracy
       original_task: false

--- a/promptsource/templates/fever/v2.0/templates.yaml
+++ b/promptsource/templates/fever/v2.0/templates.yaml
@@ -1,23 +1,12 @@
 dataset: fever
 subset: v2.0
 templates:
-  43acc4a7-262f-4c7c-9774-3e1e06376c52: !Template
-    answer_choices: Yes|||No
-    id: 43acc4a7-262f-4c7c-9774-3e1e06376c52
-    jinja: "I've heard that {{claim}} Is this correct?\n|||\n{{\n{\"SUPPORTS\": \"\
-      Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Accuracy
-      original_task: false
-    name: cbqa_fever_dialog_style_surrounded
-    reference: CBQA fever, like a conversation, with prompts surrounding claim
-  6d109e17-3fc0-4cad-bc97-1ffb2c82d1de: !Template
-    answer_choices: Yes|||No
-    id: 6d109e17-3fc0-4cad-bc97-1ffb2c82d1de
-    jinja: "{{claim}} Is this true?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
-      : \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
+  0870481e-e5d1-43a1-821e-b11c6bfd248a: !Template
+    answer_choices: Yes|||No|||Not sure
+    id: 0870481e-e5d1-43a1-821e-b11c6bfd248a
+    jinja: "{{claim}} Is this true?\n|||\n{% if label != \"\" %}\n{{\n{\"SUPPORTS\"\
+      : \"Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"Not sure\"\n}[label]\n\
+      }}\n{% endif %}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -25,23 +14,26 @@ templates:
       original_task: false
     name: cbqa_fever_postprompt
     reference: CBQA fever, prompt after claim
-  6e43e0de-988b-45d1-b43d-0ac2c6b396fc: !Template
-    answer_choices: Yes|||No
-    id: 6e43e0de-988b-45d1-b43d-0ac2c6b396fc
-    jinja: "\"{{claim}}\", I have heard. Correct?\n|||\n{{\n{\"SUPPORTS\": \"Yes\"\
-      ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
+  51c55af8-1996-4cb2-88a1-ca7ddb8f9e1b: !Template
+    answer_choices: Yes|||No|||Not Sure
+    id: 51c55af8-1996-4cb2-88a1-ca7ddb8f9e1b
+    jinja: "I've heard that {{claim}} Is this correct? Yes, No or Not Sure?\n|||\n\
+      {% if label != \"\" %}\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\": \"No\",\n\
+      \"NOT ENOUGH INFO\": \"Not Sure\"\n}[label]\n}}\n{% endif %}"
     metadata: !TemplateMetadata
-      choices_in_prompt: false
+      choices_in_prompt: true
       metrics:
       - Accuracy
       original_task: false
-    name: cbqa_fever_dialog_style_postprompt
-    reference: CBQA fever, like a conversation, prompt after output
-  a5a3f123-0390-4221-b481-83f1165eabda: !Template
-    answer_choices: Yes|||No
-    id: a5a3f123-0390-4221-b481-83f1165eabda
-    jinja: "Is this statement correct? {{claim}} ||| \n{{\n{\"SUPPORTS\": \"Yes\"\
-      ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
+    name: cbqa_fever_dialog_style_surrounded_all_class
+    reference: CBQA fever, like a conversation, with prompts surrounding claim, all
+      class included.
+  6cc8f145-3fb4-43a9-aaf1-8c25dd6e2cdc: !Template
+    answer_choices: Yes|||No|||Unsure
+    id: 6cc8f145-3fb4-43a9-aaf1-8c25dd6e2cdc
+    jinja: "Is this statement correct? {{claim}} ||| \n{% if label != \"\" %}\n{{\n\
+      {\"SUPPORTS\": \"Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"Unsure\"\
+      \n}[label]\n}}\n{% endif %}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -49,38 +41,12 @@ templates:
       original_task: false
     name: cbqa_fever_preprompt
     reference: Closed-book QA from only the claim, prompt before the content
-  bb9e5769-c67b-4a71-bdd8-01dd61f140ed: !Template
-    answer_choices: Yes|||No|||Not Sure
-    id: bb9e5769-c67b-4a71-bdd8-01dd61f140ed
-    jinja: "\"{{claim}}\", I have heard. Is this Correct? Yes, No or Not Sure?\n|||\n\
-      {{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\
-      Not Sure\"\n}[label]\n}}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: true
-      metrics:
-      - Accuracy
-      original_task: true
-    name: cbqa_fever_dialog_style_postprompt_all_class
-    reference: CBQA fever, like a conversation, prompt after output. Includes 3 class.
-  f66235bd-054c-4408-8d53-6901aaa8be64: !Template
-    answer_choices: Yes|||No|||Not Sure
-    id: f66235bd-054c-4408-8d53-6901aaa8be64
-    jinja: "I've heard that {{claim}} Is this correct? Yes, No or Not Sure?\n|||\n\
-      {{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\
-      Not Sure\"\n}[label]\n}}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: true
-      metrics:
-      - Accuracy
-      original_task: true
-    name: cbqa_fever_dialog_style_surrounded_all_class
-    reference: CBQA fever, like a conversation, with prompts surrounding claim, all
-      class included.
-  febc986d-7651-4f0c-bc42-ec22efc76b2c: !Template
-    answer_choices: Yes|||No
-    id: febc986d-7651-4f0c-bc42-ec22efc76b2c
-    jinja: "\"{{claim}}\" Yes or no?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
-      : \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
+  948f41ab-e6bb-4de6-af3e-7f0b5d5f39ad: !Template
+    answer_choices: Yes|||No|||Maybe
+    id: 948f41ab-e6bb-4de6-af3e-7f0b5d5f39ad
+    jinja: "\"{{claim}}\" Yes, no, maybe?\n|||\n{% if label != \"\" %}\n{{\n{\"SUPPORTS\"\
+      : \"Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"Maybe\"\n}[label]\n\
+      }}\n{% endif %}\n"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -88,3 +54,16 @@ templates:
       original_task: false
     name: cbqa_fever_short
     reference: CBQA fever, minimal
+  b1d8f035-c3af-41a8-b0b8-1604f9dc00fe: !Template
+    answer_choices: Yes|||No|||Not Sure
+    id: b1d8f035-c3af-41a8-b0b8-1604f9dc00fe
+    jinja: "\"{{claim}}\", I have heard. Is this Correct? Yes, No or Not Sure?\n|||\n\
+      {% if label != \"\" %}\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\": \"No\",\n\
+      \"NOT ENOUGH INFO\": \"Not Sure\"\n}[label]\n}}\n{% endif %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: false
+    name: cbqa_fever_dialog_style_postprompt_all_class
+    reference: CBQA fever, like a conversation, prompt after output. Includes 3 class.

--- a/promptsource/templates/fever/v2.0/templates.yaml
+++ b/promptsource/templates/fever/v2.0/templates.yaml
@@ -2,57 +2,89 @@ dataset: fever
 subset: v2.0
 templates:
   43acc4a7-262f-4c7c-9774-3e1e06376c52: !Template
-    answer_choices: null
+    answer_choices: Yes|||No
     id: 43acc4a7-262f-4c7c-9774-3e1e06376c52
     jinja: "I've heard that {{claim}} Is this correct?\n|||\n{{\n{\"SUPPORTS\": \"\
       Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: false
     name: cbqa_fever_dialog_style_surrounded
     reference: CBQA fever, like a conversation, with prompts surrounding claim
   6d109e17-3fc0-4cad-bc97-1ffb2c82d1de: !Template
-    answer_choices: null
+    answer_choices: Yes|||No
     id: 6d109e17-3fc0-4cad-bc97-1ffb2c82d1de
     jinja: "{{claim}} Is this true?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
       : \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: false
     name: cbqa_fever_postprompt
     reference: CBQA fever, prompt after claim
   6e43e0de-988b-45d1-b43d-0ac2c6b396fc: !Template
-    answer_choices: null
+    answer_choices: Yes|||No
     id: 6e43e0de-988b-45d1-b43d-0ac2c6b396fc
     jinja: "\"{{claim}}\", I have heard. Correct?\n|||\n{{\n{\"SUPPORTS\": \"Yes\"\
       ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: false
     name: cbqa_fever_dialog_style_postprompt
     reference: CBQA fever, like a conversation, prompt after output
   a5a3f123-0390-4221-b481-83f1165eabda: !Template
-    answer_choices: null
+    answer_choices: Yes|||No
     id: a5a3f123-0390-4221-b481-83f1165eabda
     jinja: "Is this statement correct? {{claim}} ||| \n{{\n{\"SUPPORTS\": \"Yes\"\
       ,\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: false
     name: cbqa_fever_preprompt
     reference: Closed-book QA from only the claim, prompt before the content
+  bb9e5769-c67b-4a71-bdd8-01dd61f140ed: !Template
+    answer_choices: Yes|||No|||Not Sure
+    id: bb9e5769-c67b-4a71-bdd8-01dd61f140ed
+    jinja: "\"{{claim}}\", I have heard. Is this Correct? Yes, No or Not Sure?\n|||\n\
+      {{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\
+      Not Sure\"\n}[label]\n}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: cbqa_fever_dialog_style_postprompt_all_class
+    reference: CBQA fever, like a conversation, prompt after output. Includes 3 class.
+  f66235bd-054c-4408-8d53-6901aaa8be64: !Template
+    answer_choices: Yes|||No|||Not Sure
+    id: f66235bd-054c-4408-8d53-6901aaa8be64
+    jinja: "I've heard that {{claim}} Is this correct? Yes, No or Not Sure?\n|||\n\
+      {{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\": \"No\",\n\"NOT ENOUGH INFO\": \"\
+      Not Sure\"\n}[label]\n}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: cbqa_fever_dialog_style_surrounded_all_class
+    reference: CBQA fever, like a conversation, with prompts surrounding claim, all
+      class included.
   febc986d-7651-4f0c-bc42-ec22efc76b2c: !Template
-    answer_choices: null
+    answer_choices: Yes|||No
     id: febc986d-7651-4f0c-bc42-ec22efc76b2c
     jinja: "\"{{claim}}\" Yes or no?\n|||\n{{\n{\"SUPPORTS\": \"Yes\",\n \"REFUTES\"\
       : \"No\",\n\"NOT ENOUGH INFO\": \"\"\n}[label]\n}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: false
     name: cbqa_fever_short
     reference: CBQA fever, minimal


### PR DESCRIPTION
Two important things to consider here,

**NOT ENOUGH INFO related issue**

Earlier the prompt is written in the following format,
```
"{{claim}}", I have heard. Correct?
|||
{{
{"SUPPORTS": "Yes",
 "REFUTES": "No",
"NOT ENOUGH INFO": ""
}[label]
}}
```
In this format, `NOT ENOUGH INFO` will replace empty label. I assumed these samples will automatically filtered away from the dataset.

So I wrote a new prompt, 

```
"{{claim}}", I have heard. Is this Correct? Yes, No or Not Sure?
|||
{{
{"SUPPORTS": "Yes",
 "REFUTES": "No",
"NOT ENOUGH INFO": "Not Sure"
}[label]
}}
```

**Answer Choice**
Though the prompts are not written with `answer_choices`, I wrote the expected class names in this field. 
