### PR TITLE
Clean up `numer_sense`

### DIFF
--- a/promptsource/templates/numer_sense/templates.yaml
+++ b/promptsource/templates/numer_sense/templates.yaml
@@ -1,30 +1,18 @@
 dataset: numer_sense
 templates:
-  15ca5a34-71ed-48c0-b0ad-afc40e698a67: !Template
-    answer_choices: null
-    id: 15ca5a34-71ed-48c0-b0ad-afc40e698a67
-    jinja: "{{sentence | replace(\"<mask>\", \"__________\")}}\n\nThe above sentence\
-      \ can be filled with a number word. True or False?\n\n||| \n\n{% if target ==\
-      \ \"no\" %} \nFalse\n{% elif target != \"no\" %}\nTrue\n{% endif %}"
-    metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: false
-    name: fill_in_the_blank_v6
-    reference: ''
   1f959d92-dca8-4647-9840-69391dfbd000: !Template
-    answer_choices: null
+    answer_choices: nine ||| three ||| four ||| zero ||| two ||| six ||| eight |||
+      one ||| five ||| ten ||| no ||| seven
     id: 1f959d92-dca8-4647-9840-69391dfbd000
     jinja: "Fill in the blank in the following sentence using world knowledge:\n\n\
       {{sentence | replace(\"<mask>\", \"__________\")}}\n\nChose from the following\
-      \ options:\n\n{{\"nine\"}}, {{\"three\"}}, {{\"four\"}}, {{\"zero\"}}, {{\"\
-      two\"}}, {{\"six\"}}, {{\"eight\"}}, {{\"one\"}}, {{\"five\"}}, {{\"ten\"}},\
-      \ {{\"no\"}}, {{\"seven\"}}\n\n||| \n\n{{target}}"
+      \ options:\n\n{{ ', '.join(answer_choices) }}\n\n||| \n\n{{target}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: true
-    name: fill_in_the_blank_v5
+    name: fill_in_the_blank_with_choices_after
     reference: ''
   4e9da2b8-2502-44a7-a7da-ae62f2d554c9: !Template
     answer_choices: null
@@ -44,20 +32,21 @@ templates:
 
       {{target}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
       original_task: true
-    name: fill_in_the_blank_v2
+    name: fill_in_the_blank_with_instruction
     reference: ''
   5d8e8d21-8059-4373-bbf2-a25cbe1e6960: !Template
-    answer_choices: null
+    answer_choices: nine ||| three ||| four ||| zero ||| two ||| six ||| eight |||
+      one ||| five ||| ten ||| no ||| seven
     id: 5d8e8d21-8059-4373-bbf2-a25cbe1e6960
     jinja: 'Using common sense reasoning of the world and only the following options,
       how would you fill in the blank?:
 
 
-      {{"nine"}}, {{"three"}}, {{"four"}}, {{"zero"}}, {{"two"}}, {{"six"}}, {{"eight"}},
-      {{"one"}}, {{"five"}}, {{"ten"}}, {{"no"}}, {{"seven"}}
+      {{ '', ''.join(answer_choices) }}
 
 
       {{sentence | replace("<mask>", "__________")}}
@@ -68,10 +57,11 @@ templates:
 
       {{target}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: true
-    name: fill_in_the_blank_v3
+    name: fill_in_the_blank_with_choices_before
     reference: with all the given options
   cacee36c-e2b7-458e-9d51-6fcfd83842b4: !Template
     answer_choices: null
@@ -90,22 +80,23 @@ templates:
 
       {{target}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
       original_task: true
-    name: fill_in_the_blank_v1
+    name: fill_in_the_blank_before_sentence
     reference: replace mask with fill in the blank
   fc76beb7-c258-412f-a623-42fc8d2331b6: !Template
-    answer_choices: null
+    answer_choices: nine ||| three ||| four ||| zero ||| two ||| six ||| eight |||
+      one ||| five ||| ten ||| no ||| seven
     id: fc76beb7-c258-412f-a623-42fc8d2331b6
     jinja: "{{sentence | replace(\"<mask>\", \"__________\")}}\n\nUsing only the following\
-      \ options, what answer would make the most sense in the blank above?\n\n{{\"\
-      nine\"}}, {{\"three\"}}, {{\"four\"}}, {{\"zero\"}}, {{\"two\"}}, {{\"six\"\
-      }}, {{\"eight\"}}, {{\"one\"}}, {{\"five\"}}, {{\"ten\"}}, {{\"no\"}}, {{\"\
-      seven\"}}\n\n||| \n\n{{target}}"
+      \ options, what answer would make the most sense in the blank above?\n\n{{ ',\
+      \ '.join(answer_choices) }}\n\n||| \n\n{{target}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
       original_task: true
-    name: fill_in_the_blank_v8
+    name: fill_in_the_blank_with_instruction_and_choices
     reference: missing word simple


### PR DESCRIPTION
This PR cleans up `numer_sense` by:
- Remove an inappropriate and unbalanced template
- Rename the templates
- Add tags 
- Add metric
- Use `answer_choices`