### PR TITLE
Clean templates for scan/filler_num_x, x=1,2,3

### DIFF
--- a/promptsource/templates/scan/filler_num1/templates.yaml
+++ b/promptsource/templates/scan/filler_num1/templates.yaml
@@ -4,35 +4,28 @@ templates:
   21cbc219-c6ec-46d8-8cfc-e039e0429746: !Template
     answer_choices: null
     id: 21cbc219-c6ec-46d8-8cfc-e039e0429746
-    jinja: 'Please translate correctly the following commands in natural language
-      into the corresponding SCAN actions.
-
-
-      {{ commands }}
-
-      |||
-
-      {{ actions }} '
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nPlease translate correctly the\
+      \ following commands in natural language into the corresponding sequence of\
+      \ actions.\n\n{{ commands }}\n|||\n{{ actions }} "
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: translate
     reference: ''
   237e411d-1f01-4b96-86e5-9023f93071fa: !Template
     answer_choices: null
     id: 237e411d-1f01-4b96-86e5-9023f93071fa
-    jinja: 'Given the SCAN actions below, what is the corresponding sequence of actions
-      in natural language?
-
-
-      {{ actions }}
-
-      |||
-
-      {{ commands }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven a sequence of actions below,\
+      \ what are the corresponding instructions in natural language?\n\n{{ actions\
+      \ }}\n|||\n{{ commands }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -44,36 +37,31 @@ templates:
   23b9f23e-8c4d-4275-85f2-9cea58bb4e23: !Template
     answer_choices: null
     id: 23b9f23e-8c4d-4275-85f2-9cea58bb4e23
-    jinja: 'Natural language commands: {{ commands }}
-
-
-
-      SCAN actions: |||{{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nNatural language commands: {{\
+      \ commands }}\n\nSequence of actions: ||| {{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: plain
     reference: ''
   316ad8b2-edca-4ca8-94d3-941fa4a46757: !Template
     answer_choices: null
     id: 316ad8b2-edca-4ca8-94d3-941fa4a46757
-    jinja: 'Given the commands below, what is the corresponding correct sequence of
-      actions?
-
-
-      {{ commands }}
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands below, what\
+      \ is the corresponding correct sequence of actions (comma-separated)?\n\n{{\
+      \ commands }}\n|||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: interrogative_beginning
     reference: ''
@@ -83,7 +71,8 @@ templates:
     jinja: '{{ commands }}
 
 
-      Given the commands above, produce the corresponding correct sequence of actions.
+      Given the commands above, produce the corresponding correct sequence of actions
+      (space-separated).
 
 
       Hereafter a hint on how to translate each command to the corresponding action:
@@ -124,27 +113,23 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: false
     name: affirmative_bottom_with_hint
     reference: ''
   5a421d94-4059-4edf-a4ea-7dc862948976: !Template
     answer_choices: null
     id: 5a421d94-4059-4edf-a4ea-7dc862948976
-    jinja: '{{ commands }}
-
-
-      Given the commands above, what is the corresponding correct sequence of actions?
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\n{{ commands }}\n\nGiven the commands\
+      \ above, what is the corresponding correct sequence of actions (comma-separated)?\n\
+      |||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: interrogative_bottom
     reference: ''
@@ -188,7 +173,7 @@ templates:
 
 
       Given the commands-to-actions mapping and the commands above, produce the corresponding
-      correct sequence of actions.
+      correct sequence of actions (space-separated).
 
 
       |||
@@ -197,8 +182,7 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: false
     name: affirmative_top_with_hint
     reference: ''
@@ -242,7 +226,7 @@ templates:
 
 
       Given the commands above and the commands-to-actions mapping, what is the corresponding
-      correct sequence of actions?
+      correct sequence of actions (space-separated)?
 
       |||
 
@@ -250,27 +234,23 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: false
     name: interrogative_bottom_with_hint
     reference: ''
   80a30953-99c4-44aa-b5bf-da4b35c81269: !Template
     answer_choices: null
     id: 80a30953-99c4-44aa-b5bf-da4b35c81269
-    jinja: 'Given the commands: {{ commands }}
-
-
-      Produce the corresponding correct sequence of actions
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands: {{ commands\
+      \ }}\n\nProduce the corresponding correct sequence of actions (comma-separated):\n\
+      |||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: affirmative_mix
     reference: ''
@@ -278,7 +258,7 @@ templates:
     answer_choices: null
     id: 83bcb225-85e0-4a18-becc-ee74e095c67a
     jinja: 'Please translate correctly the following commands in natural language
-      into the corresponding SCAN actions.
+      into the corresponding sequence of actions.
 
 
       {{ commands }}
@@ -323,42 +303,35 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: false
     name: translate_with_hint
     reference: ''
   9d0c5da0-4d60-4e66-b273-091c39dcc2b7: !Template
     answer_choices: null
     id: 9d0c5da0-4d60-4e66-b273-091c39dcc2b7
-    jinja: '{{ commands }}
-
-
-      Given the commands above, produce the corresponding correct sequence of actions.
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\n{{ commands }}\n\nGiven the commands\
+      \ above, produce the corresponding correct sequence of actions. The actions\
+      \ should be comma-separated.\n|||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: affirmative_bottom
     reference: ''
   a3fd4bd7-511f-4dfb-a134-29317f4ee61d: !Template
     answer_choices: null
     id: a3fd4bd7-511f-4dfb-a134-29317f4ee61d
-    jinja: 'Given the SCAN actions below, please produce the corresponding correct
-      sequence of actions in natural language.
-
-
-      {{ actions }}
-
-      |||
-
-      {{ commands }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven a sequence of actions below,\
+      \ please produce the corresponding  instructions in natural language.\n\n{{\
+      \ actions }}\n|||\n{{ commands }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -370,30 +343,27 @@ templates:
   a61db237-78a5-46f2-a791-43728b5e4be8: !Template
     answer_choices: null
     id: a61db237-78a5-46f2-a791-43728b5e4be8
-    jinja: 'Given the following commands: {{ commands }}
-
-
-      What is the corresponding correct sequence of actions?
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the following commands:\
+      \ {{ commands }}\n\nWhat is the corresponding correct sequence of actions (comma-separated)?\n\
+      |||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: interrogative_mix
     reference: ''
   cce9fea7-b2e0-4fa2-8f14-c8caa7cc029d: !Template
     answer_choices: null
     id: cce9fea7-b2e0-4fa2-8f14-c8caa7cc029d
-    jinja: 'Given some SCAN actions "{{actions}}", translate them into natural language.
-
-      |||
-
-      {{commands}}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven some actions \"{{actions}}\"\
+      , translate them into natural language.\n|||\n{{commands}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -405,20 +375,17 @@ templates:
   d7037f77-f0b5-4c40-80ed-20dd637826f0: !Template
     answer_choices: null
     id: d7037f77-f0b5-4c40-80ed-20dd637826f0
-    jinja: 'Given the commands below, please produce the corresponding correct sequence
-      of actions.
-
-
-      {{ commands }}
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands below, please\
+      \ produce the corresponding correct sequence of actions. The actions should\
+      \ be comma-separated. A few examples of actions include: \"turn right\", \"\
+      walk\", \"run\", etc.\n\n{{ commands }}\n|||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: affirmative_beginning
     reference: ''

--- a/promptsource/templates/scan/filler_num1/templates.yaml
+++ b/promptsource/templates/scan/filler_num1/templates.yaml
@@ -7,7 +7,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nPlease translate correctly the\
+      \ actions = lst_of_actions | join(\", \") %}\n\nPlease translate correctly the\
       \ following commands in natural language into the corresponding sequence of\
       \ actions.\n\n{{ commands }}\n|||\n{{ actions }} "
     metadata: !TemplateMetadata
@@ -23,9 +23,9 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven a sequence of actions below,\
-      \ what are the corresponding instructions in natural language?\n\n{{ actions\
-      \ }}\n|||\n{{ commands }}"
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven a sequence of actions\
+      \ below, what are the corresponding instructions in natural language?\n\n{{\
+      \ actions }}\n|||\n{{ commands }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -40,7 +40,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nNatural language commands: {{\
+      \ actions = lst_of_actions | join(\", \") %}\n\nNatural language commands: {{\
       \ commands }}\n\nSequence of actions: ||| {{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -55,7 +55,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands below, what\
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven the commands below, what\
       \ is the corresponding correct sequence of actions (comma-separated)?\n\n{{\
       \ commands }}\n|||\n{{ actions }}"
     metadata: !TemplateMetadata
@@ -65,66 +65,14 @@ templates:
       original_task: true
     name: interrogative_beginning
     reference: ''
-  46d86128-23a7-4c5a-9ac3-9c6b11b4f168: !Template
-    answer_choices: null
-    id: 46d86128-23a7-4c5a-9ac3-9c6b11b4f168
-    jinja: '{{ commands }}
-
-
-      Given the commands above, produce the corresponding correct sequence of actions
-      (space-separated).
-
-
-      Hereafter a hint on how to translate each command to the corresponding action:
-
-
-      {{ "walk: I_WALK"}}
-
-
-      {{ "run: I_RUN"}}
-
-
-      {{ "jump: I_JUMP"}}
-
-
-      {{ "look: I_LOOK"}}
-
-
-      {{ "turn left: I_TURN_LEFT"}}
-
-
-      {{ "turn right: I_TURN_RIGHT"}}
-
-
-      {{ "turn opposite left: I_TURN_LEFT I_TURN_LEFT"}}
-
-
-      {{ "turn opposite right: I_TURN_RIGHT I_TURN_RIGHT"}}
-
-
-      {{ "turn around left: I_TURN_LEFT I_TURN_LEFT I_TURN_LEFT I_TURN_LEFT"}}
-
-
-      {{ "turn around right: I_TURN_RIGHT I_TURN_RIGHT I_TURN_RIGHT I_TURN_RIGHT"}}
-
-      |||
-
-      {{ actions }}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Accuracy
-      original_task: false
-    name: affirmative_bottom_with_hint
-    reference: ''
   5a421d94-4059-4edf-a4ea-7dc862948976: !Template
     answer_choices: null
     id: 5a421d94-4059-4edf-a4ea-7dc862948976
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\n{{ commands }}\n\nGiven the commands\
-      \ above, what is the corresponding correct sequence of actions (comma-separated)?\n\
+      \ actions = lst_of_actions | join(\", \") %}\n\n{{ commands }}\n\nGiven the\
+      \ commands above, what is the corresponding correct sequence of actions (comma-separated)?\n\
       |||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -133,118 +81,13 @@ templates:
       original_task: true
     name: interrogative_bottom
     reference: ''
-  775cb4bf-ddbc-4cd7-b7b8-cdf095970347: !Template
-    answer_choices: null
-    id: 775cb4bf-ddbc-4cd7-b7b8-cdf095970347
-    jinja: 'Mapping commands to actions:
-
-
-      {{ "walk: I_WALK"}}
-
-
-      {{ "run: I_RUN"}}
-
-
-      {{ "jump: I_JUMP"}}
-
-
-      {{ "look: I_LOOK"}}
-
-
-      {{ "turn left: I_TURN_LEFT"}}
-
-
-      {{ "turn right: I_TURN_RIGHT"}}
-
-
-      {{ "turn opposite left: I_TURN_LEFT I_TURN_LEFT"}}
-
-
-      {{ "turn opposite right: I_TURN_RIGHT I_TURN_RIGHT"}}
-
-
-      {{ "turn around left: I_TURN_LEFT I_TURN_LEFT I_TURN_LEFT I_TURN_LEFT"}}
-
-
-      {{ "turn around right: I_TURN_RIGHT I_TURN_RIGHT I_TURN_RIGHT I_TURN_RIGHT"}}
-
-
-      Commands: {{ commands }}
-
-
-      Given the commands-to-actions mapping and the commands above, produce the corresponding
-      correct sequence of actions (space-separated).
-
-
-      |||
-
-      {{ actions }}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Accuracy
-      original_task: false
-    name: affirmative_top_with_hint
-    reference: ''
-  7b1a7d93-03cc-47f1-a17f-5ca973d546ea: !Template
-    answer_choices: null
-    id: 7b1a7d93-03cc-47f1-a17f-5ca973d546ea
-    jinja: 'Mapping commands to actions:
-
-
-      {{ "walk: I_WALK"}}
-
-
-      {{ "run: I_RUN"}}
-
-
-      {{ "jump: I_JUMP"}}
-
-
-      {{ "look: I_LOOK"}}
-
-
-      {{ "turn left: I_TURN_LEFT"}}
-
-
-      {{ "turn right: I_TURN_RIGHT"}}
-
-
-      {{ "turn opposite left: I_TURN_LEFT I_TURN_LEFT"}}
-
-
-      {{ "turn opposite right: I_TURN_RIGHT I_TURN_RIGHT"}}
-
-
-      {{ "turn around left: I_TURN_LEFT I_TURN_LEFT I_TURN_LEFT I_TURN_LEFT"}}
-
-
-      {{ "turn around right: I_TURN_RIGHT I_TURN_RIGHT I_TURN_RIGHT I_TURN_RIGHT"}}
-
-
-      Commands: {{ commands }}
-
-
-      Given the commands above and the commands-to-actions mapping, what is the corresponding
-      correct sequence of actions (space-separated)?
-
-      |||
-
-      {{ actions }}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Accuracy
-      original_task: false
-    name: interrogative_bottom_with_hint
-    reference: ''
   80a30953-99c4-44aa-b5bf-da4b35c81269: !Template
     answer_choices: null
     id: 80a30953-99c4-44aa-b5bf-da4b35c81269
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands: {{ commands\
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven the commands: {{ commands\
       \ }}\n\nProduce the corresponding correct sequence of actions (comma-separated):\n\
       |||\n{{ actions }}"
     metadata: !TemplateMetadata
@@ -254,68 +97,15 @@ templates:
       original_task: true
     name: affirmative_mix
     reference: ''
-  83bcb225-85e0-4a18-becc-ee74e095c67a: !Template
-    answer_choices: null
-    id: 83bcb225-85e0-4a18-becc-ee74e095c67a
-    jinja: 'Please translate correctly the following commands in natural language
-      into the corresponding sequence of actions.
-
-
-      {{ commands }}
-
-
-      Hint:
-
-
-      {{ "walk: I_WALK"}}
-
-
-      {{ "run: I_RUN"}}
-
-
-      {{ "jump: I_JUMP"}}
-
-
-      {{ "look: I_LOOK"}}
-
-
-      {{ "turn left: I_TURN_LEFT"}}
-
-
-      {{ "turn right: I_TURN_RIGHT"}}
-
-
-      {{ "turn opposite left: I_TURN_LEFT I_TURN_LEFT"}}
-
-
-      {{ "turn opposite right: I_TURN_RIGHT I_TURN_RIGHT"}}
-
-
-      {{ "turn around left: I_TURN_LEFT I_TURN_LEFT I_TURN_LEFT I_TURN_LEFT"}}
-
-
-      {{ "turn around right: I_TURN_RIGHT I_TURN_RIGHT I_TURN_RIGHT I_TURN_RIGHT"}}
-
-
-      |||
-
-      {{ actions }} '
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Accuracy
-      original_task: false
-    name: translate_with_hint
-    reference: ''
   9d0c5da0-4d60-4e66-b273-091c39dcc2b7: !Template
     answer_choices: null
     id: 9d0c5da0-4d60-4e66-b273-091c39dcc2b7
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\n{{ commands }}\n\nGiven the commands\
-      \ above, produce the corresponding correct sequence of actions. The actions\
-      \ should be comma-separated.\n|||\n{{ actions }}"
+      \ actions = lst_of_actions | join(\", \") %}\n\n{{ commands }}\n\nGiven the\
+      \ commands above, produce the corresponding correct sequence of actions. The\
+      \ actions should be comma-separated.\n|||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -329,9 +119,9 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven a sequence of actions below,\
-      \ please produce the corresponding  instructions in natural language.\n\n{{\
-      \ actions }}\n|||\n{{ commands }}"
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven a sequence of actions\
+      \ below, please produce the corresponding  instructions in natural language.\n\
+      \n{{ actions }}\n|||\n{{ commands }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -346,7 +136,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the following commands:\
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven the following commands:\
       \ {{ commands }}\n\nWhat is the corresponding correct sequence of actions (comma-separated)?\n\
       |||\n{{ actions }}"
     metadata: !TemplateMetadata
@@ -362,7 +152,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven some actions \"{{actions}}\"\
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven some actions \"{{actions}}\"\
       , translate them into natural language.\n|||\n{{commands}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -378,7 +168,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands below, please\
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven the commands below, please\
       \ produce the corresponding correct sequence of actions. The actions should\
       \ be comma-separated. A few examples of actions include: \"turn right\", \"\
       walk\", \"run\", etc.\n\n{{ commands }}\n|||\n{{ actions }}"

--- a/promptsource/templates/scan/filler_num1/templates.yaml
+++ b/promptsource/templates/scan/filler_num1/templates.yaml
@@ -5,7 +5,7 @@ templates:
     answer_choices: null
     id: 21cbc219-c6ec-46d8-8cfc-e039e0429746
     jinja: 'Please translate correctly the following commands in natural language
-      in the corresponding SCAN actions.
+      into the corresponding SCAN actions.
 
 
       {{ commands }}
@@ -14,10 +14,32 @@ templates:
 
       {{ actions }} '
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: translate
+    reference: ''
+  237e411d-1f01-4b96-86e5-9023f93071fa: !Template
+    answer_choices: null
+    id: 237e411d-1f01-4b96-86e5-9023f93071fa
+    jinja: 'Given the SCAN actions below, what is the corresponding sequence of actions
+      in natural language?
+
+
+      {{ actions }}
+
+      |||
+
+      {{ commands }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
+    name: interrogative_opposite
     reference: ''
   23b9f23e-8c4d-4275-85f2-9cea58bb4e23: !Template
     answer_choices: null
@@ -28,8 +50,10 @@ templates:
 
       SCAN actions: |||{{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: plain
     reference: ''
@@ -46,8 +70,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: interrogative_beginning
     reference: ''
@@ -96,8 +122,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: false
     name: affirmative_bottom_with_hint
     reference: ''
@@ -113,8 +141,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: interrogative_bottom
     reference: ''
@@ -165,8 +195,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: false
     name: affirmative_top_with_hint
     reference: ''
@@ -216,8 +248,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: false
     name: interrogative_bottom_with_hint
     reference: ''
@@ -233,8 +267,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: affirmative_mix
     reference: ''
@@ -242,7 +278,7 @@ templates:
     answer_choices: null
     id: 83bcb225-85e0-4a18-becc-ee74e095c67a
     jinja: 'Please translate correctly the following commands in natural language
-      in the corresponding SCAN actions.
+      into the corresponding SCAN actions.
 
 
       {{ commands }}
@@ -285,8 +321,10 @@ templates:
 
       {{ actions }} '
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: false
     name: translate_with_hint
     reference: ''
@@ -302,10 +340,32 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: affirmative_bottom
+    reference: ''
+  a3fd4bd7-511f-4dfb-a134-29317f4ee61d: !Template
+    answer_choices: null
+    id: a3fd4bd7-511f-4dfb-a134-29317f4ee61d
+    jinja: 'Given the SCAN actions below, please produce the corresponding correct
+      sequence of actions in natural language.
+
+
+      {{ actions }}
+
+      |||
+
+      {{ commands }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
+    name: affirmative_opposite
     reference: ''
   a61db237-78a5-46f2-a791-43728b5e4be8: !Template
     answer_choices: null
@@ -319,10 +379,28 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: interrogative_mix
+    reference: ''
+  cce9fea7-b2e0-4fa2-8f14-c8caa7cc029d: !Template
+    answer_choices: null
+    id: cce9fea7-b2e0-4fa2-8f14-c8caa7cc029d
+    jinja: 'Given some SCAN actions "{{actions}}", translate them into natural language.
+
+      |||
+
+      {{commands}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
+    name: translate_opposite
     reference: ''
   d7037f77-f0b5-4c40-80ed-20dd637826f0: !Template
     answer_choices: null
@@ -337,8 +415,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: affirmative_beginning
     reference: ''

--- a/promptsource/templates/scan/filler_num2/templates.yaml
+++ b/promptsource/templates/scan/filler_num2/templates.yaml
@@ -4,20 +4,17 @@ templates:
   05ae758e-801a-4295-8f25-605114379a55: !Template
     answer_choices: null
     id: 05ae758e-801a-4295-8f25-605114379a55
-    jinja: 'Given the commands below, please produce the corresponding correct sequence
-      of actions.
-
-
-      {{ commands }}
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands below, please\
+      \ produce the corresponding correct sequence of actions. The actions should\
+      \ be comma-separated. A few examples of actions include: \"turn right\", \"\
+      walk\", \"run\", etc.\n\n{{ commands }}\n|||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: affirmative_beginning
     reference: ''
@@ -27,7 +24,8 @@ templates:
     jinja: '{{ commands }}
 
 
-      Given the commands above, produce the corresponding correct sequence of actions.
+      Given the commands above, produce the corresponding correct sequence of actions
+      (space-separated).
 
 
       Hereafter a hint on how to translate each command to the corresponding action:
@@ -68,62 +66,51 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: false
     name: affirmative_bottom_with_hint
     reference: ''
   27e17a7d-54c6-40b2-961c-f0a8409e94ee: !Template
     answer_choices: null
     id: 27e17a7d-54c6-40b2-961c-f0a8409e94ee
-    jinja: 'Given the commands below, what is the corresponding correct sequence of
-      actions?
-
-
-      {{ commands }}
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands below, what\
+      \ is the corresponding correct sequence of actions (comma-separated)?\n\n{{\
+      \ commands }}\n|||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: interrogative_beginning
     reference: ''
   2840eb59-129f-41aa-be04-67d0b93126a2: !Template
     answer_choices: null
     id: 2840eb59-129f-41aa-be04-67d0b93126a2
-    jinja: '{{ commands }}
-
-
-      Given the commands above, what is the corresponding correct sequence of actions?
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\n{{ commands }}\n\nGiven the commands\
+      \ above, what is the corresponding correct sequence of actions (comma-separated)?\n\
+      |||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: interrogative_bottom
     reference: ''
   549d00ef-276b-4cb4-b986-7829d0e0a045: !Template
     answer_choices: null
     id: 549d00ef-276b-4cb4-b986-7829d0e0a045
-    jinja: 'Given the SCAN actions below, please produce the corresponding correct
-      sequence of actions in natural language.
-
-
-      {{ actions }}
-
-      |||
-
-      {{ commands }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven a sequence of actions below,\
+      \ please produce the corresponding  instructions in natural language.\n\n{{\
+      \ actions }}\n|||\n{{ commands }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -172,7 +159,7 @@ templates:
 
 
       Given the commands-to-actions mapping and the commands above, produce the corresponding
-      correct sequence of actions.
+      correct sequence of actions (space-separated).
 
 
       |||
@@ -181,19 +168,18 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: false
     name: affirmative_top_with_hint
     reference: ''
   5ae1fca7-6c08-4494-894e-fbe560655e1b: !Template
     answer_choices: null
     id: 5ae1fca7-6c08-4494-894e-fbe560655e1b
-    jinja: 'Given some SCAN actions "{{actions}}", translate them into natural language.
-
-      |||
-
-      {{commands}}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven some actions \"{{actions}}\"\
+      , translate them into natural language.\n|||\n{{commands}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -205,69 +191,59 @@ templates:
   6fe70c4d-379e-4d29-9dbb-117d1ca0d9f4: !Template
     answer_choices: null
     id: 6fe70c4d-379e-4d29-9dbb-117d1ca0d9f4
-    jinja: 'Given the following commands: {{ commands }}
-
-
-      What is the corresponding correct sequence of actions?
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the following commands:\
+      \ {{ commands }}\n\nWhat is the corresponding correct sequence of actions (comma-separated)?\n\
+      |||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: interrogative_mix
     reference: ''
   751e07c6-2a37-4fed-8ee0-a7f501acaeda: !Template
     answer_choices: null
     id: 751e07c6-2a37-4fed-8ee0-a7f501acaeda
-    jinja: '{{ commands }}
-
-
-      Given the commands above, produce the corresponding correct sequence of actions.
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\n{{ commands }}\n\nGiven the commands\
+      \ above, produce the corresponding correct sequence of actions. The actions\
+      \ should be comma-separated.\n|||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: affirmative_bottom
     reference: ''
   9300d348-fbc8-4e7a-8a9c-9ff5dda44448: !Template
     answer_choices: null
     id: 9300d348-fbc8-4e7a-8a9c-9ff5dda44448
-    jinja: 'Natural language commands: {{ commands }}
-
-
-
-      SCAN actions: |||{{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nNatural language commands: {{\
+      \ commands }}\n\nSequence of actions: ||| {{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: plain
     reference: ''
   95c27c03-a6e8-40ca-90e7-0fa04878b3d6: !Template
     answer_choices: null
     id: 95c27c03-a6e8-40ca-90e7-0fa04878b3d6
-    jinja: 'Given the SCAN actions below, what is the corresponding sequence of actions
-      in natural language?
-
-
-      {{ actions }}
-
-      |||
-
-      {{ commands }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven a sequence of actions below,\
+      \ what are the corresponding instructions in natural language?\n\n{{ actions\
+      \ }}\n|||\n{{ commands }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -279,19 +255,16 @@ templates:
   a4cdaf62-bb3d-4f0a-81d8-a5c02519ed47: !Template
     answer_choices: null
     id: a4cdaf62-bb3d-4f0a-81d8-a5c02519ed47
-    jinja: 'Given the commands: {{ commands }}
-
-
-      Produce the corresponding correct sequence of actions
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands: {{ commands\
+      \ }}\n\nProduce the corresponding correct sequence of actions (comma-separated):\n\
+      |||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: affirmative_mix
     reference: ''
@@ -299,7 +272,7 @@ templates:
     answer_choices: null
     id: c1fe04f7-be41-4ac2-a936-193187271067
     jinja: 'Please translate correctly the following commands in natural language
-      into the corresponding SCAN actions.
+      into the corresponding sequence of actions.
 
 
       {{ commands }}
@@ -344,8 +317,7 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: false
     name: translate_with_hint
     reference: ''
@@ -389,7 +361,7 @@ templates:
 
 
       Given the commands above and the commands-to-actions mapping, what is the corresponding
-      correct sequence of actions?
+      correct sequence of actions (space-separated)?
 
       |||
 
@@ -397,28 +369,23 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: false
     name: interrogative_bottom_with_hint
     reference: ''
   e90eee3e-f2a4-4b9f-b5c3-9edc76c6e38c: !Template
     answer_choices: null
     id: e90eee3e-f2a4-4b9f-b5c3-9edc76c6e38c
-    jinja: 'Please translate correctly the following commands in natural language
-      into the corresponding SCAN actions.
-
-
-      {{ commands }}
-
-      |||
-
-      {{ actions }} '
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nPlease translate correctly the\
+      \ following commands in natural language into the corresponding sequence of\
+      \ actions.\n\n{{ commands }}\n|||\n{{ actions }} "
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: translate
     reference: ''

--- a/promptsource/templates/scan/filler_num2/templates.yaml
+++ b/promptsource/templates/scan/filler_num2/templates.yaml
@@ -7,7 +7,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands below, please\
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven the commands below, please\
       \ produce the corresponding correct sequence of actions. The actions should\
       \ be comma-separated. A few examples of actions include: \"turn right\", \"\
       walk\", \"run\", etc.\n\n{{ commands }}\n|||\n{{ actions }}"
@@ -76,7 +76,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands below, what\
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven the commands below, what\
       \ is the corresponding correct sequence of actions (comma-separated)?\n\n{{\
       \ commands }}\n|||\n{{ actions }}"
     metadata: !TemplateMetadata
@@ -92,8 +92,8 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\n{{ commands }}\n\nGiven the commands\
-      \ above, what is the corresponding correct sequence of actions (comma-separated)?\n\
+      \ actions = lst_of_actions | join(\", \") %}\n\n{{ commands }}\n\nGiven the\
+      \ commands above, what is the corresponding correct sequence of actions (comma-separated)?\n\
       |||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -108,9 +108,9 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven a sequence of actions below,\
-      \ please produce the corresponding  instructions in natural language.\n\n{{\
-      \ actions }}\n|||\n{{ commands }}"
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven a sequence of actions\
+      \ below, please produce the corresponding  instructions in natural language.\n\
+      \n{{ actions }}\n|||\n{{ commands }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -178,7 +178,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven some actions \"{{actions}}\"\
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven some actions \"{{actions}}\"\
       , translate them into natural language.\n|||\n{{commands}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -194,7 +194,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the following commands:\
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven the following commands:\
       \ {{ commands }}\n\nWhat is the corresponding correct sequence of actions (comma-separated)?\n\
       |||\n{{ actions }}"
     metadata: !TemplateMetadata
@@ -210,9 +210,9 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\n{{ commands }}\n\nGiven the commands\
-      \ above, produce the corresponding correct sequence of actions. The actions\
-      \ should be comma-separated.\n|||\n{{ actions }}"
+      \ actions = lst_of_actions | join(\", \") %}\n\n{{ commands }}\n\nGiven the\
+      \ commands above, produce the corresponding correct sequence of actions. The\
+      \ actions should be comma-separated.\n|||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -226,7 +226,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nNatural language commands: {{\
+      \ actions = lst_of_actions | join(\", \") %}\n\nNatural language commands: {{\
       \ commands }}\n\nSequence of actions: ||| {{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -241,9 +241,9 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven a sequence of actions below,\
-      \ what are the corresponding instructions in natural language?\n\n{{ actions\
-      \ }}\n|||\n{{ commands }}"
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven a sequence of actions\
+      \ below, what are the corresponding instructions in natural language?\n\n{{\
+      \ actions }}\n|||\n{{ commands }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -258,7 +258,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands: {{ commands\
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven the commands: {{ commands\
       \ }}\n\nProduce the corresponding correct sequence of actions (comma-separated):\n\
       |||\n{{ actions }}"
     metadata: !TemplateMetadata
@@ -379,7 +379,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nPlease translate correctly the\
+      \ actions = lst_of_actions | join(\", \") %}\n\nPlease translate correctly the\
       \ following commands in natural language into the corresponding sequence of\
       \ actions.\n\n{{ commands }}\n|||\n{{ actions }} "
     metadata: !TemplateMetadata

--- a/promptsource/templates/scan/filler_num2/templates.yaml
+++ b/promptsource/templates/scan/filler_num2/templates.yaml
@@ -14,8 +14,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: affirmative_beginning
     reference: ''
@@ -64,8 +66,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: false
     name: affirmative_bottom_with_hint
     reference: ''
@@ -82,8 +86,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: interrogative_beginning
     reference: ''
@@ -99,10 +105,32 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: interrogative_bottom
+    reference: ''
+  549d00ef-276b-4cb4-b986-7829d0e0a045: !Template
+    answer_choices: null
+    id: 549d00ef-276b-4cb4-b986-7829d0e0a045
+    jinja: 'Given the SCAN actions below, please produce the corresponding correct
+      sequence of actions in natural language.
+
+
+      {{ actions }}
+
+      |||
+
+      {{ commands }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
+    name: affirmative_opposite
     reference: ''
   5a1fbf2d-73c7-4310-8c1d-8cee38509a12: !Template
     answer_choices: null
@@ -151,10 +179,28 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: false
     name: affirmative_top_with_hint
+    reference: ''
+  5ae1fca7-6c08-4494-894e-fbe560655e1b: !Template
+    answer_choices: null
+    id: 5ae1fca7-6c08-4494-894e-fbe560655e1b
+    jinja: 'Given some SCAN actions "{{actions}}", translate them into natural language.
+
+      |||
+
+      {{commands}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
+    name: translate_opposite
     reference: ''
   6fe70c4d-379e-4d29-9dbb-117d1ca0d9f4: !Template
     answer_choices: null
@@ -168,8 +214,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: interrogative_mix
     reference: ''
@@ -185,8 +233,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: affirmative_bottom
     reference: ''
@@ -199,10 +249,32 @@ templates:
 
       SCAN actions: |||{{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: plain
+    reference: ''
+  95c27c03-a6e8-40ca-90e7-0fa04878b3d6: !Template
+    answer_choices: null
+    id: 95c27c03-a6e8-40ca-90e7-0fa04878b3d6
+    jinja: 'Given the SCAN actions below, what is the corresponding sequence of actions
+      in natural language?
+
+
+      {{ actions }}
+
+      |||
+
+      {{ commands }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
+    name: interrogative_opposite
     reference: ''
   a4cdaf62-bb3d-4f0a-81d8-a5c02519ed47: !Template
     answer_choices: null
@@ -216,8 +288,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: affirmative_mix
     reference: ''
@@ -225,7 +299,7 @@ templates:
     answer_choices: null
     id: c1fe04f7-be41-4ac2-a936-193187271067
     jinja: 'Please translate correctly the following commands in natural language
-      in the corresponding SCAN actions.
+      into the corresponding SCAN actions.
 
 
       {{ commands }}
@@ -268,8 +342,10 @@ templates:
 
       {{ actions }} '
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: false
     name: translate_with_hint
     reference: ''
@@ -319,8 +395,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: false
     name: interrogative_bottom_with_hint
     reference: ''
@@ -328,7 +406,7 @@ templates:
     answer_choices: null
     id: e90eee3e-f2a4-4b9f-b5c3-9edc76c6e38c
     jinja: 'Please translate correctly the following commands in natural language
-      in the corresponding SCAN actions.
+      into the corresponding SCAN actions.
 
 
       {{ commands }}
@@ -337,8 +415,10 @@ templates:
 
       {{ actions }} '
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: translate
     reference: ''

--- a/promptsource/templates/scan/filler_num3/templates.yaml
+++ b/promptsource/templates/scan/filler_num3/templates.yaml
@@ -10,8 +10,10 @@ templates:
 
       SCAN actions: |||{{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: plain
     reference: ''
@@ -61,8 +63,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: false
     name: interrogative_bottom_with_hint
     reference: ''
@@ -70,7 +74,7 @@ templates:
     answer_choices: null
     id: 1aa8f46d-4859-4f53-8630-718332409ff8
     jinja: 'Please translate correctly the following commands in natural language
-      in the corresponding SCAN actions.
+      into the corresponding SCAN actions.
 
 
       {{ commands }}
@@ -113,8 +117,10 @@ templates:
 
       {{ actions }} '
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: false
     name: translate_with_hint
     reference: ''
@@ -130,8 +136,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: interrogative_mix
     reference: ''
@@ -139,7 +147,7 @@ templates:
     answer_choices: null
     id: 572d665c-cf6b-4302-a112-da225a83dced
     jinja: 'Please translate correctly the following commands in natural language
-      in the corresponding SCAN actions.
+      into the corresponding SCAN actions.
 
 
       {{ commands }}
@@ -148,8 +156,10 @@ templates:
 
       {{ actions }} '
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: translate
     reference: ''
@@ -166,8 +176,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: affirmative_beginning
     reference: ''
@@ -183,8 +195,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: interrogative_bottom
     reference: ''
@@ -201,10 +215,52 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: interrogative_beginning
+    reference: ''
+  89c2d715-9cc9-4330-b9f2-9c409b2fdb91: !Template
+    answer_choices: null
+    id: 89c2d715-9cc9-4330-b9f2-9c409b2fdb91
+    jinja: 'Given the SCAN actions below, please produce the corresponding correct
+      sequence of actions in natural language.
+
+
+      {{ actions }}
+
+      |||
+
+      {{ commands }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
+    name: affirmative_opposite
+    reference: ''
+  90758d2e-1462-42aa-98cd-47802542b953: !Template
+    answer_choices: null
+    id: 90758d2e-1462-42aa-98cd-47802542b953
+    jinja: 'Given the SCAN actions below, what is the corresponding sequence of actions
+      in natural language?
+
+
+      {{ actions }}
+
+      |||
+
+      {{ commands }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
+    name: interrogative_opposite
     reference: ''
   a619fe38-cc02-4d9b-ba8d-b9ab2edce5c8: !Template
     answer_choices: null
@@ -253,10 +309,28 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: false
     name: affirmative_top_with_hint
+    reference: ''
+  c3d92532-1184-4e1c-a463-38b85fff8947: !Template
+    answer_choices: null
+    id: c3d92532-1184-4e1c-a463-38b85fff8947
+    jinja: 'Given some SCAN actions "{{actions}}", translate them into natural language.
+
+      |||
+
+      {{commands}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
+    name: translate_opposite
     reference: ''
   deffa981-1fa3-4b21-9bc1-6b87675c3aa6: !Template
     answer_choices: null
@@ -303,8 +377,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: false
     name: affirmative_bottom_with_hint
     reference: ''
@@ -320,8 +396,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: affirmative_mix
     reference: ''
@@ -337,8 +415,10 @@ templates:
 
       {{ actions }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: true
     name: affirmative_bottom
     reference: ''

--- a/promptsource/templates/scan/filler_num3/templates.yaml
+++ b/promptsource/templates/scan/filler_num3/templates.yaml
@@ -4,16 +4,15 @@ templates:
   0154a526-fdda-4c75-be3b-995bbd6f4cf5: !Template
     answer_choices: null
     id: 0154a526-fdda-4c75-be3b-995bbd6f4cf5
-    jinja: 'Natural language commands: {{ commands }}
-
-
-
-      SCAN actions: |||{{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nNatural language commands: {{\
+      \ commands }}\n\nSequence of actions: ||| {{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: plain
     reference: ''
@@ -57,7 +56,7 @@ templates:
 
 
       Given the commands above and the commands-to-actions mapping, what is the corresponding
-      correct sequence of actions?
+      correct sequence of actions (space-separated)?
 
       |||
 
@@ -65,8 +64,7 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: false
     name: interrogative_bottom_with_hint
     reference: ''
@@ -74,7 +72,7 @@ templates:
     answer_choices: null
     id: 1aa8f46d-4859-4f53-8630-718332409ff8
     jinja: 'Please translate correctly the following commands in natural language
-      into the corresponding SCAN actions.
+      into the corresponding sequence of actions.
 
 
       {{ commands }}
@@ -119,121 +117,100 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: false
     name: translate_with_hint
     reference: ''
   51caf65b-b6ab-412a-9513-f9e20e727b99: !Template
     answer_choices: null
     id: 51caf65b-b6ab-412a-9513-f9e20e727b99
-    jinja: 'Given the following commands: {{ commands }}
-
-
-      What is the corresponding correct sequence of actions?
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the following commands:\
+      \ {{ commands }}\n\nWhat is the corresponding correct sequence of actions (comma-separated)?\n\
+      |||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: interrogative_mix
     reference: ''
   572d665c-cf6b-4302-a112-da225a83dced: !Template
     answer_choices: null
     id: 572d665c-cf6b-4302-a112-da225a83dced
-    jinja: 'Please translate correctly the following commands in natural language
-      into the corresponding SCAN actions.
-
-
-      {{ commands }}
-
-      |||
-
-      {{ actions }} '
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nPlease translate correctly the\
+      \ following commands in natural language into the corresponding sequence of\
+      \ actions.\n\n{{ commands }}\n|||\n{{ actions }} "
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: translate
     reference: ''
   648ffbee-8432-4ba8-ad86-42a15a21a201: !Template
     answer_choices: null
     id: 648ffbee-8432-4ba8-ad86-42a15a21a201
-    jinja: 'Given the commands below, please produce the corresponding correct sequence
-      of actions.
-
-
-      {{ commands }}
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands below, please\
+      \ produce the corresponding correct sequence of actions. The actions should\
+      \ be comma-separated. A few examples of actions include: \"turn right\", \"\
+      walk\", \"run\", etc.\n\n{{ commands }}\n|||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: affirmative_beginning
     reference: ''
   6ce15057-a2c0-489e-8c5b-1978a5692bab: !Template
     answer_choices: null
     id: 6ce15057-a2c0-489e-8c5b-1978a5692bab
-    jinja: '{{ commands }}
-
-
-      Given the commands above, what is the corresponding correct sequence of actions?
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\n{{ commands }}\n\nGiven the commands\
+      \ above, what is the corresponding correct sequence of actions (comma-separated)?\n\
+      |||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: interrogative_bottom
     reference: ''
   80c18052-3a25-4b1d-a99e-37a0dd56793b: !Template
     answer_choices: null
     id: 80c18052-3a25-4b1d-a99e-37a0dd56793b
-    jinja: 'Given the commands below, what is the corresponding correct sequence of
-      actions?
-
-
-      {{ commands }}
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands below, what\
+      \ is the corresponding correct sequence of actions (comma-separated)?\n\n{{\
+      \ commands }}\n|||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: interrogative_beginning
     reference: ''
   89c2d715-9cc9-4330-b9f2-9c409b2fdb91: !Template
     answer_choices: null
     id: 89c2d715-9cc9-4330-b9f2-9c409b2fdb91
-    jinja: 'Given the SCAN actions below, please produce the corresponding correct
-      sequence of actions in natural language.
-
-
-      {{ actions }}
-
-      |||
-
-      {{ commands }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven a sequence of actions below,\
+      \ please produce the corresponding  instructions in natural language.\n\n{{\
+      \ actions }}\n|||\n{{ commands }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -245,15 +222,12 @@ templates:
   90758d2e-1462-42aa-98cd-47802542b953: !Template
     answer_choices: null
     id: 90758d2e-1462-42aa-98cd-47802542b953
-    jinja: 'Given the SCAN actions below, what is the corresponding sequence of actions
-      in natural language?
-
-
-      {{ actions }}
-
-      |||
-
-      {{ commands }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven a sequence of actions below,\
+      \ what are the corresponding instructions in natural language?\n\n{{ actions\
+      \ }}\n|||\n{{ commands }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -302,7 +276,7 @@ templates:
 
 
       Given the commands-to-actions mapping and the commands above, produce the corresponding
-      correct sequence of actions.
+      correct sequence of actions (space-separated).
 
 
       |||
@@ -311,19 +285,18 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: false
     name: affirmative_top_with_hint
     reference: ''
   c3d92532-1184-4e1c-a463-38b85fff8947: !Template
     answer_choices: null
     id: c3d92532-1184-4e1c-a463-38b85fff8947
-    jinja: 'Given some SCAN actions "{{actions}}", translate them into natural language.
-
-      |||
-
-      {{commands}}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven some actions \"{{actions}}\"\
+      , translate them into natural language.\n|||\n{{commands}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -338,7 +311,8 @@ templates:
     jinja: '{{ commands }}
 
 
-      Given the commands above, produce the corresponding correct sequence of actions.
+      Given the commands above, produce the corresponding correct sequence of actions
+      (space-separated).
 
 
       Hereafter a hint on how to translate each command to the corresponding action:
@@ -379,46 +353,39 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: false
     name: affirmative_bottom_with_hint
     reference: ''
   e5b8785b-06d5-4c44-af98-d6d856726b6e: !Template
     answer_choices: null
     id: e5b8785b-06d5-4c44-af98-d6d856726b6e
-    jinja: 'Given the commands: {{ commands }}
-
-
-      Produce the corresponding correct sequence of actions
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands: {{ commands\
+      \ }}\n\nProduce the corresponding correct sequence of actions (comma-separated):\n\
+      |||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: affirmative_mix
     reference: ''
   e61ce9e3-c9b8-417f-a2c3-2cd66cf74d5d: !Template
     answer_choices: null
     id: e61ce9e3-c9b8-417f-a2c3-2cd66cf74d5d
-    jinja: '{{ commands }}
-
-
-      Given the commands above, produce the corresponding correct sequence of actions.
-
-      |||
-
-      {{ actions }}'
+    jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
+      \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
+      \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
+      \ actions = lst_of_actions | join(\",\") %}\n\n{{ commands }}\n\nGiven the commands\
+      \ above, produce the corresponding correct sequence of actions. The actions\
+      \ should be comma-separated.\n|||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - BLEU
-      - ROUGE
+      - Accuracy
       original_task: true
     name: affirmative_bottom
     reference: ''

--- a/promptsource/templates/scan/filler_num3/templates.yaml
+++ b/promptsource/templates/scan/filler_num3/templates.yaml
@@ -7,7 +7,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nNatural language commands: {{\
+      \ actions = lst_of_actions | join(\", \") %}\n\nNatural language commands: {{\
       \ commands }}\n\nSequence of actions: ||| {{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -127,7 +127,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the following commands:\
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven the following commands:\
       \ {{ commands }}\n\nWhat is the corresponding correct sequence of actions (comma-separated)?\n\
       |||\n{{ actions }}"
     metadata: !TemplateMetadata
@@ -143,7 +143,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nPlease translate correctly the\
+      \ actions = lst_of_actions | join(\", \") %}\n\nPlease translate correctly the\
       \ following commands in natural language into the corresponding sequence of\
       \ actions.\n\n{{ commands }}\n|||\n{{ actions }} "
     metadata: !TemplateMetadata
@@ -159,7 +159,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands below, please\
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven the commands below, please\
       \ produce the corresponding correct sequence of actions. The actions should\
       \ be comma-separated. A few examples of actions include: \"turn right\", \"\
       walk\", \"run\", etc.\n\n{{ commands }}\n|||\n{{ actions }}"
@@ -176,8 +176,8 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\n{{ commands }}\n\nGiven the commands\
-      \ above, what is the corresponding correct sequence of actions (comma-separated)?\n\
+      \ actions = lst_of_actions | join(\", \") %}\n\n{{ commands }}\n\nGiven the\
+      \ commands above, what is the corresponding correct sequence of actions (comma-separated)?\n\
       |||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -192,7 +192,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands below, what\
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven the commands below, what\
       \ is the corresponding correct sequence of actions (comma-separated)?\n\n{{\
       \ commands }}\n|||\n{{ actions }}"
     metadata: !TemplateMetadata
@@ -208,9 +208,9 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven a sequence of actions below,\
-      \ please produce the corresponding  instructions in natural language.\n\n{{\
-      \ actions }}\n|||\n{{ commands }}"
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven a sequence of actions\
+      \ below, please produce the corresponding  instructions in natural language.\n\
+      \n{{ actions }}\n|||\n{{ commands }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -225,9 +225,9 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven a sequence of actions below,\
-      \ what are the corresponding instructions in natural language?\n\n{{ actions\
-      \ }}\n|||\n{{ commands }}"
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven a sequence of actions\
+      \ below, what are the corresponding instructions in natural language?\n\n{{\
+      \ actions }}\n|||\n{{ commands }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -295,7 +295,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven some actions \"{{actions}}\"\
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven some actions \"{{actions}}\"\
       , translate them into natural language.\n|||\n{{commands}}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -363,7 +363,7 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\nGiven the commands: {{ commands\
+      \ actions = lst_of_actions | join(\", \") %}\n\nGiven the commands: {{ commands\
       \ }}\n\nProduce the corresponding correct sequence of actions (comma-separated):\n\
       |||\n{{ actions }}"
     metadata: !TemplateMetadata
@@ -379,9 +379,9 @@ templates:
     jinja: "{% set scan_lst_of_actions = actions.split(' ') %}\n{% set lst_of_actions\
       \ = [] %}\n{% for item in scan_lst_of_actions %}\n    {{ lst_of_actions.append(item.lower()[2:]\
       \ | replace(\"_\", \" \")) | default(\"\", True) }}\n{% endfor %}\n\n{% set\
-      \ actions = lst_of_actions | join(\",\") %}\n\n{{ commands }}\n\nGiven the commands\
-      \ above, produce the corresponding correct sequence of actions. The actions\
-      \ should be comma-separated.\n|||\n{{ actions }}"
+      \ actions = lst_of_actions | join(\", \") %}\n\n{{ commands }}\n\nGiven the\
+      \ commands above, produce the corresponding correct sequence of actions. The\
+      \ actions should be comma-separated.\n|||\n{{ actions }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:


### PR DESCRIPTION
**Important Points:**
- [x] **The task is explicitly stated. However, I have reservations about the answer format. The answer is a string and has terms like "I_TURN_RIGHT", "I_TURN_LEFT", etc. which isn't exactly "natural language". Should we change this? Should we modify the input string to "...in SCAN format"?**
- [x] All "Original Task" checkbox entries have been double-checked. **Templates with names ending with `_with_hint` have not been marked as "Original Task.**
- [x] The Choices in Prompt template looks correct. **Now, for templates with names ending with `_with_hint`, should I tick the "Choices in Prompt" checkbox?**
- [x] I have **added BLEU and ROUGE scores** as metrics since this is a generation task.
- [x] I have added three templates ending with `_opposite`, which translates SCAN actions into NL commands. 

**Common Points:**
- [x] The dataset is appropriate. It does not have any harmful content.
- [x] The templates do not have any bugs. Tried with multiple examples.
- [x] The templates do not have any other issues like span indices (since it is not a QA task), negated answers (no real scope of negation here). The passages are short; there is no "long distance" issue either.
- [x] This is a generation task, and it does not have multiple correct answers.
- [x] There are 8 original task templates.
- [x] We don't need to define `answer_choices` for this task.
- [x] The output contains only the answer.
- [x] Key terms have been correctly escaped.
- [x] Templates have been named appropriately.