### PR TITLE
clean limit

### DIFF
--- a/promptsource/templates/limit/templates.yaml
+++ b/promptsource/templates/limit/templates.yaml
@@ -6,7 +6,8 @@ templates:
     jinja: '{{sentence}}
 
 
-      What is the last entity in motion mentioned in the sentence if any?
+      What is the last entity in motion mentioned in the sentence if any? Otherwise,
+      respond with "No entity in motion".
 
       |||
 
@@ -20,13 +21,14 @@ templates:
 
       {% endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
       original_task: false
     name: last_moving_entity
     reference: ''
   3b88c578-db77-4fd0-ad50-c78a39197ce5: !Template
-    answer_choices: null
+    answer_choices: Yes ||| No
     id: 3b88c578-db77-4fd0-ad50-c78a39197ce5
     jinja: '{{sentence}}
 
@@ -37,49 +39,61 @@ templates:
       |||
 
 
-      {{motion}}'
+      {% if motion == "yes" %}
+
+      {{ answer_choices[0] }}
+
+      {% else %}
+
+      {{ answer_choices[1] }}
+
+      {% endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
       original_task: false
     name: any_entity
     reference: Asking if there is any entity in motion in the text
   3f1689a9-b255-4d8d-b780-062ca2f83596: !Template
     answer_choices: null
     id: 3f1689a9-b255-4d8d-b780-062ca2f83596
-    jinja: "{{sentence}}\n\nWhat are the entities in motion in the previous sentence?\
-      \ Return {{\"'No entity'\"}} if you can't find any. \n\n|||\n{% if (motion_entities\
-      \  | length) == 0 %}\n{{ \"No entity\" }}\n{% else %}\n{{motion_entities | map(attribute=\"\
-      entity\") | join(\", \")}}\n{% endif %}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: true
-    name: find_entities_question
-    reference: ''
-  74c9962e-3ec2-4f06-ace4-fcac6f506076: !Template
-    answer_choices: null
-    id: 74c9962e-3ec2-4f06-ace4-fcac6f506076
-    jinja: 'Extract: {{sentence}}
+    jinja: '{{sentence}}
 
 
-      Is there more than one mention of a moving entity in the extract?
+      What are the entities in motion in the previous sentence? Return {{"''No entity''"}}
+      if you can''t find any. If there are multiple entities, use a comma to join
+      them.
 
 
       |||
 
-      {% if (motion_entities  | length) > 1 %}
+      {% if (motion_entities  | length) == 0 %}
 
-      {{ "Yes" }}
+      {{ "No entity" }}
 
       {% else %}
 
-      {{ "No" }}
+      {{motion_entities | map(attribute="entity") | join(", ")}}
 
       {% endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: find_entities_question
+    reference: ''
+  74c9962e-3ec2-4f06-ace4-fcac6f506076: !Template
+    answer_choices: Yes ||| No
+    id: 74c9962e-3ec2-4f06-ace4-fcac6f506076
+    jinja: "Extract: {{sentence}}\n\nIs there more than one mention of a moving entity\
+      \ in the extract? \n\n|||\n{% if (motion_entities  | length) > 1 %}\n{{ answer_choices[0]\
+      \ }}\n{% else %}\n{{ answer_choices[1] }}\n{% endif %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
       original_task: false
     name: more_than_one
     reference: ''
@@ -88,29 +102,47 @@ templates:
     id: 766ab346-6fa6-4496-915f-65e7b06ab8ac
     jinja: '{{sentence}}
 
-      How many moving entities are mentioned in the sentence?
+      How many moving entities are mentioned in the sentence above?
 
       |||
 
       {{motion_entities | length}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: false
     name: count_entities
     reference: ''
   957deab1-7570-4cbf-a31f-55bfad5212a7: !Template
     answer_choices: null
     id: 957deab1-7570-4cbf-a31f-55bfad5212a7
-    jinja: "Name the entities in motion in the following sentence. Respond {{\"'No\
-      \ entity'\"}} if you can't find any. \n\n{{sentence}}\n\n|||\n\n{% if (motion_entities\
-      \ | length) == 0 %}\n{{\"No entity\"}}\n{% else %}\n{{motion_entities | map(attribute=\"\
+    jinja: "List out the entities in motion in the following sentence (if there are\
+      \ multiple entities, use a comma to join them). Respond {{\"'No entity'\"}}\
+      \ if you can't find any. \n\n{{sentence}}\n\n|||\n\n{% if (motion_entities |\
+      \ length) == 0 %}\n{{\"No entity\"}}\n{% else %}\n{{motion_entities | map(attribute=\"\
       entity\") | join(\", \")}}\n{% endif %}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: true
-    name: find_entities_affirm
+    name: find_entities_list_out
+    reference: ''
+  9cbb6dce-6463-4785-8130-fbe21216eb69: !Template
+    answer_choices: null
+    id: 9cbb6dce-6463-4785-8130-fbe21216eb69
+    jinja: "Sam has watched a video described as \"{{sentence}}\". What are the entities\
+      \ moving in the video? \n\nList the entities separated by commas. Return {{\"\
+      'No entity'\"}} if there isn't any.\n\n|||\n{% if (motion_entities  | length)\
+      \ == 0 %}\n{{ \"No entity\" }}\n{% else %}\n{{motion_entities | map(attribute=\"\
+      entity\") | join(\", \")}}\n{% endif %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: find_entities_moving_in_video
     reference: ''
   af2203ba-d176-4981-82bd-088ef0c39214: !Template
     answer_choices: null
@@ -118,7 +150,8 @@ templates:
     jinja: '{{sentence}}
 
 
-      Name the first entity in motion mentioned in the sentence if any
+      Name the first entity in motion mentioned in the sentence if any. Otherwise,
+      respond with "No entity in motion".
 
 
       |||
@@ -134,8 +167,9 @@ templates:
 
       {% endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
       original_task: false
     name: first_moving_entity
     reference: ''
@@ -150,13 +184,14 @@ templates:
 
       {{motion_entities | length}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: false
     name: count_entities_affirm
     reference: ''
   e5482b0d-ed6e-44de-a6e9-b64cdd1e2013: !Template
-    answer_choices: null
+    answer_choices: Yes ||| No
     id: e5482b0d-ed6e-44de-a6e9-b64cdd1e2013
     jinja: 'Is there any reference to movement in the following sentence?
 
@@ -167,23 +202,64 @@ templates:
       |||
 
 
-      {{motion}}'
+      {% if motion == "yes" %}
+
+      {{ answer_choices[0] }}
+
+      {% else %}
+
+      {{ answer_choices[1] }}
+
+      {% endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
       original_task: false
-    name: any_entity_indirect
+    name: any_entity_reference
     reference: Indirectly asking whether there are moving entities
   e8fca13b-7063-4ebc-9a4d-c124398cacf4: !Template
     answer_choices: null
     id: e8fca13b-7063-4ebc-9a4d-c124398cacf4
-    jinja: "Extract: {{sentence}}\n\nCan you find all mentions of moving entities\
-      \ in the extract? Return {{\"'No entity'\"}} if you can't find any. \n\n|||\n\
-      {% if (motion_entities  | length) == 0 %}\n{{ \"No entity\" }}\n{% else %}\n\
-      {{motion_entities | map(attribute=\"entity\") | join(\", \")}}\n{% endif %}"
+    jinja: 'Extract: {{sentence}}
+
+
+      Can you find all mentions of moving entities in the extract? Return {{"''No
+      entity''"}} if you can''t find any.  If there are multiple entities, use a comma
+      to join them.
+
+
+      |||
+
+      {% if (motion_entities  | length) == 0 %}
+
+      {{ "No entity" }}
+
+      {% else %}
+
+      {{motion_entities | map(attribute="entity") | join(", ")}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: true
     name: find_entities_extract
+    reference: ''
+  ebfec558-fce8-4935-8f28-648c184a3f1a: !Template
+    answer_choices: null
+    id: ebfec558-fce8-4935-8f28-648c184a3f1a
+    jinja: "What are the dynamic entities in the following sentence (if there are\
+      \ multiple entities, use a comma to join them)? Dynamic entities refer to objects\
+      \ in motion. Respond {{\"'No entity'\"}} if you can't find any. \n\n{{sentence}}\n\
+      \n|||\n\n{% if (motion_entities | length) == 0 %}\n{{\"No entity\"}}\n{% else\
+      \ %}\n{{motion_entities | map(attribute=\"entity\") | join(\", \")}}\n{% endif\
+      \ %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: find_entities_dynamic
     reference: ''


### PR DESCRIPTION
I've done the following for the cleaning:
- [X] add metrics
- [X] add more templates so we have more than 5 templates.
- [X] add answer choices for yes/no prompts

### Discussion about metrics
- The original tasks (`find_entities_*`) are sequence tagging tasks. The prompt output here is a list of entities in motion. Given this [discussion about Accuracy](https://github.com/bigscience-workshop/promptsource/pull/592/files#diff-65f41d4038388a2817ae686969f206cb05c4c61a9efeebf91221f533ed895328R89), I believe evaluating output requires parsing. Therefore, I choose Others as the metric. The correct metric would be Precision, Recall, and F1.
- However, I use Accuracy as a metrics for the two prompts: first_moving_entity and last_moving_entity. My reasoning is that exact string match can be applied here.
- For the regression task (`count_entities*`), I use Other metrics because the appropriate metrics should be the mean-squared error. Should I use accuracy instead?