### PR TITLE
Adding prompts for POS tagging on Universal Dependencies dataset

### DIFF
--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -26,7 +26,7 @@ env.globals.update(zip=zip)
 
 # These are users whose datasets should be included in the results returned by
 # filter_english_datasets (regardless of their metadata)
-INCLUDED_USERS = {"Zaid", "craffel"}
+INCLUDED_USERS = {"Zaid", "craffel", "aakanksha"}
 
 
 def highlight(input):

--- a/promptsource/templates/aakanksha/udpos/templates.yaml
+++ b/promptsource/templates/aakanksha/udpos/templates.yaml
@@ -1,0 +1,104 @@
+dataset: aakanksha/udpos
+templates:
+  14dd9141-58b7-456b-a998-f1678cb8e3f5: !Template
+    answer_choices: null
+    id: 14dd9141-58b7-456b-a998-f1678cb8e3f5
+    jinja: "Given a sentence, label every word in the sentence with a part of speech\
+      \ tag. Following is the list of possible tags: ADJ (adjective), ADP (adposition),\
+      \ ADV (adverb), AUX (auxiliary), CCONJ (coordinating conjunction), DET (determiner),\
+      \ INTJ (interjection), NOUN (noun), NUM (numeral), PART (particle), PRON (pronoun),\
+      \ PROPN (proposition), PUNCT (punctuation), SCONJ (subordinating conjunction),\
+      \ SYM (symbol), VERB (verb), X (other).  \n\nGenerate this output in the form\
+      \ of word tag pairs for the following sentence:\n{{sentence}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: pos-tag-fine-defs-alternate
+    reference: Generating fine-grained POS tags for a sentence (and provides one word
+      expansions of POS tag abbreviations with sentence at end)
+  49c5272f-f5d4-496f-b98d-6b5410efac60: !Template
+    answer_choices: null
+    id: 49c5272f-f5d4-496f-b98d-6b5410efac60
+    jinja: "Given a sentence, label every word in the sentence with a part of speech\
+      \ tag. Following is the list of possible tags: ADJ, ADP, ADV, AUX, CCONJ, DET,\
+      \ INTJ, NOUN, NUM, PART, PRON, PROPN, PUNCT, SCONJ, SYM, VERB, X.  \n\nGenerate\
+      \ this output in the form of word tag pairs for the following sentence:\n{{sentence}}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: pos-tag-fine-alternate
+    reference: Generating fine-grained POS tags for a sentence (but sentence is provided
+      at the end of the prompt)
+  71f1dcc0-53cf-4986-977b-5d67f92e0a6c: !Template
+    answer_choices: null
+    id: 71f1dcc0-53cf-4986-977b-5d67f92e0a6c
+    jinja: "Provide part of speech tags for every word in the following sentence:\n\
+      {{sentence}}\nFollowing is the list of possible part of speech tags: ADJ, ADP,\
+      \ ADV, AUX, CCONJ, DET, INTJ, NOUN, NUM, PART, PRON, PROPN, PUNCT, SCONJ, SYM,\
+      \ VERB, X.  \nPlease output every word in the sentence followed by its part\
+      \ of speech tag."
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: pos-tag-fine
+    reference: Generating fine-grained POS tags for a sentence
+  935decc6-8f35-45e8-9cf5-1f0bf44e4a09: !Template
+    answer_choices: null
+    id: 935decc6-8f35-45e8-9cf5-1f0bf44e4a09
+    jinja: "Read the following sentence and answer the following question:\n{{sentence}}\n\
+      Following is a list of possible part of speech tags: ADJ, ADP, ADV, AUX, CCONJ,\
+      \ DET, INTJ, NOUN, NUM, PART, PRON, PROPN, PUNCT, SCONJ, SYM, VERB, X. Given\
+      \ this list, what are the part of speech tags for each word in the sentence?\
+      \  \nAnswer this by generating every word in the sentence followed by its part\
+      \ of speech tag."
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: pos-tag-fine-qa
+    reference: Generating fine-grained POS tags for a sentence (with prompt posed
+      as question)
+  ccd712a7-116c-498c-9e94-a9bd9931f8fd: !Template
+    answer_choices: null
+    id: ccd712a7-116c-498c-9e94-a9bd9931f8fd
+    jinja: "Provide part of speech tags for every word in the following sentence:\n\
+      {{sentence}}\nFollowing is the list of possible part of speech tags: ADJ (adjective),\
+      \ ADP (adposition), ADV (adverb), AUX (auxiliary), CCONJ (coordinating conjunction),\
+      \ DET (determiner), INTJ (interjection), NOUN (noun), NUM (numeral), PART (particle),\
+      \ PRON (pronoun), PROPN (proposition), PUNCT (punctuation), SCONJ (subordinating\
+      \ conjunction), SYM (symbol), VERB (verb), X (other).  \nPlease output every\
+      \ word in the sentence followed by its part of speech tag."
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: pos-tag-fine-defs
+    reference: Generating fine-grained POS tags for a sentence (and provides one word
+      expansions of POS tag abbreviations)
+  fed39065-26da-4e12-8a9f-37153023f120: !Template
+    answer_choices: null
+    id: fed39065-26da-4e12-8a9f-37153023f120
+    jinja: "Read the following sentence and answer the following question:\n{{sentence}}\n\
+      Following is a list of possible part of speech tags: ADJ (adjective), ADP (adposition),\
+      \ ADV (adverb), AUX (auxiliary), CCONJ (coordinating conjunction), DET (determiner),\
+      \ INTJ (interjection), NOUN (noun), NUM (numeral), PART (particle), PRON (pronoun),\
+      \ PROPN (proposition), PUNCT (punctuation), SCONJ (subordinating conjunction),\
+      \ SYM (symbol), VERB (verb), X (other). Given this list, what are the part of\
+      \ speech tags for each word in the sentence?  \nAnswer this by generating every\
+      \ word in the sentence followed by its part of speech tag."
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: pos-tag-fine-qa-defs
+    reference: Generating fine-grained POS tags for a sentence (with prompt posed
+      as question and POS tag definitions)


### PR DESCRIPTION
Six prompts have been created to add part-of-speech tagging on the Universal Dependencies dataset to PromptSource. These prompts have been created from scratch since we could not find any POS tagging task references. We are using the following output format: the model must produce a sequence of word-tag pairs (e.g., the DET black ADJ sheep NOUN). Since computing model accuracy will require parsing out the POS tags from this string, we will need to implement a custom metric, and so the metric variable is currently set to "Other". 

In addition to these prompts, the universal dependencies dataset has also been added to Huggingface (under aakanksha/udpos) in a prompting-friendly format. To allow this dataset to be visible in promptsource, I have added my user name (aakanksha) to the list of included_users. If there is a better way to do this, please let me know and I can change this.

If there are any issues with the PR, please comment below and I will work on addressing them. Thanks a lot!