### PR TITLE
clean ambig_qa/light

### DIFF
--- a/promptsource/templates/ambig_qa/light/templates.yaml
+++ b/promptsource/templates/ambig_qa/light/templates.yaml
@@ -21,7 +21,7 @@ templates:
       metrics:
       - BLEU
       - Edit Distance
-      original_task: true
+      original_task: false
     name: is_question_ambiguous
     reference: ''
   09880e1a-0fcc-49dc-8462-b6603e15d691: !Template
@@ -88,7 +88,7 @@ templates:
       choices_in_prompt: true
       metrics:
       - Accuracy
-      original_task: true
+      original_task: false
     name: answer_prediction_yes_or_no
     reference: Classify if the given answer if correct compared to the chosen question
   bb089312-23cb-475d-93b5-952781bc6be4: !Template
@@ -113,6 +113,6 @@ templates:
       metrics:
       - BLEU
       - ROUGE
-      original_task: true
+      original_task: false
     name: perform_question_disambiguation
     reference: ''

--- a/promptsource/templates/ambig_qa/light/templates.yaml
+++ b/promptsource/templates/ambig_qa/light/templates.yaml
@@ -1,28 +1,74 @@
 dataset: ambig_qa
 subset: light
 templates:
-  5f79fa25-3804-4e32-9493-a12c1c2ddff0: !Template
+  050b1534-b53f-4341-b42c-6e689ef8911b: !Template
     answer_choices: null
-    id: 5f79fa25-3804-4e32-9493-a12c1c2ddff0
+    id: 050b1534-b53f-4341-b42c-6e689ef8911b
     jinja: "{# Assignement in if clause breaks test, we need to declare variables\
       \ in global scope first: https://github.com/pallets/jinja/issues/1314 #}\n{%\
       \ set selected_question = \"\" %}\n{% set selected_answer = \"\" %}\n{% set\
       \ random_question_id = -1 %}\n{% if annotations.type[0] == \"multipleQAs\" %}\n\
       \   {% set random_question_id = range(0, annotations.qaPairs[0].question | length)\
-      \ | choice%}\n   {% set selected_question = annotations.qaPairs[0].question[random_question_id]\
-      \ %}\n   {% set selected_answer = annotations.qaPairs[0].answer[random_question_id]\
-      \ | choice %}\n{% else %}\n    {% set selected_question = question %}\n    {%\
-      \ set selected_answer = annotations.answer | choice %}\n{% endif %}\n\n{{selected_question}}\n\
-      |||\n{{selected_answer}}"
+      \ | choice%}\n   {% set selected_question = annotations.qaPairs[0].question[random_question_id]%}\n\
+      \   {% set selected_answer = annotations.qaPairs[0].answer[random_question_id]\
+      \ | choice%}\n{% else %}\n   {% set selected_question = question %}\n   {% set\
+      \ selected_answer = annotations.answer[0] | choice %}\n{% endif %}\n\nHere's\
+      \ a question-answer pair: {{question}} {{selected_answer}}.\nIs the question\
+      \ ambiguous? If so, generate a better question suitable for the answer. Otherwise,\
+      \ output the same question.\n|||\n{{selected_question}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: ambig_qa_light3
-    reference: Randomly choose an annotated question and answer it using one of its
-      answers.
-  72bf511b-44ce-4b9f-a2d0-5ed6334f0e07: !Template
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - Edit Distance
+      original_task: true
+    name: is_question_ambiguous
+    reference: ''
+  09880e1a-0fcc-49dc-8462-b6603e15d691: !Template
     answer_choices: null
+    id: 09880e1a-0fcc-49dc-8462-b6603e15d691
+    jinja: "What are the possible answers to the question \"{{question}}\"? Use semi-colons\
+      \ to separate your answers if you have multiple answers.\n\n|||\n\n{# Assignement\
+      \ in if clause breaks test, we need to declare variables in global scope first:\
+      \ https://github.com/pallets/jinja/issues/1314 #}\n{% set random_answer = \"\
+      \" %}\n{% set random_answer_form = \"\" %}\n{% if annotations.type[0] == \"\
+      singleAnswer\" %}\n    {% set random_answer_form = [] %}\n    {% for possible_answer\
+      \ in annotations.answer[0] %}\n    {{ random_answer_form.append(possible_answer\
+      \ ) or \"\"}}\n    {% endfor %}\n{% else %}\n    {% set random_answer_form =\
+      \ [] %}\n    {% for possible_answers in annotations.qaPairs[0].answer %}\n \
+      \   {% for possible_answer in possible_answers %}\n    {{ random_answer_form.append(possible_answer\
+      \ ) or \"\"}}\n    {% endfor %}\n    {% endfor %}\n{% endif %}\n\n{{random_answer_form\
+      \ | join(\"; \")}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: answer_prediction_all_answers_interrogative
+    reference: ''
+  45b20de4-a3c1-4e76-ad79-06d7c8c66009: !Template
+    answer_choices: null
+    id: 45b20de4-a3c1-4e76-ad79-06d7c8c66009
+    jinja: "Given the question \"{{question}}\", generate all the possible answers,\
+      \ separated by semi-colon.\n\n|||\n\n{# Assignement in if clause breaks test,\
+      \ we need to declare variables in global scope first: https://github.com/pallets/jinja/issues/1314\
+      \ #}\n{% set random_answer = \"\" %}\n{% set random_answer_form = \"\" %}\n\
+      {% if annotations.type[0] == \"singleAnswer\" %}\n    {% set random_answer_form\
+      \ = [] %}\n    {% for possible_answer in annotations.answer[0] %}\n    {{ random_answer_form.append(possible_answer\
+      \ ) or \"\"}}\n    {% endfor %}\n{% else %}\n    {% set random_answer_form =\
+      \ [] %}\n    {% for possible_answers in annotations.qaPairs[0].answer %}\n \
+      \   {% for possible_answer in possible_answers %}\n    {{ random_answer_form.append(possible_answer\
+      \ ) or \"\"}}\n    {% endfor %}\n    {% endfor %}\n{% endif %}\n\n{{random_answer_form\
+      \ | join(\"; \")}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: answer_prediction_all_answers_affirmative
+    reference: ''
+  72bf511b-44ce-4b9f-a2d0-5ed6334f0e07: !Template
+    answer_choices: Yes ||| No
     id: 72bf511b-44ce-4b9f-a2d0-5ed6334f0e07
     jinja: "{# Assignement in if clause breaks test, we need to declare variables\
       \ in global scope first: https://github.com/pallets/jinja/issues/1314 #}\n{%\
@@ -35,31 +81,16 @@ templates:
       \ | choice%}\n{% else %}\n   {% set random_question_id = 0 %}\n   {% set random_answer_id\
       \ = 0 %}\n   {% set selected_question = question %}\n   {% set selected_answer\
       \ = annotations.answer[0] | choice %}\n{% endif %}\n\nIs \"{{selected_answer}}\"\
-      \ the answer to \"{{selected_question}}\"?\n\n|||\n\n{% if random_answer_id\
-      \ == random_question_id %} Yes {% else %} No {% endif %}"
+      \ an acceptable answer to \"{{selected_question}}\"? {{answer_choices[0]}} or\
+      \ {{answer_choices[1].lower()}}?\n\n|||\n\n{% if random_answer_id == random_question_id\
+      \ %} {{answer_choices[0]}} {% else %} {{answer_choices[1]}} {% endif %}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: ambig_qa_light4
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: answer_prediction_yes_or_no
     reference: Classify if the given answer if correct compared to the chosen question
