### PR TITLE
fix answer_choices (1,2,3,4 vs a,b,c,d) in ai2 arc

### DIFF
--- a/promptsource/templates/ai2_arc/ARC-Challenge/templates.yaml
+++ b/promptsource/templates/ai2_arc/ARC-Challenge/templates.yaml
@@ -32,7 +32,7 @@ templates:
     name: pick_false_options
     reference: ''
   540ebc31-2ea6-4feb-a6fd-67b6e71cf20a: !Template
-    answer_choices: A ||| B ||| C ||| D
+    answer_choices: '{{choices.label | join("|||")}}'
     id: 540ebc31-2ea6-4feb-a6fd-67b6e71cf20a
     jinja: "Here's a problem to solve: {{question}}\n\nAmong the 4 following options,\
       \ which is the correct answer?\n{% for letter, t in zip(answer_choices, choices.text)\
@@ -104,7 +104,7 @@ templates:
     name: multiple_choice
     reference: ''
   e371fc1a-8edb-477b-b345-9d73e97ffade: !Template
-    answer_choices: A ||| B ||| C ||| D
+    answer_choices: '{{choices.label | join("|||")}}'
     id: e371fc1a-8edb-477b-b345-9d73e97ffade
     jinja: 'Pick the most correct option to answer the following question.
 

--- a/promptsource/templates/ai2_arc/ARC-Easy/templates.yaml
+++ b/promptsource/templates/ai2_arc/ARC-Easy/templates.yaml
@@ -2,7 +2,7 @@ dataset: ai2_arc
 subset: ARC-Easy
 templates:
   033498ca-3d9a-47e3-b631-d881ab53b5ad: !Template
-    answer_choices: A ||| B ||| C ||| D
+    answer_choices: '{{choices.label | join("|||")}}'
     id: 033498ca-3d9a-47e3-b631-d881ab53b5ad
     jinja: 'Pick the most correct option to answer the following question.
 
@@ -116,7 +116,7 @@ templates:
     name: pick_false_options
     reference: ''
   d90da519-0e2c-4f9b-a546-7cba82824eb2: !Template
-    answer_choices: A ||| B ||| C ||| D
+    answer_choices: '{{choices.label | join("|||")}}'
     id: d90da519-0e2c-4f9b-a546-7cba82824eb2
     jinja: "Here's a problem to solve: {{question}}\n\nAmong the 4 following options,\
       \ which is the correct answer?\n{% for letter, t in zip(answer_choices, choices.text)\


### PR DESCRIPTION
In somre rare cases, the indexing used is 1,2,3,4 instead of A,b,c,d.
This fixes the discrepancy so that the target is always in `answer_choices`