### PR TITLE
Clean up `mdd`

### DIFF
--- a/promptsource/templates/mdd/task1_qa/templates.yaml
+++ b/promptsource/templates/mdd/task1_qa/templates.yaml
@@ -1,24 +1,91 @@
 dataset: mdd
 subset: task1_qa
 templates:
+  0523ad87-64ab-4a9c-8772-56deda832ab4: !Template
+    answer_choices: null
+    id: 0523ad87-64ab-4a9c-8772-56deda832ab4
+    jinja: "Using the internet, answer the following question:\n\n{{ dialogue_turns.utterance[0][0]\
+      \ | capitalize }}{{ dialogue_turns.utterance[0][1:] }} \n|||\n{{dialogue_turns.utterance[1]}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: using_internet_answer
+    reference: Template asks the model to answer the question with a prefix "using
+      the internet"
+  1aa44534-ddbf-4478-9682-50192183ab82: !Template
+    answer_choices: null
+    id: 1aa44534-ddbf-4478-9682-50192183ab82
+    jinja: 'Given the best answer(s), "{{ dialogue_turns.utterance[1] }}", generate
+      a movie-trivia question:
+
+      |||
+
+      {{ dialogue_turns.utterance[0][0] | capitalize }}{{ dialogue_turns.utterance[0][1:]
+      }} '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
+      original_task: false
+    name: prompt_generate_question
+    reference: Given the answer with prompt, generate a question related to it.
   59b9d82e-b778-429c-a45c-a27d6abdf13a: !Template
     answer_choices: null
     id: 59b9d82e-b778-429c-a45c-a27d6abdf13a
-    jinja: '{{dialogue_turns.utterance[0]}}|||{{dialogue_turns.utterance[1]}}'
+    jinja: "{{ dialogue_turns.utterance[0][0] | capitalize }}{{ dialogue_turns.utterance[0][1:]\
+      \ }} \n|||\n{{dialogue_turns.utterance[1]}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: true
     name: question_answering
     reference: Given a question, return the answer.
+  a0b665ab-001f-44f6-9094-d2d5ef60926c: !Template
+    answer_choices: null
+    id: a0b665ab-001f-44f6-9094-d2d5ef60926c
+    jinja: "Complete this movie-trivia-related dialogue between Speaker {{ dialogue_turns.speaker[0]\
+      \ }} and Speaker {{ dialogue_turns.speaker[1] }} by answering Speaker {{ dialogue_turns.speaker[0]\
+      \ }}'s question as Speaker {{ dialogue_turns.speaker[1] }}.\n\nSpeaker {{ dialogue_turns.speaker[0]\
+      \ }}: {{ dialogue_turns.utterance[0][0] | capitalize }}{{ dialogue_turns.utterance[0][1:]\
+      \ }} \n\nSpeaker {{ dialogue_turns.speaker[1] }}:\n|||\n{{dialogue_turns.utterance[1]}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: question_answering_speaker
+    reference: Given a question, return the answer with speaker information.
   bedf40a1-630a-4aae-ad2f-cfc90f77fb9f: !Template
     answer_choices: null
     id: bedf40a1-630a-4aae-ad2f-cfc90f77fb9f
-    jinja: 'Generate a movie-trivia question for this answer: {{ dialogue_turns.utterance[1]
-      }}|||{{ dialogue_turns.utterance[0] }}'
+    jinja: 'Generate a movie-trivia question for the answer(s): {{ dialogue_turns.utterance[1]
+      }}
+
+      |||
+
+      {{ dialogue_turns.utterance[0][0] | capitalize }}{{ dialogue_turns.utterance[0][1:]
+      }} '
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - BLEU
+      - ROUGE
       original_task: false
     name: generate_question
     reference: Given the answer, generate a question related to it.
