### PR TITLE
cleaned hotpot_qa

### DIFF
--- a/promptsource/templates/hotpot_qa/distractor/templates.yaml
+++ b/promptsource/templates/hotpot_qa/distractor/templates.yaml
@@ -1,65 +1,86 @@
 dataset: hotpot_qa
 subset: distractor
 templates:
+  0eff7d44-d78a-47b5-9526-8c38f74be939: !Template
+    answer_choices: null
+    id: 0eff7d44-d78a-47b5-9526-8c38f74be939
+    jinja: "In the paragraphs below, what sentence(s) support the answer of \"{{answer}}\"\
+      \ to the question \"{{question}}\"?\n\nInformation:\n{% for sents in context.sentences\
+      \ %}\n  - {{sents | join(\"\")}}\n{% endfor %}\n\n|||\n{%- for paragraph in\
+      \ supporting_facts.title -%}\n{% set outer_loop = loop %}\n{%- for title in\
+      \ context.title -%}\n{%- if title==paragraph %}\n{{ context.sentences[loop.index0][supporting_facts.sent_id[outer_loop.index0]]\
+      \ }}\n{%- endif -%}\n{%- endfor -%}\n{%- endfor -%}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - COQA F1
+      - Other
+      original_task: true
+    name: generate_explanations_interrogative
+    reference: ''
   20242fae-2b56-43db-ae50-734c5ca10c5c: !Template
     answer_choices: null
     id: 20242fae-2b56-43db-ae50-734c5ca10c5c
-    jinja: "Information:\n{% for sents in context.sentences %}\n  - {{sents | join(\"\
-      \")}}\n{% endfor %}\nQuestion: {{question}}\n\nAnswer: {{answer}}\n\nTask: Select\
-      \ sentences from the paragraphs in Information that explain the answer.\n|||\n\
-      Explanations:\n{% for paragraph in supporting_facts.title%}\n{% set outer_loop\
-      \ = loop %}\n{% for title in context.title%}\n{% if title==paragraph %}\n- {{\
-      \ context.sentences[loop.index0][supporting_facts.sent_id[outer_loop.index0]]\
-      \ }}\n{% endif %}\n{% endfor %}\n{% endfor %}"
+    jinja: "Select sentences from the paragraphs below that explain the question-answer\
+      \ pair. \"{{question}} {{answer}}\"\n\nInformation:\n{% for sents in context.sentences\
+      \ %}\n  - {{sents | join(\"\")}}\n{% endfor %}\n\n|||\n{%- for paragraph in\
+      \ supporting_facts.title -%}\n{% set outer_loop = loop %}\n{%- for title in\
+      \ context.title -%}\n{%- if title==paragraph %}\n{{ context.sentences[loop.index0][supporting_facts.sent_id[outer_loop.index0]]\
+      \ }}\n{%- endif -%}\n{%- endfor -%}\n{%- endfor -%}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: Generate Explanations
+      choices_in_prompt: false
+      metrics:
+      - COQA F1
+      - Other
+      original_task: true
+    name: generate_explanations_affirmative
     reference: 'Given information, question, and its answer, list the sentences from
       information that explain the answer '
+  690f571f-5113-426c-8aec-bdbbf21f99ae: !Template
+    answer_choices: null
+    id: 690f571f-5113-426c-8aec-bdbbf21f99ae
+    jinja: "{{question}} \n\nHint: use the information from the paragraphs below to\
+      \ answer the question.\n\n{% for sents in context.sentences %}\n  - {{sents\
+      \ | join(\"\")}}\n{% endfor %}\n||| \n{{answer}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics: []
+      original_task: false
+    name: generate_answer_interrogative
+    reference: ''
   6e33c684-725d-49a2-8da3-f9d0b2bb60a0: !Template
     answer_choices: null
     id: 6e33c684-725d-49a2-8da3-f9d0b2bb60a0
-    jinja: "Information:\n{% for sents in context.sentences %}\n  - {{sents | join(\"\
-      \")}}\n{% endfor %}\nWhat is the question that begets the answer of \"{{answer}}\"\
-      ?\n||| \n{{question}}"
+    jinja: "What is the question that begets the answer of \"{{answer}}\"?\n\nInformation:\n\
+      {% for sents in context.sentences %}\n  - {{sents | join(\"\")}}\n{% endfor\
+      \ %}\n||| \n{{question}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - COQA F1
+      - Other
       original_task: false