-  7655d2aa-70df-42cf-9bfa-80484521f856: !Template
-    answer_choices: null
-    id: 7655d2aa-70df-42cf-9bfa-80484521f856
-    jinja: "{{question}}\n\n|||\n\n{# Assignement in if clause breaks test, we need\
-      \ to declare variables in global scope first: https://github.com/pallets/jinja/issues/1314\
-      \ #}\n{% set random_answer = \"\" %}\n{% set random_answer_form = \"\" %}\n\
-      {% if annotations.type[0] == \"singleAnswer\" %}\n    {% set random_answer_form\
-      \ = annotations.answer[0] | choice %}\n{% else %}\n    {% set random_answer\
-      \ = annotations.qaPairs[0].answer | choice %}\n    {% set random_answer_form\
-      \ = random_answer | choice %}\n{% endif %}\n\n{{random_answer_form}}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: ambig_qa_light1
-    reference: Given the question, we choose the answer in single QA and randomly
-      choose when in multipleQA.
   bb089312-23cb-475d-93b5-952781bc6be4: !Template
     answer_choices: null
     id: bb089312-23cb-475d-93b5-952781bc6be4
@@ -71,24 +102,17 @@ templates:
       \ | choice%}\n   {% set selected_question = annotations.qaPairs[0].question[random_question_id]%}\n\
       \   {% set selected_answer = annotations.qaPairs[0].answer[random_question_id]\
       \ | choice%}\n{% else %}\n   {% set selected_question = question %}\n   {% set\
-      \ selected_answer = annotations.answer | choice %}\n{% endif %}\nKnowing that\
-      \ \"{{selected_answer}}\" is the answer, what could have been the question?\n\
-      |||\n{{selected_question}}"
+      \ selected_answer = annotations.answer[0] | choice %}\n{% endif %}\n\nQuestion:\
+      \ {{question}}\nAnswer: {{selected_answer}}\n\nKnowing that the question can\
+      \ be ambiguous, can you perform question disambiguation by generating a question\
+      \ such that \"{{selected_answer}}\" is a more suitable answer? If you deem that\
+      \ the question is not ambiguous, generate the same question given above.\n|||\n\
+      {{selected_question}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: ambig_qa_light5
-    reference: Generate the answer from the question
-  f53d00ea-98a8-45d3-92f6-93a8909aef2a: !Template
-    answer_choices: null
-    id: f53d00ea-98a8-45d3-92f6-93a8909aef2a
-    jinja: "{{question}}\n\n|||\n\n{% if annotations.type[0] == \"singleAnswer\" %}\n\
-      \    {{annotations.answer[0] | choice}}\n{% else %}\n    The questions was ambiguous.\
-      \ Did you mean \"{{annotations.qaPairs[0].question |choice}}\"?\n{% endif %}\n"
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: ambig_qa_light2
-    reference: If a question is ambiguous, ask another question, otherwise answer.
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: true
+    name: perform_question_disambiguation
+    reference: ''


### PR DESCRIPTION
I have completed the following:
- [X] increase templates for original tasks 
- [X] rename templates
- [X] include metrics and answer choices

### Discussion and Reasoning:
- I use Other metrics for the original task of answer prediction because the evaluation setup requires parsing the gold target output into a set of answers, and check if the model's output matches any of the gold answer.
- I use BLEU and Edit distance for the original task of question disambiguation, but I am not too sure if it is the right one. The evaluation setup wants to find the maximum BLEU and minimum Edit distance (as it is evaluated on a set of strings instead of a single string). See equation for correctness score in the original paper [here](https://arxiv.org/pdf/2004.10645.pdf).