+  cba3d029-993d-4a95-a213-0e70efde6009: !Template
+    answer_choices: null
+    id: cba3d029-993d-4a95-a213-0e70efde6009
+    jinja: "Answer the following question:\n\n{{ dialogue_turns.utterance[0][0] |\
+      \ capitalize }}{{ dialogue_turns.utterance[0][1:] }} \n|||\n{{dialogue_turns.utterance[1]}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: prompt_question_answering
+    reference: Given a question with prompt, return the answer.

--- a/promptsource/templates/mdd/task2_recs/templates.yaml
+++ b/promptsource/templates/mdd/task2_recs/templates.yaml
@@ -1,13 +1,49 @@
 dataset: mdd
 subset: task2_recs
 templates:
+  3596d528-12c6-440b-bdc0-d61076b108c5: !Template
+    answer_choices: null
+    id: 3596d528-12c6-440b-bdc0-d61076b108c5
+    jinja: "Complete this movie-trivia-related dialogue between Speaker {{ dialogue_turns.speaker[0]\
+      \ }} and Speaker {{ dialogue_turns.speaker[1] }} by answering Speaker {{ dialogue_turns.speaker[0]\
+      \ }}'s question as Speaker {{ dialogue_turns.speaker[1] }}.\n\nSpeaker {{dialogue_turns.speaker[0]}}:\
+      \ {{dialogue_turns.utterance[0]}}\n\nSpeaker {{dialogue_turns.speaker[1]}}:\
+      \ \n|||\n{{dialogue_turns.utterance[1]}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: recommend_movies_speaker
+    reference: Given likes, recomend a movie with speaker information.
   6f0eb61c-d9f9-4e52-a317-3d7b8049eb9b: !Template
     answer_choices: null
     id: 6f0eb61c-d9f9-4e52-a317-3d7b8049eb9b
-    jinja: '{{dialogue_turns.utterance[0]}}|||{{dialogue_turns.utterance[1]}}'
+    jinja: '{{dialogue_turns.utterance[0]}}
+
+      |||
+
+      {{dialogue_turns.utterance[1]}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: true
     name: recommed_movies
     reference: Given the likes,  recommend a movie.
+  8948a52c-a422-4858-bbf7-19790597d278: !Template
+    answer_choices: null
+    id: 8948a52c-a422-4858-bbf7-19790597d278
+    jinja: '{{ ["Someone said:", "He said:", "She said:", "They said:", "A friend
+      asked me:", "A colleague asked me:"] | choice  }} "{{ dialogue_turns.utterance[0].rsplit(".")[0]
+      }}."{{ dialogue_turns.utterance[0].rsplit(".")[1] }}
+
+      |||
+
+      {{dialogue_turns.utterance[1]}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics: []
+      original_task: false
+    name: recommend_movies_dialogue
+    reference: Given the likes, recommend a movie as a dialogue

--- a/promptsource/templates/mdd/task2_recs/templates.yaml
+++ b/promptsource/templates/mdd/task2_recs/templates.yaml
@@ -35,8 +35,8 @@ templates:
     answer_choices: null
     id: 8948a52c-a422-4858-bbf7-19790597d278
     jinja: '{{ ["Someone said:", "He said:", "She said:", "They said:", "A friend
-      asked me:", "A colleague asked me:"] | choice  }} "{{ dialogue_turns.utterance[0].rsplit(".")[0]
-      }}."{{ dialogue_turns.utterance[0].rsplit(".")[1] }}
+      asked me:", "A colleague asked me:"] | choice  }} {{ dialogue_turns.utterance[0]
+      }}
 
       |||
 

--- a/promptsource/templates/mdd/task3_qarecs/templates.yaml
+++ b/promptsource/templates/mdd/task3_qarecs/templates.yaml
@@ -6,56 +6,58 @@ templates:
     id: 1614890b-362c-4ee8-850d-841cf511d169
     jinja: '{% if dialogue_turns.utterance|length==6%}
 
