### PR TITLE
Sel qa PR and thoughts

### DIFF
--- a/promptsource/templates/selqa/answer_selection_analysis/templates.yaml
+++ b/promptsource/templates/selqa/answer_selection_analysis/templates.yaml
@@ -2,29 +2,29 @@ dataset: selqa
 subset: answer_selection_analysis
 templates:
   39f5f57c-50b9-40b3-bb4f-3f0e4fec7776: !Template
-    answer_choices: null
+    answer_choices: No ||| Yes
     id: 39f5f57c-50b9-40b3-bb4f-3f0e4fec7776
     jinja: '{% set rand_index = range(0,10)|choice %} He asked me "{{ question }}"
       Is he talking about {{ ["MUSIC", "TV","TRAVEL","ART","SPORT","COUNTRY","MOVIES","HISTORICAL
       EVENTS","SCIENCE","FOOD"][rand_index]|lower}}? ||| {% if topic == rand_index
-      %}Yes{% else %}No{% endif %}'
+      %}{{answer_choices[1]}}{% else %}{{answer_choices[0]}}{% endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
       original_task: false
     name: is-he-talking-about
     reference: ''
   5354e98d-8aa2-49d0-a50b-fc72a503d7d4: !Template
-    answer_choices: null
+    answer_choices: No ||| Yes
     id: 5354e98d-8aa2-49d0-a50b-fc72a503d7d4
     jinja: '{% set rand_index = range(0,candidates|length)|choice %} Would it make
       sense to reply "{{ candidates[rand_index]|trim|trim(''.'') }}" to the question
-      "{{ question }}"? ||| {% if rand_index in answers %}Yes{%else %}No{%endif%}
-
-      '
+      "{{ question }}"? ||| {% if rand_index in answers %}{{answer_choices[1]}}{%else %}{{answer_choices[0]}}{%endif%}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
       original_task: false
     name: would-make-sense-qu-rand
     reference: ''
@@ -37,26 +37,28 @@ templates:
       Is it {{ topics[rand_index]|lower}} or {{ topics[topic]|lower}}? ||| {{ topics[topic]|lower
       }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: false
     name: about-topic-vs-random
     reference: ''
   9de0a553-63e7-4b67-a6c5-1a15ac0d5483: !Template
-    answer_choices: null
+    answer_choices: No ||| Yes
     id: 9de0a553-63e7-4b67-a6c5-1a15ac0d5483
     jinja: 'Someone asked me "{{ question }}" I replied "{{ candidates[0] }} Does
-      my answer make sense? ||| {% if 0 in answers %}Yes{%else %}No{%endif%}
+      my answer make sense? ||| {% if 0 in answers %}{{answer_choices[1]}}{%else %}{{answer_choices[0]}}{%endif%}
 
       '
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: false
     name: make-sense-0
     reference: ''
   c2be1297-cfce-48bd-9ef0-9f46fc898e84: !Template
-    answer_choices: null
+    answer_choices: 1 ||| 2
     id: c2be1297-cfce-48bd-9ef0-9f46fc898e84
     jinja: "{% set rand_val = range(0,candidates|length)|choice %}{% set rand_index\
       \ = namespace(value=rand_val)%}\n{% for answer in answers|sort(reverse=True)%}\n\
@@ -68,8 +70,9 @@ templates:
       \ }}\" Which is the correct answer? 1: \"{{ real_fake_answers|join('\" or 2:\
       \ \"') }} ||| {{ response }}\n"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: false
     name: which-answer-1st-vs-random
     reference: ''

--- a/promptsource/templates/selqa/answer_selection_analysis/templates.yaml
+++ b/promptsource/templates/selqa/answer_selection_analysis/templates.yaml
@@ -5,8 +5,8 @@ templates:
     answer_choices: No ||| Yes
     id: 39f5f57c-50b9-40b3-bb4f-3f0e4fec7776
     jinja: '{% set rand_index = range(0,10)|choice %} He asked me "{{ question }}"
-      Is he talking about {{ ["MUSIC", "TV","TRAVEL","ART","SPORT","COUNTRY","MOVIES","HISTORICAL
-      EVENTS","SCIENCE","FOOD"][rand_index]|lower}}? ||| {% if topic == rand_index
+      Is he talking about the topic "{{ ["MUSIC", "TV","TRAVEL","ART","SPORT","COUNTRY","MOVIES","HISTORICAL
+      EVENTS","SCIENCE","FOOD"][rand_index]|lower}}"? ||| {% if topic == rand_index
       %}{{answer_choices[1]}}{% else %}{{answer_choices[0]}}{% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: false

--- a/promptsource/templates/selqa/answer_selection_analysis/templates.yaml
+++ b/promptsource/templates/selqa/answer_selection_analysis/templates.yaml
@@ -18,7 +18,7 @@ templates:
   5354e98d-8aa2-49d0-a50b-fc72a503d7d4: !Template
     answer_choices: No ||| Yes
     id: 5354e98d-8aa2-49d0-a50b-fc72a503d7d4
-    jinja: '{% set rand_index = range(0,candidates|length)|choice %} Would it make
+    jinja: '{% set possible_indexes = [] %}{% for c in candidates %}{% if c|trim %}{% set _ = possible_indexes.append(loop.index0) %}{% endif %}{% endfor %}{% set rand_index = possible_indexes | choice %} Would it make
       sense to reply "{{ candidates[rand_index]|trim|trim(''.'') }}" to the question
       "{{ question }}"? ||| {% if rand_index in answers %}{{answer_choices[1]}}{%else %}{{answer_choices[0]}}{%endif%}'
     metadata: !TemplateMetadata
@@ -46,8 +46,8 @@ templates:
   9de0a553-63e7-4b67-a6c5-1a15ac0d5483: !Template
     answer_choices: No ||| Yes
     id: 9de0a553-63e7-4b67-a6c5-1a15ac0d5483
-    jinja: 'Someone asked me "{{ question }}" I replied "{{ candidates[0] }} Does
-      my answer make sense? ||| {% if 0 in answers %}{{answer_choices[1]}}{%else %}{{answer_choices[0]}}{%endif%}
+    jinja: '{% set possible_indexes = [] %}{% for c in candidates %}{% if c|trim %}{% set _ = possible_indexes.append(loop.index0) %}{% endif %}{% endfor %}{% set rand_index = possible_indexes | choice %}Someone asked me "{{ question }}" I replied "{{ candidates[rand_index] }}" Does
+      my answer make sense? ||| {% if rand_index in answers %}{{answer_choices[1]}}{%else %}{{answer_choices[0]}}{%endif%}
 
       '
     metadata: !TemplateMetadata
@@ -55,7 +55,7 @@ templates:
       metrics:
       - Accuracy
       original_task: false
-    name: make-sense-0
+    name: make-sense-rand
     reference: ''
   c2be1297-cfce-48bd-9ef0-9f46fc898e84: !Template
     answer_choices: 1 ||| 2


### PR DESCRIPTION
I took a look at the current templates for `Sel_qa` and made some minor fixes. 

A major issue is that the original task is not template-friendly: The original task ranks up to ~15-20 passages, where multiple answers can be valid. 2 main issues: 1. the prompt is too long 2. not really a great way to check for multiple answers and their order. The current templates are reformulations and easier tasks (e.g: picking one of two passages), as well as predicting some metadata. I did not add original task prompts as I do not believe they would work without our framework.

Two other issues I noticed with the current prompts:
1. The dataset is a bit noisy, esp. when it comes to the metadata that one must predict. This is an issue for the templates "about-topic-vs-random", "is-he-talking-about",  E.g: 
Input: What is the topic of the question "When did the Nazis take over Poland?"? Is it sport or art?
Target: art
2. Some of the answers one has to rank are the empty string, which means the 1 vs 1 comparisons can be very easy sometimes. This is a problem for the templates: "which-answer-1st-vs-random" and "would-make-sense-qu-rand", "makes-sense-0".  E.g: 
Input: The next question was "How many viewers did "Family Guy" premier to?" Which is
the correct answer? 1: "" or 2: ""Family Guy" officially premiered after Fox's
broadcast of Super Bowl XXXIII on January 31, 1999, with "Death Has a Shadow".
Target: 2


First issue is not easily fixable aside from dropping those templates. Second issue is fixable by excluding empty strings from the possible distractors. The template code is already quite complex (see which-answer-1st-vs-random), so I thought this was not worth it for this task.

