### PR TITLE
fix: for sent_comp, remove single quotes and add the metric of "Other"

### DIFF
--- a/promptsource/templates/sent_comp/templates.yaml
+++ b/promptsource/templates/sent_comp/templates.yaml
@@ -15,25 +15,25 @@ templates:
       metrics:
       - Other
       original_task: true
-    name: Template_0
-    reference: generate compression
+    name: <premise>-given_the_above-generate_compressed-<entailment>
+    reference: ''
   336ba469-f315-49ff-8c02-baf6d059972b: !Template
     answer_choices: null
     id: 336ba469-f315-49ff-8c02-baf6d059972b
-    jinja: '{{headline}}
+    jinja: '{{graph.sentence}}
 
 
       ===
 
 
-      Given the above headline, write one compressed sentence: ||| {{compression.text}}'
+      Given the above sentence, write a headline: ||| {{compression.text}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
       - Other
       original_task: false
-    name: Template_6
-    reference: write compression given headline
+    name: <premise>-given_the_above-write_headline-<entailment>
+    reference: ''
   6493cbf3-bce9-4556-92ab-ec815f768eb6: !Template
     answer_choices: null
     id: 6493cbf3-bce9-4556-92ab-ec815f768eb6
@@ -46,8 +46,8 @@ templates:
       metrics:
       - Other
       original_task: true
-    name: Template_1
-    reference: 'compressed sentence, sentence '
+    name: sentence-<premise>-compressed-<entailment>
+    reference: ''
   9391497d-4fd1-4977-aba8-dc20f9e9445a: !Template
     answer_choices: null
     id: 9391497d-4fd1-4977-aba8-dc20f9e9445a
@@ -60,42 +60,51 @@ templates:
       metrics:
       - Other
       original_task: true
-    name: Template_4
-    reference: extreme TLDR
+    name: <premise>-extreme_TLDR-<entailment>
+    reference: ''
   b7b2934c-cf3e-42b9-b7be-d6f1af679bce: !Template
     answer_choices: null
     id: b7b2934c-cf3e-42b9-b7be-d6f1af679bce
-    jinja: 'Compress this headline: {{headline}}
+    jinja: 'Write a headline for the sentence below:
+
+      {{graph.sentence}}
 
 
-      compressed sentence: ||| {{compression.text}}'
+      headline:
+
+      |||
+
+      {{headline}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
       - Other
       original_task: false
-    name: Template_5
-    reference: from headline to compressed version
+    name: write_headline-<premise>-headline-<entailment>
+    reference: ''
   ca70c220-b9d8-46fa-8d83-3b9ba9e177c0: !Template
     answer_choices: null
     id: ca70c220-b9d8-46fa-8d83-3b9ba9e177c0
-    jinja: "{{graph.sentence}}\n ===\n Given the above sentence, write one compressed\
-      \ sentence to summarize: ||| {{compression.text}}"
+    jinja: '{{graph.sentence}}
+
+      ===
+
+      Given the above sentence, write one compressed sentence to summarize: ||| {{compression.text}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
       - Other
       original_task: true
-    name: Template_2
-    reference: write one compressed sentence
+    name: <premise>-given_the_above-write_compressed_to_summarize-<entailment>
+    reference: ''
   f797c3f9-2a93-46a6-8c84-ba4871eba79b: !Template
     answer_choices: null
     id: f797c3f9-2a93-46a6-8c84-ba4871eba79b
-    jinja: "Compress: {{graph.sentence}}|||\n\n  {{compression.text}}"
+    jinja: 'Compress: {{graph.sentence}} ||| {{compression.text}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
       - Other
       original_task: true
-    name: Template_3
-    reference: compress
+    name: compress-<premise>-<entailment>
+    reference: ''

--- a/promptsource/templates/sent_comp/templates.yaml
+++ b/promptsource/templates/sent_comp/templates.yaml
@@ -3,92 +3,99 @@ templates:
   185b5001-19e3-47d3-afd3-40f74346f4bb: !Template
     answer_choices: null
     id: 185b5001-19e3-47d3-afd3-40f74346f4bb
-    jinja: '''{{graph.sentence}}
+    jinja: '{{graph.sentence}}
 
 
       ===
 
 
-      Given the above sentence, generate a compressed sentence: ||| {{compression.text}}'''
+      Given the above sentence, generate a compressed sentence: ||| {{compression.text}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: true
     name: Template_0
     reference: generate compression
   336ba469-f315-49ff-8c02-baf6d059972b: !Template
     answer_choices: null
     id: 336ba469-f315-49ff-8c02-baf6d059972b
-    jinja: '''{{headline}}
+    jinja: '{{headline}}
 
 
       ===
 
 
-      Given the above headline, write one compressed sentence: ||| {{compression.text}}'''
+      Given the above headline, write one compressed sentence: ||| {{compression.text}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: false
     name: Template_6
     reference: write compression given headline
   6493cbf3-bce9-4556-92ab-ec815f768eb6: !Template
     answer_choices: null
     id: 6493cbf3-bce9-4556-92ab-ec815f768eb6
-    jinja: '''Sentence: {{graph.sentence}}
+    jinja: 'Sentence: {{graph.sentence}}
 
 
-      Compressed sentence: ||| {{compression.text}}'''
+      Compressed sentence: ||| {{compression.text}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: true
     name: Template_1
     reference: 'compressed sentence, sentence '
   9391497d-4fd1-4977-aba8-dc20f9e9445a: !Template
     answer_choices: null
     id: 9391497d-4fd1-4977-aba8-dc20f9e9445a
-    jinja: '''{{graph.sentence}}
+    jinja: '{{graph.sentence}}
 
 
-      Extreme TL;DR: ||| {{compression.text}}'''
+      Extreme TL;DR: ||| {{compression.text}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: true
     name: Template_4
     reference: extreme TLDR
   b7b2934c-cf3e-42b9-b7be-d6f1af679bce: !Template
     answer_choices: null
     id: b7b2934c-cf3e-42b9-b7be-d6f1af679bce
-    jinja: '''Compress this headline: {{headline}}
+    jinja: 'Compress this headline: {{headline}}
 
 
-      compressed sentence: ||| {{compression.text}}'''
+      compressed sentence: ||| {{compression.text}}'
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: false
     name: Template_5
     reference: from headline to compressed version
   ca70c220-b9d8-46fa-8d83-3b9ba9e177c0: !Template
     answer_choices: null
     id: ca70c220-b9d8-46fa-8d83-3b9ba9e177c0
-    jinja: "'{{graph.sentence}}\n ===\n Given the above sentence, write one compressed\
-      \ sentence to summarize: ||| {{compression.text}}'"
+    jinja: "{{graph.sentence}}\n ===\n Given the above sentence, write one compressed\
+      \ sentence to summarize: ||| {{compression.text}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: true
     name: Template_2
     reference: write one compressed sentence
   f797c3f9-2a93-46a6-8c84-ba4871eba79b: !Template
     answer_choices: null
     id: f797c3f9-2a93-46a6-8c84-ba4871eba79b
-    jinja: "'Compress: {{graph.sentence}}|||\n\n  {{compression.text}}'"
+    jinja: "Compress: {{graph.sentence}}|||\n\n  {{compression.text}}"
     metadata: !TemplateMetadata
-      choices_in_prompt: null
-      metrics: []
+      choices_in_prompt: false
+      metrics:
+      - Other
       original_task: true
     name: Template_3
     reference: compress


### PR DESCRIPTION
The PR fixes:
- The templates had `'''` that caused the UI (and probably the training data) to have single quotes around the prompts.
- The original paper and the follow up papers use F1 of dependency tree features.

A side note:
No offense, but Template_5 and Template_6 make little sense. Because they ask humans to compress headlines. Yet the answers are usually longer than headlines.