-      This is a film-related dialogue between Speaker 1 and Speaker 2. Complete Speaker
-      2''s intervention to answer Speaker 1''s question.
+      Complete this movie-trivia-related dialogue between Speaker {{ dialogue_turns.speaker[0]
+      }} and Speaker {{ dialogue_turns.speaker[1] }} by answering Speaker {{ dialogue_turns.speaker[0]
+      }}''s question as Speaker {{ dialogue_turns.speaker[1] }}.
 
 
-      Speaker 1: {{dialogue_turns.utterance[0]}}
+      Speaker {{ dialogue_turns.speaker[0] }}: {{dialogue_turns.utterance[0]}}
 
 
-      Speaker 2: {{dialogue_turns.utterance[1]}}
+      Speaker {{ dialogue_turns.speaker[1] }}: {{dialogue_turns.utterance[1]}}
 
 
-      Speaker 1: {{dialogue_turns.utterance[2]}}
+      Speaker {{ dialogue_turns.speaker[2] }}: {{dialogue_turns.utterance[2]}}
 
 
-      Speaker 2:|||{{dialogue_turns.utterance[3]}}
-
-      {% else %}
+      Speaker {{ dialogue_turns.speaker[3] }}:
 
       |||
 
+      {{dialogue_turns.utterance[3]}}
+
       {% endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: false
     name: next_utterance_4_for_6
     reference: Given the first three dialogues,  generate next utterance for dialogues
       of length 6.
   3e5a19e5-aa33-467a-bcd2-f84d99f32759: !Template
     answer_choices: null
     id: 3e5a19e5-aa33-467a-bcd2-f84d99f32759
-    jinja: '{% set context_init= ["", "Someone said", "He said", "She said", "They
-      said", "A friend asked me", "A colleague asked me"]|choice %}
+    jinja: '{{ ["Someone said:", "He said:", "She said:", "They said:", "A friend
+      asked me:", "A colleague asked me:"] | choice  }} "{{dialogue_turns.utterance[0]}}"
+      Which movie will you recommend?
 
-      {{context_init}}
+      |||
 
-      {% if context_init =="" %}{{dialogue_turns.utterance[0]}}|||{{dialogue_turns.utterance[1]}}{%
-      else %}"{{dialogue_turns.utterance[0]}}". Which movie will you recommend?|||{{dialogue_turns.utterance[1]}}{%
-      endif %}'
+      {{dialogue_turns.utterance[1]}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: false
     name: recommend_movie_1
     reference: Given likes, recommend a movie.
   76888d6e-76fa-47db-a8b3-9980f082df51: !Template
     answer_choices: null
     id: 76888d6e-76fa-47db-a8b3-9980f082df51
-    jinja: ' {% set context_init = ["", "Someone said", "He said", "She said", "They
-      asked", "A friend asked me", "A colleague asked me"]|choice %} {% set pronoun
-      = "he" %}
+    jinja: ' {% set context_init = ["", "Someone said:", "He said:", "She said:",
+      "They asked:", "A friend asked me:", "A colleague asked me:"]|choice %} {% set
+      pronoun = "he" %}
 
       {% if dialogue_turns.utterance|length==6 %}
 
