### PR TITLE
clean kelm

### DIFF
--- a/promptsource/templates/kelm/templates.yaml
+++ b/promptsource/templates/kelm/templates.yaml
@@ -1,83 +1,98 @@
 dataset: kelm
 templates:
-  26acfe5b-f295-4b84-b643-45e05a17d286: !Template
-    answer_choices: null
-    id: 26acfe5b-f295-4b84-b643-45e05a17d286
-    jinja: "Given a natural language sentence expressing facts of the form (subject,\
-      \ relation, object), generate structured triples expressing all relevant relations\
-      \ \n\n{{sentence}} |||\n{{triple}}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: Generated Sentence to KB Triple Paraphrase 1
-    reference: Given a sentence, generate triples of the form (subject, relation,
-      object)
   3381175a-b93e-4d1e-a7f2-428c5d2c7c2b: !Template
     answer_choices: null
     id: 3381175a-b93e-4d1e-a7f2-428c5d2c7c2b
-    jinja: 'Given facts from a knowledge base encoded in the form (subject, relation,
-      object), generate a natural language sentence that uses all facts provided as
-      input.
-
-
-      {{ triple }} |||
-
-      {{ sentence }}'
+    jinja: "Given facts from a knowledge base encoded in the form \"subject relation\
+      \ object, relation object, ...\" below (the subject and object are entities\
+      \ that are involved in a relationship defined by the relation), what would be\
+      \ a natural language sentence that uses all facts provided as input?\n\n{{ triple\
+      \ }} \n|||\n{{ sentence }}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Pearson Correlation
       original_task: true
-    name: KB Triple to Generated Sentence Paraphrase 1
+    name: kb_to_sentence_uses_all_facts
     reference: Convert a KB triple of the form (subject, relation, object) to a natural
       language sentence
   4d674e43-c569-4f0c-9b5c-436f430da92a: !Template
     answer_choices: null
     id: 4d674e43-c569-4f0c-9b5c-436f430da92a
-    jinja: 'Given a sentence, generate triples of the form (subject, relation, object):
-
-
-      {{sentence}} |||
-
-      {{triple}}'
+    jinja: "Given a sentence below, generate knowledge base triples in the form of\
+      \ \"subject relation object, relation object, ...\". The subject and object\
+      \ are entities that are involved in a relationship defined by the relation.\n\
+      \nSentence: {{sentence}} \n|||\n{{triple}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - ROUGE
+      - BLEU
       original_task: false
-    name: Generated Sentence to KB Triple
+    name: sentence_to_kb
     reference: Given a sentence, generate a string of the form (subject, relation,
       object)
+  510324d1-1c45-4747-8cd1-ea817355f895: !Template
+    answer_choices: null
+    id: 510324d1-1c45-4747-8cd1-ea817355f895
+    jinja: "How would you rephrase the following information in the format of \"subject\
+      \ relation object, relation object, ...\" (the subject and object are entities\
+      \ that are involved in a relationship defined by the relation) into something\
+      \ easier to understand? Give your response in a complete sentence.\n\nInformation:\
+      \ {{ triple }} \n\n|||\n\n{{ sentence }}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Pearson Correlation
+      original_task: true
+    name: kb_to_sentence_easier_to_understand
+    reference: ''
   55909592-633d-4cef-97ff-058c86eea28f: !Template
     answer_choices: null
     id: 55909592-633d-4cef-97ff-058c86eea28f
-    jinja: 'Given facts of the form (subject, relation, object), create a natural
-      language sentence that uses all of the facts provided as input:
+    jinja: 'How would you combine the following facts of the form "subject relation
+      object, relation object, ..." (the subject and object are entities that are
+      involved in a relationship defined by the relation) into a sentence?
 
 
       "{{ triple }}" |||
 
       {{ sentence }}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Pearson Correlation
       original_task: true
-    name: KB Triple to Generated Sentence Paraphrase 2
+    name: kb_to_sentence_combine
     reference: Convert a KB triple of the form (subject, relation, object) to a natural
       language sentence
   7478edee-5950-4ca2-8878-9c5a98925952: !Template
     answer_choices: null
     id: 7478edee-5950-4ca2-8878-9c5a98925952
-    jinja: 'Given KB triples of the form (subject, relation, object), generate a natural
-      language sentence:
-
-
-      {{ triple }} |||
-
-      {{ sentence }}'
+    jinja: "Given knowledge base triples of the format of \"subject relation object,\
+      \ relation object, ...\" (the subject and object are entities that are involved\
+      \ in a relationship defined by the relation) generate a natural language sentence.\n\
+      \nTriples: {{ triple }} \n|||\n{{ sentence }}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Pearson Correlation
       original_task: true
-    name: KB Triple to Generated Sentence
+    name: kb_to_sentence_affirmative
     reference: Convert a KB triple of the form (subject, relation, object) to a natural
       language sentence
+  d72c07d6-9c16-4520-8891-4bfc6a7a956f: !Template
+    answer_choices: null
+    id: d72c07d6-9c16-4520-8891-4bfc6a7a956f
+    jinja: "I am going through my notes about facts, and my notes are written in the\
+      \ form of \"subject relation object, relation object, ...\". The subject and\
+      \ object are entities that are involved in a relationship defined by the relation.\
+      \ I want to convert the facts into a sentence to include in my written report.\
+      \ What is the sentence?\n\nFacts: {{ triple }} \n\n|||\n\n{{ sentence }}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Pearson Correlation
+      original_task: true
+    name: kb_to_sentence_from_notes
+    reference: ''

--- a/promptsource/templates/kelm/templates.yaml
+++ b/promptsource/templates/kelm/templates.yaml
@@ -11,7 +11,7 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - Pearson Correlation
+      - Other
       original_task: true
     name: kb_to_sentence_uses_all_facts
     reference: Convert a KB triple of the form (subject, relation, object) to a natural
@@ -43,7 +43,7 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - Pearson Correlation
+      - Other
       original_task: true
     name: kb_to_sentence_easier_to_understand
     reference: ''
@@ -61,7 +61,7 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - Pearson Correlation
+      - Other
       original_task: true
     name: kb_to_sentence_combine
     reference: Convert a KB triple of the form (subject, relation, object) to a natural
@@ -69,14 +69,14 @@ templates:
   7478edee-5950-4ca2-8878-9c5a98925952: !Template
     answer_choices: null
     id: 7478edee-5950-4ca2-8878-9c5a98925952
-    jinja: "Given knowledge base triples of the format of \"subject relation object,\
+    jinja: "Given knowledge base triples in the format of \"subject relation object,\
       \ relation object, ...\" (the subject and object are entities that are involved\
       \ in a relationship defined by the relation) generate a natural language sentence.\n\
-      \nTriples: {{ triple }} \n|||\n{{ sentence }}"
+      \nTriple: {{ triple }} \n|||\n{{ sentence }}"
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - Pearson Correlation
+      - Other
       original_task: true
     name: kb_to_sentence_affirmative
     reference: Convert a KB triple of the form (subject, relation, object) to a natural
@@ -92,7 +92,7 @@ templates:
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
-      - Pearson Correlation
+      - Other
       original_task: true
     name: kb_to_sentence_from_notes
     reference: ''


### PR DESCRIPTION
I've completed the following:
- [X] added metrics (for `sentence_to_kb`, which is not an original task, I choose BLEU and ROUGE. My reasoning is that it is reasonable to compare n-gram words between the generated KB and the correct KB.)
- [X] add the description of KB triples in the prompt.
- [X] reformat the template names