### PR TITLE
fix double linebreak issue in jinja rendering #694 

### DIFF
--- a/promptsource/app.py
+++ b/promptsource/app.py
@@ -82,12 +82,19 @@ st.markdown(
     "<style>" + HtmlFormatter(style="friendly").get_style_defs(".highlight") + "</style>", unsafe_allow_html=True
 )
 
-WIDTH = 80
+WIDTH = 140
 
 
 def show_jinja(t, width=WIDTH):
+    def replace_double_linebreaks(t):
+        """
+        st.write does not handle double breaklines very well. When it encounters `\n\n`, it exit the curent <div> block.
+        Explicitely replacing `\n\n` with their html equivalent to bypass this issue.
+        """
+        return t.replace("\n\n", "<br/><br/>")
     wrap = textwrap.fill(t, width=width, replace_whitespace=False)
     out = highlight(wrap, DjangoLexer(), HtmlFormatter())
+    out = replace_double_linebreaks(out)
     st.write(out, unsafe_allow_html=True)
 
 

--- a/promptsource/app.py
+++ b/promptsource/app.py
@@ -86,16 +86,17 @@ WIDTH = 140
 
 
 def show_jinja(t, width=WIDTH):
-    def replace_double_linebreaks(t):
+    def replace_linebreaks(t):
         """
         st.write does not handle double breaklines very well. When it encounters `\n\n`, it exit the curent <div> block.
-        Explicitely replacing `\n\n` with their html equivalent to bypass this issue.
+        Explicitely replacing all `\n` with their html equivalent to bypass this issue.
+        Also stripping the trailing `\n` first.
         """
-        return t.replace("\n\n", "<br/><br/>")
+        return t.strip("\n").replace("\n", "<br/>")
 
     wrap = textwrap.fill(t, width=width, replace_whitespace=False)
     out = highlight(wrap, DjangoLexer(), HtmlFormatter())
-    out = replace_double_linebreaks(out)
+    out = replace_linebreaks(out)
     st.write(out, unsafe_allow_html=True)
 
 

--- a/promptsource/app.py
+++ b/promptsource/app.py
@@ -92,6 +92,7 @@ def show_jinja(t, width=WIDTH):
         Explicitely replacing `\n\n` with their html equivalent to bypass this issue.
         """
         return t.replace("\n\n", "<br/><br/>")
+
     wrap = textwrap.fill(t, width=width, replace_whitespace=False)
     out = highlight(wrap, DjangoLexer(), HtmlFormatter())
     out = replace_double_linebreaks(out)


### PR DESCRIPTION
Addresses #694 

The issue was coming from `st.write` which does not handle well double linebreaks. I explicitly replaced `\n\n` with their HTML equivalent `<br/><br/>` to address that problem.

**Before:**
<img width="1307" alt="Capture d’écran 2022-01-21 à 5 55 51 PM" src="https://user-images.githubusercontent.com/16107619/150611274-20dd8701-1e08-40b1-8ae9-dc096488a81a.png">
<img width="667" alt="Capture d’écran 2022-01-21 à 5 56 21 PM" src="https://user-images.githubusercontent.com/16107619/150611285-9a42ae98-742b-481f-9ec2-aecb8578eabb.png">

**Now:**
<img width="1310" alt="Capture d’écran 2022-01-21 à 5 56 02 PM" src="https://user-images.githubusercontent.com/16107619/150611292-c7cc3143-0cda-4d2c-abf0-e68546421ee6.png">
<img width="721" alt="Capture d’écran 2022-01-21 à 5 56 11 PM" src="https://user-images.githubusercontent.com/16107619/150611303-3a30ee42-8103-42c3-82cf-efaf0ec48329.png">