-    name: Generate Question
+    name: generate_question
     reference: Given information and answer, generate question.
   9aab7543-e491-403f-a77b-63a57ef3316f: !Template
     answer_choices: null
     id: 9aab7543-e491-403f-a77b-63a57ef3316f
-    jinja: "{{question}} \n\nAnswer the question and give explanations, using the\
-      \ paragraphs below. \n{% for sents in context.sentences %}\n  - {{sents | join(\"\
-      \")}}\n{% endfor %}\n|||\nAnswer: {{answer}}\n\nExplanations:\n{% for paragraph\
-      \ in supporting_facts.title%}\n{% set outer_loop = loop %}\n{% for title in\
-      \ context.title%}\n{% if title==paragraph %}\n- {{ context.sentences[loop.index0][supporting_facts.sent_id[outer_loop.index0]]\
-      \ }}\n{% endif %}\n{% endfor %}\n{% endfor %}"
+    jinja: "{{question}} Answer the question and give supporting facts from the paragraphs\
+      \ below.  Give your response in the following format:\nAnswer: ... \nExplanations:\n\
+      - ...\n- ...\n\nParagraphs:\n{% for sents in context.sentences %}\n  - {{sents\
+      \ | join(\"\")}}\n{% endfor %}\n\n|||\n{{answer}}\n\nExplanations:\n{%- for\
+      \ paragraph in supporting_facts.title -%}\n{% set outer_loop = loop %}\n{%-\
+      \ for title in context.title -%}\n{%- if title==paragraph %}\n- {{ context.sentences[loop.index0][supporting_facts.sent_id[outer_loop.index0]]\
+      \ }}\n{%- endif -%}\n{%- endfor -%}\n{%- endfor -%}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - COQA F1
+      - Other
       original_task: true
-    name: Generate Answer and Explanations
+    name: generate_answer_and_explanations
     reference: Given information and question, answer it and list the sentences from
       information that explain the answer.
-  c80dce20-70c3-4e5e-b792-ed000d035215: !Template
-    answer_choices: null
-    id: c80dce20-70c3-4e5e-b792-ed000d035215
-    jinja: "Generate titles (in the format of \"paragraph : title\") for each of the\
-      \ paragraphs below:\n{% for sents in context.sentences %}\n  - {{sents | join(\"\
-      \")}}\n{% endfor %}\n||| \n{% for sents in context.sentences %}\n  - {{sents\
-      \ | join(\"\")}} : {{context.title[loop.index0]}}\n{% endfor %}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: 'Generate Title #2'
-    reference: 'Given a list of paragraphs, generate titles for each of them with
-      the format of "paragraph: title".'
   ea62fe03-8871-4322-8b5c-c060f8d41923: !Template
     answer_choices: null
     id: ea62fe03-8871-4322-8b5c-c060f8d41923
