### PR TITLE
fix: pin datasets to `<1.15.0` for qed's pyarrow issue #659

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 black
-datasets>=1.7.0
+datasets>=1.7.0,<1.15.0
 flake8
 isort==5.8.0
 pytest


### PR DESCRIPTION
close #659

Not sure where the root cause is, but here are some candidates:
- https://github.com/huggingface/datasets/pull/3158/files
- https://github.com/huggingface/datasets/pull/3120/files
- https://github.com/huggingface/datasets/pull/3196/files
- https://github.com/huggingface/datasets/pull/2891/files

Simply using `load_dataset("qed")` does not encounter the same issue. So I suspect we are using an old and incompatible way of dataset builder.