### PR TITLE
Clean up newspop

### DIFF
--- a/promptsource/templates/newspop/templates.yaml
+++ b/promptsource/templates/newspop/templates.yaml
@@ -47,6 +47,38 @@ templates:
       original_task: true
     name: topic_no_choice_in_template
     reference: ''
+  8fdfb019-2f82-4f94-a703-355b40ed9de2: !Template
+    answer_choices: economy |||  microsoft |||  obama ||| palestine
+    id: 8fdfb019-2f82-4f94-a703-355b40ed9de2
+    jinja: "Title: {{title}} \n\nIs this article about {{answer_choices[0]}}, {{answer_choices[1]}},\
+      \ {{answer_choices[2]}} or {{answer_choices[3]}}?\n|||\n\n{{topic}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: false
+    name: after_text_question_title_only
+    reference: ''
+  b2b833b7-e431-40b8-869e-a675daa7e392: !Template
+    answer_choices: economy |||  microsoft |||  obama ||| palestine
+    id: b2b833b7-e431-40b8-869e-a675daa7e392
+    jinja: 'Headline: {{headline}}
+
+
+      Is this article about {{answer_choices[0]}}, {{answer_choices[1]}}, {{answer_choices[2]}}
+      or {{answer_choices[3]}}?
+
+      |||
+
+
+      {{topic}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: false
+    name: after_text_question_headline_only
+    reference: ''
   e4cadaf7-5330-418c-bf8e-4897a39467f5: !Template
     answer_choices: null
     id: e4cadaf7-5330-418c-bf8e-4897a39467f5

--- a/promptsource/templates/newspop/templates.yaml
+++ b/promptsource/templates/newspop/templates.yaml
@@ -1,89 +1,74 @@
 dataset: newspop
 templates:
-  13fec306-ae32-4fc0-aa5c-d1fb1e717a5e: !Template
-    answer_choices: null
-    id: 13fec306-ae32-4fc0-aa5c-d1fb1e717a5e
-    jinja: "{{title}}\n\nThis title is about {{\"economy\"}}, or {{\"Microsoft\"}},\
-      \  or {{\"Obama\"}}, or  {{\"Palestine\"}}.\n\nAnswer: \n\n|||\n\n{{topic}}"
+  3f264cef-d7f0-4f62-81f6-fb2292ab59dd: !Template
+    answer_choices: economy |||  microsoft |||  obama ||| palestine
+    id: 3f264cef-d7f0-4f62-81f6-fb2292ab59dd
+    jinja: "Title: {{title}} \nHeadline: {{headline}}\n\nIs this article about {{answer_choices[0]}},\
+      \ {{answer_choices[1]}}, {{answer_choices[2]}} or {{answer_choices[3]}}?\n|||\n\
+      \n{{topic}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: template_3
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: after_text_question
+    reference: ''
+  5053ada5-7fd3-491f-981e-be64ba35aa39: !Template
+    answer_choices: economy |||  microsoft |||  obama ||| palestine
+    id: 5053ada5-7fd3-491f-981e-be64ba35aa39
+    jinja: "What is the following article about?\n\nTitle: {{title}} \nHeadline: {{headline}}\n\
+      \n|||\n\n{{topic}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: before_text_question_no_choice
+    reference: ''
+  590017ce-8204-400d-a172-93da2337aa6f: !Template
+    answer_choices: economy |||  microsoft |||  obama ||| palestine
+    id: 590017ce-8204-400d-a172-93da2337aa6f
+    jinja: "Title: {{title}} \nHeadline: {{headline}}\n\nWhat is this news about?\n\
+      |||\n\n{{topic}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: after_text_question_no_choice
     reference: ''
   71d4d30d-7340-4ad4-bbfe-d587361c3ad8: !Template
-    answer_choices: null
+    answer_choices: economy |||  microsoft |||  obama ||| palestine
     id: 71d4d30d-7340-4ad4-bbfe-d587361c3ad8
-    jinja: "{{headline}}\n\nThe article is about {{\"economy\"}}, {{\"Microsoft\"\
-      }}, {{\"Obama\"}}, or {{\"Palestine\"}}.\n\nTopic: \n\n|||\n\n{{topic}}"
+    jinja: "{{title}}\n{{headline}}\n\nTopic: \n\n|||\n\n{{topic}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
+      choices_in_prompt: false
       metrics: []
-      original_task: false
-    name: template_2
-    reference: ''
-  87986179-afef-4b2a-8ef0-4723a269ce47: !Template
-    answer_choices: null
-    id: 87986179-afef-4b2a-8ef0-4723a269ce47
-    jinja: "{{title}}\n\n: \n\n{{headline}} \n\nThis article is about one of the following\
-      \ topics {{\"economy\"}}, {{\"Microsoft\"}}, {{\"Obama\"}}, {{\"Palestine\"\
-      }}. Which is it?\n\nAnswer:\n\n||| \n\n{{topic}}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: template_5
-    reference: ''
-  87fc2347-6d83-4624-9620-6890e287a120: !Template
-    answer_choices: null
-    id: 87fc2347-6d83-4624-9620-6890e287a120
-    jinja: "Title: {{title}} \n\nand \n\nHeadline: {{headline}}\n\nis news about {{\"\
-      economy\"}}, or {{\"Microsoft\"}}, or {{\"Obama\"}}, or {{\"Palestine\"}}\n\n\
-      Topic: \n\n|||\n\n{{topic}}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: template_1
-    reference: ''
-  bfca2096-ee45-4ee3-acf0-e3a9c0acdc7c: !Template
-    answer_choices: null
-    id: bfca2096-ee45-4ee3-acf0-e3a9c0acdc7c
-    jinja: 'I read a news article titled :
-
-
-      {{title}}
-
-
-      The main article was: {{headline}}
-
-
-      And it was about one of the following: {{"economy"}}, {{"Microsoft"}}, {{"Obama"}},
-      or {{"Palestine"}}:
-
-
-      Answer:
-
-
-      |||
-
-
-      {{topic}}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: template_4
+      original_task: true
+    name: topic_no_choice_in_template
     reference: ''
   e4cadaf7-5330-418c-bf8e-4897a39467f5: !Template
     answer_choices: null
     id: e4cadaf7-5330-418c-bf8e-4897a39467f5
-    jinja: "For the article, I am writing about {{topic}}:\n\nthe headline is related\
-      \ to {{\"economy\"}}, {{\"Microsoft\"}}, {{\"Obama\"}},  or {{\"Palestine\"\
-      }}::\n\n {{headline}}\n\nthe title is:\n\n|||\n\n{{title}}"
+    jinja: "Summarize the headline to a title:\n {{headline}}\n\nThe title is:\n\n\
+      |||\n\n{{title}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
       original_task: false
-    name: template_6
+    name: headline_to_title
+    reference: Summarize the headline to a title.
+  f8c33f6b-86a8-46bb-b26f-9a38a91207e3: !Template
+    answer_choices: economy |||  microsoft |||  obama ||| palestine
+    id: f8c33f6b-86a8-46bb-b26f-9a38a91207e3
+    jinja: "Is the following article about {{answer_choices[0]}}, {{answer_choices[1]}},\
+      \ {{answer_choices[2]}} or {{answer_choices[3]}}?\n\nTitle: {{title}} \nHeadline:\
+      \ {{headline}}\n\n|||\n\n{{topic}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: before_text_question
     reference: ''

--- a/promptsource/templates/newspop/templates.yaml
+++ b/promptsource/templates/newspop/templates.yaml
@@ -1,11 +1,11 @@
 dataset: newspop
 templates:
   3f264cef-d7f0-4f62-81f6-fb2292ab59dd: !Template
-    answer_choices: economy |||  microsoft |||  obama ||| palestine
+    answer_choices: Economy |||  Microsoft |||  Obama ||| Palestine
     id: 3f264cef-d7f0-4f62-81f6-fb2292ab59dd
     jinja: "Title: {{title}} \nHeadline: {{headline}}\n\nIs this article about {{answer_choices[0]}},\
       \ {{answer_choices[1]}}, {{answer_choices[2]}} or {{answer_choices[3]}}?\n|||\n\
-      \n{{topic}}"
+      \n{{topic|capitalize}}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -14,10 +14,10 @@ templates:
     name: after_text_question
     reference: ''
   5053ada5-7fd3-491f-981e-be64ba35aa39: !Template
-    answer_choices: economy |||  microsoft |||  obama ||| palestine
+    answer_choices: Economy |||  Microsoft |||  Obama ||| Palestine
     id: 5053ada5-7fd3-491f-981e-be64ba35aa39
     jinja: "What is the following article about?\n\nTitle: {{title}} \nHeadline: {{headline}}\n\
-      \n|||\n\n{{topic}}"
+      \n|||\n\n{{topic|capitalize}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -26,10 +26,10 @@ templates:
     name: before_text_question_no_choice
     reference: ''
   590017ce-8204-400d-a172-93da2337aa6f: !Template
-    answer_choices: economy |||  microsoft |||  obama ||| palestine
+    answer_choices: Economy |||  Microsoft |||  Obama ||| Palestine
     id: 590017ce-8204-400d-a172-93da2337aa6f
     jinja: "Title: {{title}} \nHeadline: {{headline}}\n\nWhat is this news about?\n\
-      |||\n\n{{topic}}"
+      |||\n\n{{topic|capitalize}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -38,20 +38,21 @@ templates:
     name: after_text_question_no_choice
     reference: ''
   71d4d30d-7340-4ad4-bbfe-d587361c3ad8: !Template
-    answer_choices: economy |||  microsoft |||  obama ||| palestine
+    answer_choices: Economy |||  Microsoft |||  Obama ||| Palestine
     id: 71d4d30d-7340-4ad4-bbfe-d587361c3ad8
-    jinja: "{{title}}\n{{headline}}\n\nTopic: \n\n|||\n\n{{topic}}"
+    jinja: "{{title}}\n{{headline}}\n\nTopic: \n\n|||\n\n{{topic|capitalize}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
-      metrics: []
+      metrics:
+      - Accuracy
       original_task: true
     name: topic_no_choice_in_template
     reference: ''
   8fdfb019-2f82-4f94-a703-355b40ed9de2: !Template
-    answer_choices: economy |||  microsoft |||  obama ||| palestine
+    answer_choices: Economy |||  Microsoft |||  Obama ||| Palestine
     id: 8fdfb019-2f82-4f94-a703-355b40ed9de2
     jinja: "Title: {{title}} \n\nIs this article about {{answer_choices[0]}}, {{answer_choices[1]}},\
-      \ {{answer_choices[2]}} or {{answer_choices[3]}}?\n|||\n\n{{topic}}"
+      \ {{answer_choices[2]}} or {{answer_choices[3]}}?\n|||\n\n{{topic|capitalize}}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -60,7 +61,7 @@ templates:
     name: after_text_question_title_only
     reference: ''
   b2b833b7-e431-40b8-869e-a675daa7e392: !Template
-    answer_choices: economy |||  microsoft |||  obama ||| palestine
+    answer_choices: Economy |||  Microsoft |||  Obama ||| Palestine
     id: b2b833b7-e431-40b8-869e-a675daa7e392
     jinja: 'Headline: {{headline}}
 
@@ -71,7 +72,7 @@ templates:
       |||
 
 
-      {{topic}}'
+      {{topic|capitalize}}'
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -88,15 +89,16 @@ templates:
       choices_in_prompt: false
       metrics:
       - BLEU
+      - ROUGE
       original_task: false
     name: headline_to_title
     reference: Summarize the headline to a title.
   f8c33f6b-86a8-46bb-b26f-9a38a91207e3: !Template
-    answer_choices: economy |||  microsoft |||  obama ||| palestine
+    answer_choices: Economy |||  Microsoft |||  Obama ||| Palestine
     id: f8c33f6b-86a8-46bb-b26f-9a38a91207e3
     jinja: "Is the following article about {{answer_choices[0]}}, {{answer_choices[1]}},\
       \ {{answer_choices[2]}} or {{answer_choices[3]}}?\n\nTitle: {{title}} \nHeadline:\
-      \ {{headline}}\n\n|||\n\n{{topic}}"
+      \ {{headline}}\n\n|||\n\n{{topic|capitalize}}"
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:


### PR DESCRIPTION
This PR cleans up `newspop` by:
- Rename `template_X` to descriptive template names
- Clean up the formats
- Add more original task templates
- Remove duplicate templates
- Add metrics