@@ -67,20 +88,25 @@ templates:
       \ below:\n{% for sents in context.sentences %}\n  - {{sents | join(\"\")}}\n\
       {% endfor %}\n||| \n{{context.title | join(\"; \")}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: false
-    name: 'Generate Title #1'
+    name: generate_title_affirmative
     reference: Given a list of paragraphs, generate a string of titles (separated
       by semi-colons) for each of them.
   f14adb21-34ba-4641-b9ce-dfbd0ae9744c: !Template
     answer_choices: null
     id: f14adb21-34ba-4641-b9ce-dfbd0ae9744c
-    jinja: "Information:\n{% for sents in context.sentences %}\n  - {{sents | join(\"\
-      \")}}\n{% endfor %}\nQuestion: {{question}}\n||| \nAnswer: {{answer}}"
+    jinja: "Answer the following question, \"{{question}}\", using the information\
+      \ provided below.\n\n{% for sents in context.sentences %}\n  - {{sents | join(\"\
+      \")}}\n{% endfor %}\n||| \n{{answer}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: Generate Answer
+      choices_in_prompt: false
+      metrics:
+      - COQA F1
+      - Other
+      original_task: true
+    name: generate_answer_affirmative
     reference: Given information and question, generate answer.

--- a/promptsource/templates/hotpot_qa/distractor/templates.yaml
+++ b/promptsource/templates/hotpot_qa/distractor/templates.yaml
@@ -30,8 +30,9 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - COQA F1
+      - BLEU
       - Other
+      - ROUGE
       original_task: true
     name: generate_explanations_affirmative
     reference: 'Given information, question, and its answer, list the sentences from
@@ -44,8 +45,9 @@ templates:
       \ | join(\"\")}}\n{% endfor %}\n||| \n{{answer}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
-      metrics: []
-      original_task: false
+      metrics:
+      - Squad
+      original_task: true
     name: generate_answer_interrogative
     reference: ''
   6e33c684-725d-49a2-8da3-f9d0b2bb60a0: !Template
@@ -57,8 +59,8 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - COQA F1
-      - Other
+      - BLEU
+      - ROUGE
       original_task: false
     name: generate_question
     reference: Given information and answer, generate question.
@@ -75,7 +77,6 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - COQA F1
       - Other
       original_task: true
     name: generate_answer_and_explanations
@@ -105,8 +106,7 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - COQA F1
-      - Other
+      - Squad
       original_task: true
     name: generate_answer_affirmative
     reference: Given information and question, generate answer.

--- a/promptsource/templates/hotpot_qa/fullwiki/templates.yaml
+++ b/promptsource/templates/hotpot_qa/fullwiki/templates.yaml
@@ -1,100 +1,128 @@
 dataset: hotpot_qa
 subset: fullwiki
 templates:
-  287a9cf1-2c45-4e05-a596-8d03221275f8: !Template
+  0b5bab65-4109-4a80-91fd-f26af330b558: !Template
     answer_choices: null
-    id: 287a9cf1-2c45-4e05-a596-8d03221275f8
-    jinja: "{{question}} \n\nAnswer the question and give explanations, using the\
-      \ paragraphs below. \n{% for sents in context.sentences %}\n  - {{sents | join(\"\
-      \")}}\n{% endfor %}\n|||\nAnswer: {{answer}}\n\nExplanations:\n{% for paragraph\
-      \ in supporting_facts.title%}\n{% set outer_loop = loop %}\n{% for title in\
-      \ context.title%}\n{% if title==paragraph %}\n- {{ context.sentences[loop.index0][supporting_facts.sent_id[outer_loop.index0]]\
-      \ }}\n{% endif %}\n{% endfor %}\n{% endfor %}"
+    id: 0b5bab65-4109-4a80-91fd-f26af330b558
+    jinja: "Answer the following question, \"{{question}}\", using the information\
+      \ provided below.\n\n{% for sents in context.sentences %}\n  - {{sents | join(\"\
+      \")}}\n{% endfor %}\n||| \n{{answer}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - COQA F1
+      - Other
       original_task: true
-    name: Generate Answer and Explanations
+    name: generate_answer_affirmative
+    reference: Given information and question, generate answer.
+  465625a7-52be-431f-a07d-8a0fb1bcfe8b: !Template
+    answer_choices: null
+    id: 465625a7-52be-431f-a07d-8a0fb1bcfe8b
+    jinja: "{{question}} Answer the question and give supporting facts from the paragraphs\
+      \ below.  Give your response in the following format:\nAnswer: ... \nExplanations:\n\
+      - ...\n- ...\n\nParagraphs:\n{% for sents in context.sentences %}\n  - {{sents\
+      \ | join(\"\")}}\n{% endfor %}\n\n|||\n{{answer}}\n\nExplanations:\n{%- for\
+      \ paragraph in supporting_facts.title -%}\n{% set outer_loop = loop %}\n{%-\
+      \ for title in context.title -%}\n{%- if title==paragraph %}\n- {{ context.sentences[loop.index0][supporting_facts.sent_id[outer_loop.index0]]\
+      \ }}\n{%- endif -%}\n{%- endfor -%}\n{%- endfor -%}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - COQA F1
+      - Other
+      original_task: true
+    name: generate_answer_and_explanations
     reference: Given information and question, answer it and list the sentences from
       information that explain the answer.
-  3c9260ef-ca10-40fc-b775-39bae9d28ae5: !Template
+  736cf572-0299-48cc-86e2-821527f2b796: !Template
     answer_choices: null
-    id: 3c9260ef-ca10-40fc-b775-39bae9d28ae5
-    jinja: "Generate titles (in the format of \"paragraph : title\") for each of the\
-      \ paragraphs below:\n{% for sents in context.sentences %}\n  - {{sents | join(\"\
-      \")}}\n{% endfor %}\n||| \n{% for sents in context.sentences %}\n  - {{sents\
-      \ | join(\"\")}} : {{context.title[loop.index0]}}\n{% endfor %}"
+    id: 736cf572-0299-48cc-86e2-821527f2b796
+    jinja: "In the paragraphs below, what sentence(s) support the answer of \"{{answer}}\"\
+      \ to the question \"{{question}}\"?\n\nInformation:\n{% for sents in context.sentences\
+      \ %}\n  - {{sents | join(\"\")}}\n{% endfor %}\n\n|||\n{%- for paragraph in\
+      \ supporting_facts.title -%}\n{% set outer_loop = loop %}\n{%- for title in\
+      \ context.title -%}\n{%- if title==paragraph %}\n{{ context.sentences[loop.index0][supporting_facts.sent_id[outer_loop.index0]]\
+      \ }}\n{%- endif -%}\n{%- endfor -%}\n{%- endfor -%}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: 'Generate Title #2'
-    reference: 'Given a list of paragraphs, generate titles for each of them with
-      the format of "paragraph: title".'
-  43e2a527-a0b1-498f-ac1c-e0b3c272603d: !Template
-    answer_choices: null
-    id: 43e2a527-a0b1-498f-ac1c-e0b3c272603d
-    jinja: "Information:\n{% for sents in context.sentences %}\n  - {{sents | join(\"\
-      \")}}\n{% endfor %}\nWhat is the question that begets the answer of \"{{answer}}\"\
-      ?\n||| \n{{question}}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: Generate Question
-    reference: Given information and answer, generate question.
+      choices_in_prompt: false
+      metrics:
+      - COQA F1
+      - Other
+      original_task: true
+    name: generate_explanations_interrogative
+    reference: ''
   8b7b3f27-c235-4a1c-907d-3f37e5f94d93: !Template
-    answer_choices: null
+    answer_choices: comparison ||| bridge
     id: 8b7b3f27-c235-4a1c-907d-3f37e5f94d93
-    jinja: 'What is the type of the question "{{question}}" Comparison or bridge?
+    jinja: 'What is the type of the question "{{question}}" {{ answer_choices[0].capitalize()
+      }} or {{answer_choices[1]}}?
 
       |||
 
       {{type}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: Classify Question Type
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: false
+    name: classify_question_type
     reference: Given question, classify its type.
-  970e537a-5295-4712-a3a2-d31ca11d1695: !Template
+  928f7bd2-2e4b-413e-aa1e-ffb5e00b2ff5: !Template
     answer_choices: null
-    id: 970e537a-5295-4712-a3a2-d31ca11d1695
-    jinja: "Information:\n{% for sents in context.sentences %}\n  - {{sents | join(\"\
-      \")}}\n{% endfor %}\nQuestion: {{question}}\n\nAnswer: {{answer}}\n\nTask: Select\
-      \ sentences from the paragraphs in Information that explain the answer.\n|||\n\
-      Explanations:\n{% for paragraph in supporting_facts.title%}\n{% set outer_loop\
-      \ = loop %}\n{% for title in context.title%}\n{% if title==paragraph %}\n- {{\
-      \ context.sentences[loop.index0][supporting_facts.sent_id[outer_loop.index0]]\
-      \ }}\n{% endif %}\n{% endfor %}\n{% endfor %}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: Generate Explanations
-    reference: 'Given information, question, and its answer, list the sentences from
-      information that explain the answer '
-  e1aadf60-85b4-4c1b-9803-c5231e71e74d: !Template
-    answer_choices: null
-    id: e1aadf60-85b4-4c1b-9803-c5231e71e74d
-    jinja: "Information:\n{% for sents in context.sentences %}\n  - {{sents | join(\"\
-      \")}}\n{% endfor %}\nQuestion: {{question}}\n||| \nAnswer: {{answer}}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
-    name: Generate Answer
-    reference: Given information and question, generate answer.
-  e20171e3-8965-4878-9014-0b72c84e9fec: !Template
-    answer_choices: null
-    id: e20171e3-8965-4878-9014-0b72c84e9fec
+    id: 928f7bd2-2e4b-413e-aa1e-ffb5e00b2ff5
     jinja: "Generate titles (separated by semi-colons) for each of the paragraphs\
       \ below:\n{% for sents in context.sentences %}\n  - {{sents | join(\"\")}}\n\
       {% endfor %}\n||| \n{{context.title | join(\"; \")}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: false
-    name: 'Generate Title #1'
+    name: generate_title_affirmative
     reference: Given a list of paragraphs, generate a string of titles (separated
       by semi-colons) for each of them.
+  9a121de7-1162-48cd-8277-31862d6dfb16: !Template
+    answer_choices: null
+    id: 9a121de7-1162-48cd-8277-31862d6dfb16
+    jinja: "What is the question that begets the answer of \"{{answer}}\"?\n\nInformation:\n\
+      {% for sents in context.sentences %}\n  - {{sents | join(\"\")}}\n{% endfor\
+      \ %}\n||| \n{{question}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - COQA F1
+      - Other
+      original_task: false
+    name: generate_question
+    reference: Given information and answer, generate question.
+  c6664543-0f44-4486-a37c-9db39ef87680: !Template
+    answer_choices: null
+    id: c6664543-0f44-4486-a37c-9db39ef87680
+    jinja: "Select sentences from the paragraphs below that explain the question-answer\
+      \ pair. \"{{question}} {{answer}}\"\n\nInformation:\n{% for sents in context.sentences\
+      \ %}\n  - {{sents | join(\"\")}}\n{% endfor %}\n\n|||\n{%- for paragraph in\
+      \ supporting_facts.title -%}\n{% set outer_loop = loop %}\n{%- for title in\
+      \ context.title -%}\n{%- if title==paragraph %}\n{{ context.sentences[loop.index0][supporting_facts.sent_id[outer_loop.index0]]\
+      \ }}\n{%- endif -%}\n{%- endfor -%}\n{%- endfor -%}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - COQA F1
+      - Other
+      original_task: true
+    name: generate_explanations_affirmative
+    reference: 'Given information, question, and its answer, list the sentences from
+      information that explain the answer '
+  f899ab35-1ac8-4223-8f0c-19437e95df7b: !Template
+    answer_choices: null
+    id: f899ab35-1ac8-4223-8f0c-19437e95df7b
+    jinja: "{{question}} \n\nHint: use the information from the paragraphs below to\
+      \ answer the question.\n\n{% for sents in context.sentences %}\n  - {{sents\
+      \ | join(\"\")}}\n{% endfor %}\n||| \n{{answer}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics: []
+      original_task: false
+    name: generate_answer_interrogative
+    reference: ''

--- a/promptsource/templates/hotpot_qa/fullwiki/templates.yaml
+++ b/promptsource/templates/hotpot_qa/fullwiki/templates.yaml
@@ -10,8 +10,7 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - COQA F1
-      - Other
+      - Squad
       original_task: true
     name: generate_answer_affirmative
     reference: Given information and question, generate answer.
@@ -28,7 +27,6 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - COQA F1
       - Other
       original_task: true
     name: generate_answer_and_explanations
@@ -91,8 +89,8 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - COQA F1
-      - Other
+      - BLEU
+      - ROUGE
       original_task: false
     name: generate_question
     reference: Given information and answer, generate question.
@@ -108,8 +106,9 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - COQA F1
+      - BLEU
       - Other
+      - ROUGE
       original_task: true
     name: generate_explanations_affirmative
     reference: 'Given information, question, and its answer, list the sentences from
@@ -122,7 +121,8 @@ templates:
       \ | join(\"\")}}\n{% endfor %}\n||| \n{{answer}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
-      metrics: []
-      original_task: false
+      metrics:
+      - Squad
+      original_task: true
     name: generate_answer_interrogative
     reference: ''


### PR DESCRIPTION
Tasks for all subsets.
- [X] rename templates to be more meaningful
- [X] indicate original tasks
- [X] add metrics (see Discussion)
- [X] fix whitespace controls in the answer generation
- [X] make the output contain only answers, except `generate_answer_and_explanations`. 

Discussion
In the paper, the metrics for evaluating original tasks are F1 and EM. However, in the dataset presented in promptsource, there are no answer choices (as they are part of the {{ question }}). In this case, does the use of COQA F1 and Other correct metrics? Should I indicate that answer choices exist in the prompts?