### PR TITLE
Support for multiple targets.

### DIFF
--- a/promptsource/app.py
+++ b/promptsource/app.py
@@ -413,8 +413,9 @@ def run_app():
                     st.markdown("###### Input template")
                     show_jinja(splitted_template[0].strip())
                     if len(splitted_template) > 1:
-                        st.markdown("###### Target template")
-                        show_jinja(splitted_template[1].strip())
+                        for splitted_target in splitted_template[1:]:
+                            st.markdown("###### Target template")
+                            show_jinja(splitted_target.strip())
                     st.markdown("***")
 
                 #
@@ -437,8 +438,9 @@ def run_app():
                                 st.write("Input")
                                 show_text(prompt[0])
                                 if len(prompt) > 1:
-                                    st.write("Target")
-                                    show_text(prompt[1])
+                                    for target in prompt[1]:
+                                        st.write("Target")
+                                        show_text(target)
                     st.markdown("***")
             else:  # mode = Sourcing
                 st.markdown("## Prompt Creator")
@@ -627,8 +629,9 @@ def run_app():
                             st.write("Input")
                             show_text(prompt[0], width=40)
                             if len(prompt) > 1:
-                                st.write("Target")
-                                show_text(prompt[1], width=40)
+                                for target in prompt[1]:
+                                    st.write("Target")
+                                    show_text(target, width=40)
 
     #
     # Must sync state at end

--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -153,14 +153,14 @@ class Template(yaml.YAMLObject):
         else:
             return None
 
-    def apply(self, example, truncate=True, highlight_variables=False):
+    def apply(self, example, truncate=True, highlight_variables=False) -> Tuple[str, List[str]]:
         """
         Creates a prompt by applying this template to an example
 
         :param example: the dataset example to create a prompt for
         :param truncate: if True, example fields will be truncated to TEXT_VAR_LENGTH chars
         :param highlight_variables: highlight the added variables
-        :return: tuple of 2 strings, for prompt and output
+        :return: tuple of a string and a list of strings, for input and targets
         """
         jinja = self.jinja
 
@@ -189,7 +189,11 @@ class Template(yaml.YAMLObject):
 
         # Splits on the separator, and then replaces back any occurrences of the
         # separator in the original example
-        return [self._unescape_pipe(part).strip() for part in rendered_example.split("|||")]
+        parts = [self._unescape_pipe(part).strip() for part in rendered_example.split("|||")]
+        if len(parts) < 2:
+            raise ValueError("Prompt did not produce an input and at least one target.")
+
+        return parts[0], parts[1:]
 
     pipe_protector = "3ed2dface8203c4c9dfb1a5dc58e41e0"
 

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -98,7 +98,7 @@ def test_dataset(dataset):
         # Check 2: Prompt/output separator present?
         if "|||" not in template.jinja:
             raise ValueError(f"Template for dataset {dataset_name}/{subset_name} "
-                             f"with uuid {template.get_id()} has no prompt/output separator.")
+                             f"with uuid {template.get_id()} has no input/target separator.")
 
         # Check 3: Unique names and templates?
         if template.get_name() in template_name_set:


### PR DESCRIPTION
THIS BREAKS BACKWARDS COMPATIBILITY WITH v0.2.x. Now, Template.apply now returns `Tuple[str, List[str]]` instead of `Tuple[str, str]`. The list of strings is the valid targets.

Users can add additional `|||` to their templates to denote additional valid completions.

Example of the interface:
<img width="999" alt="Screen Shot 2022-04-26 at 8 37 27 PM" src="https://user-images.githubusercontent.com/865714/165415586-32fa30c9-72cf-415f-90f5-1f2ab4ab1ba5.png">