@@ -86,8 +88,9 @@ templates:
 
       {% endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: false
     name: recommend_movie_2
     reference: Given a single preference, recommend a movie. Only works for dialogues
@@ -138,10 +141,10 @@ templates:
 
       {%endif%}
 
-      {{context_init}} that the movie: "{{dialogue_turns.utterance[1]}}", is related
-      to: {{dialogue_turns.utterance[3]}}.
+      {{context_init}} that the movie {{dialogue_turns.utterance[1]}}, is related
+      to {{dialogue_turns.utterance[3]}}.
 
-      Also, {% if pronoun!="I" %}{{pronoun}} said "{{dialogue_turns.utterance[4]}}".
+      Also, {% if pronoun!="I" %}{{pronoun}} said: "{{dialogue_turns.utterance[4]}}".
       Can you recommend a movie for {{pronoun_2}} please?|||{{dialogue_turns.utterance[5]}}{%else%}{{dialogue_turns.utterance[4]}}|||{{dialogue_turns.utterance[5]}}{%
       endif %}
 
@@ -151,8 +154,9 @@ templates:
 
       {% endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: false
     name: recommend_movie_3
     reference: Given previous suggestion, some movie description, and preference,
@@ -160,8 +164,8 @@ templates:
   92cb9273-b89f-410f-a7f2-db8c84f42862: !Template
     answer_choices: null
     id: 92cb9273-b89f-410f-a7f2-db8c84f42862
-    jinja: ' {% set context_init= ["", "He said", "She said", "They said", "Someone
-      said", "A friend said", "A colleague said", "A person said"]|choice %}
+    jinja: ' {% set context_init= ["", "He said:", "She said:", "They said:", "Someone
+      said:", "A friend said:", "A colleague said:", "A person said:"]|choice %}
 
       {% set pronoun = "he" %} {% set pronoun_2 = "him" %} {% set choice_idx = 0 %}
       {% if dialogue_turns.utterance|length==6 %}
@@ -211,50 +215,61 @@ templates:
 
       {% endif %}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: false
     name: recommend_movie_4
     reference: Given likes and preferences, recommend a movie.
   de1179b3-b6d6-4acf-9b0a-82cb2fa9d58f: !Template
     answer_choices: null
     id: de1179b3-b6d6-4acf-9b0a-82cb2fa9d58f
-    jinja: 'Complete this movie-trivia-related dialogue between Speaker 1 and Speaker
-      2 by answering Speaker 1''s question as Speaker 2.
+    jinja: 'Complete this movie-trivia-related dialogue between Speaker {{ dialogue_turns.speaker[0]
+      }} and Speaker {{ dialogue_turns.speaker[1] }} by answering Speaker {{ dialogue_turns.speaker[0]
+      }}''s question as Speaker {{ dialogue_turns.speaker[1] }}.
 
 
-      Speaker 1: {{dialogue_turns.utterance[0]}}
+      Speaker {{ dialogue_turns.speaker[0] }}: {{dialogue_turns.utterance[0]}}
 
 
-      Speaker 2: {{dialogue_turns.utterance[1]}}
+      Speaker {{ dialogue_turns.speaker[1] }}: {{dialogue_turns.utterance[1]}}
 
 
-      Speaker 1: {{dialogue_turns.utterance[2]}}
+      Speaker {{ dialogue_turns.speaker[2] }}: {{dialogue_turns.utterance[2]}}
 
 
-      {% if dialogue_turns.utterance|length==6 %} Speaker 2: {{dialogue_turns.utterance[3]}}
+      {% if dialogue_turns.utterance|length==6 %}Speaker {{ dialogue_turns.speaker[3]
+      }}: {{dialogue_turns.utterance[3]}}
 
 
-      Speaker 1: {{dialogue_turns.utterance[4]}}
+      Speaker {{ dialogue_turns.speaker[4] }}: {{dialogue_turns.utterance[4]}}
 
 
-      {% endif %} Speaker 2:|||{{dialogue_turns.utterance[-1]}}'
+      {% endif %}Speaker {{ dialogue_turns.speaker[5] }}:|||
+
+      {{dialogue_turns.utterance[-1]}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
-      original_task: null
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: false
     name: next_utterance_4_and_6
     reference: Given the first dialogues, return the next utterance.
   e37a6f9c-344c-4b85-a41f-85bb84bab934: !Template
     answer_choices: null
     id: e37a6f9c-344c-4b85-a41f-85bb84bab934
-    jinja: 'For the movie - {{dialogue_turns.utterance[1]}}, answer this question:
+    jinja: 'Answer the following question about movie {{dialogue_turns.utterance[1]}}:
 
 
-      {{dialogue_turns.utterance[2]}}|||{{dialogue_turns.utterance[3]}}'
+      {{dialogue_turns.utterance[2]}}
+
+      |||
+
+      {{dialogue_turns.utterance[3]}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: false
     name: qa_about movie
     reference: Given the movie name and a question, answer the question.

--- a/promptsource/templates/mdd/task3_qarecs/templates.yaml
+++ b/promptsource/templates/mdd/task3_qarecs/templates.yaml
@@ -50,7 +50,7 @@ templates:
       metrics:
       - Other
       original_task: false
-    name: recommend_movie_1
+    name: recommend_movie_first_round
     reference: Given likes, recommend a movie.
   76888d6e-76fa-47db-a8b3-9980f082df51: !Template
     answer_choices: null
@@ -92,7 +92,7 @@ templates:
       metrics:
       - Other
       original_task: false
-    name: recommend_movie_2
+    name: recommend_movie_second_round
     reference: Given a single preference, recommend a movie. Only works for dialogues
       with 6 utterances.
   91f33bcf-3c0e-49e6-ae86-28f77e224734: !Template
@@ -158,69 +158,9 @@ templates:
       metrics:
       - Other
       original_task: false
-    name: recommend_movie_3
+    name: recommend_movie_second_round_with_context
     reference: Given previous suggestion, some movie description, and preference,
       recommend a movie.
-  92cb9273-b89f-410f-a7f2-db8c84f42862: !Template
-    answer_choices: null
-    id: 92cb9273-b89f-410f-a7f2-db8c84f42862
-    jinja: ' {% set context_init= ["", "He said:", "She said:", "They said:", "Someone
-      said:", "A friend said:", "A colleague said:", "A person said:"]|choice %}
-
-      {% set pronoun = "he" %} {% set pronoun_2 = "him" %} {% set choice_idx = 0 %}
-      {% if dialogue_turns.utterance|length==6 %}
-
-      {% if "He" in context_init %}
-
-      {% set pronoun = "he" %}
-
-      {% set pronoun_2 = "him" %}
-
-      {% elif "She" in context_init %}
-
-      {% set pronoun = "she" %}
-
-      {% set pronoun_2 = "her" %}
-
-      {% elif "They" in context_init or "Someone" in context_init or "person" in context_init%}
-
-      {% set pronoun = "they" %}
-
-      {% set pronoun_2 = "them" %}
-
-      {% elif "colleague" in context_init or "friend" in context_init %}
-
-      {% set choice_idx = range(3)|list|choice %}
-
-      {% set pronoun = ["he","she","they"][choice_idx] %}
-
-      {% set pronoun_2 = ["him","her","them"][choice_idx] %}
-
-      {%endif%}
-
-      {% if context_init!="" %}
-
-      {{context_init}} "{{dialogue_turns.utterance[0]}}". "{{dialogue_turns.utterance[4]}}",
-      {{pronoun}} added. Please recommend a movie for {{pronoun_2}}.|||{{dialogue_turns.utterance[5]}}
-
-      {%else%}
-
-      {{dialogue_turns.utterance[0]}} Also, {{dialogue_turns.utterance[4]}}|||{{dialogue_turns.utterance[5]}}
-
-      {% endif %}
-
-      {% else %}
-
-      |||
-
-      {% endif %}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Other
-      original_task: false
-    name: recommend_movie_4
-    reference: Given likes and preferences, recommend a movie.
   de1179b3-b6d6-4acf-9b0a-82cb2fa9d58f: !Template
     answer_choices: null
     id: de1179b3-b6d6-4acf-9b0a-82cb2fa9d58f


### PR DESCRIPTION
This PR cleans the three subtasks from the `math_dataset` dataset. Added more original prompts to the task.

Specifically, for the `task1_qa` subtask, I currently set the metrics for question-generation-style non-original tasks to BLEU and ROUGE. Please let me know if there are other better metrics.
Also, some movie entities and actor entities in the `train` split of `task1_qa` are not well-capitalized. I currently cannot find a jinja-based way to solve this problem.
