### PR TITLE
Add LinCE sentiment analysis prompts

### DIFF
--- a/promptsource/templates/lince/sa_spaeng/templates.yaml
+++ b/promptsource/templates/lince/sa_spaeng/templates.yaml
@@ -4,7 +4,7 @@ templates:
   24eba864-8859-4a15-a7a9-0fdf42d9f6cf: !Template
     answer_choices: positive ||| negative ||| neutral
     id: 24eba864-8859-4a15-a7a9-0fdf42d9f6cf
-    jinja: '{{words | join(" ") }} What is the sentiment expressed by the original
+    jinja: '{{words | join(" ") }}. What is the sentiment expressed by the original
       poster? ||| {{ sa }}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -16,7 +16,7 @@ templates:
   29756194-c221-48b8-8d25-db1e681d9eeb: !Template
     answer_choices: positive ||| negative ||| neutral
     id: 29756194-c221-48b8-8d25-db1e681d9eeb
-    jinja: '{{words | join(" ") }} What sentiment is this post trying to express?
+    jinja: '{{words | join(" ") }}. What sentiment is this post trying to express?
       ||| {{ sa }}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -26,9 +26,9 @@ templates:
     name: sentiment trying to express
     reference: ''
   52708ad1-0029-4d97-a5e9-e179da16e452: !Template
-    answer_choices: null
+    answer_choices: positive ||| negative ||| neutral
     id: 52708ad1-0029-4d97-a5e9-e179da16e452
-    jinja: "{{ words | join(\" \") }} This is definitely \n||| \n{% if sa == \"negative\"\
+    jinja: "{{ words | join(\" \") }}. This is definitely \n||| \n{% if sa == \"negative\"\
       \ %} \nnot a positive post. \n{% elif sa == \"positive\" %} \nnot a negative\
       \ post. \n{% else %} \na neutral post.\n{% endif %}"
     metadata: !TemplateMetadata
@@ -42,7 +42,7 @@ templates:
     answer_choices: positive ||| negative ||| neutral
     id: 5dd871bc-140e-43a1-bf8d-6139863d85cd
     jinja: What sentiment does following post express? Positive, negative, or neutral?
-      {{words | join(" ") }} ||| {{ sa }}
+      {{words | join(" ") }}. ||| {{ sa }}
     metadata: !TemplateMetadata
       choices_in_prompt: true
       metrics:
@@ -50,11 +50,23 @@ templates:
       original_task: true
     name: express sentiment
     reference: imdb
+  6186210a-a902-4f9b-b34a-25b01f193842: !Template
+    answer_choices: positive ||| negative ||| neutral
+    id: 6186210a-a902-4f9b-b34a-25b01f193842
+    jinja: From this post, "{{words | join(" ") }}". Does the author seem positive,
+      negative or neutral? ||| {{ sa }}
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: the author seem
+    reference: ''
   684d3d19-3100-432a-beb7-5fc0f8de72b5: !Template
     answer_choices: positive ||| negative ||| neutral
     id: 684d3d19-3100-432a-beb7-5fc0f8de72b5
     jinja: What sentiment is the following post trying to express?  {{words | join("
-      ") }} ||| {{ sa }}
+      ") }}. ||| {{ sa }}
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -65,7 +77,7 @@ templates:
   a036a20f-8192-4af8-83cd-e56f60fd6a0f: !Template
     answer_choices: positive ||| negative ||| neutral
     id: a036a20f-8192-4af8-83cd-e56f60fd6a0f
-    jinja: '{{ words | join(" ") }} The sentiment expressed in this post is ||| {{
+    jinja: '{{ words | join(" ") }}. The sentiment expressed in this post is ||| {{
       sa }}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -74,3 +86,15 @@ templates:
       original_task: true
     name: express sentiment 2
     reference: imdb
+  e26e9b00-f33a-43d2-98f7-5164d102fe7b: !Template
+    answer_choices: positive ||| negative ||| neutral
+    id: e26e9b00-f33a-43d2-98f7-5164d102fe7b
+    jinja: '{{words | join(" ") }}. Does this post sound positive, negative or neutral?
+      ||| {{ sa }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: sentence sounds
+    reference: ''

--- a/promptsource/templates/lince/sa_spaeng/templates.yaml
+++ b/promptsource/templates/lince/sa_spaeng/templates.yaml
@@ -1,0 +1,76 @@
+dataset: lince
+subset: sa_spaeng
+templates:
+  24eba864-8859-4a15-a7a9-0fdf42d9f6cf: !Template
+    answer_choices: positive ||| negative ||| neutral
+    id: 24eba864-8859-4a15-a7a9-0fdf42d9f6cf
+    jinja: '{{words | join(" ") }} What is the sentiment expressed by the original
+      poster? ||| {{ sa }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: original poster expressed sentiment
+    reference: imdb
+  29756194-c221-48b8-8d25-db1e681d9eeb: !Template
+    answer_choices: positive ||| negative ||| neutral
+    id: 29756194-c221-48b8-8d25-db1e681d9eeb
+    jinja: '{{words | join(" ") }} What sentiment is this post trying to express?
+      ||| {{ sa }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: sentiment trying to express
+    reference: ''
+  52708ad1-0029-4d97-a5e9-e179da16e452: !Template
+    answer_choices: null
+    id: 52708ad1-0029-4d97-a5e9-e179da16e452
+    jinja: "{{ words | join(\" \") }} This is definitely \n||| \n{% if sa == \"negative\"\
+      \ %} \nnot a positive post. \n{% elif sa == \"positive\" %} \nnot a negative\
+      \ post. \n{% else %} \na neutral post.\n{% endif %}"
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: false
+    name: negation template
+    reference: imdb
+  5dd871bc-140e-43a1-bf8d-6139863d85cd: !Template
+    answer_choices: positive ||| negative ||| neutral
+    id: 5dd871bc-140e-43a1-bf8d-6139863d85cd
+    jinja: What sentiment does following post express? Positive, negative, or neutral?
+      {{words | join(" ") }} ||| {{ sa }}
+    metadata: !TemplateMetadata
+      choices_in_prompt: true
+      metrics:
+      - Accuracy
+      original_task: true
+    name: express sentiment
+    reference: imdb
+  684d3d19-3100-432a-beb7-5fc0f8de72b5: !Template
+    answer_choices: positive ||| negative ||| neutral
+    id: 684d3d19-3100-432a-beb7-5fc0f8de72b5
+    jinja: What sentiment is the following post trying to express?  {{words | join("
+      ") }} ||| {{ sa }}
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: sentiment trying to express 2
+    reference: ''
+  a036a20f-8192-4af8-83cd-e56f60fd6a0f: !Template
+    answer_choices: positive ||| negative ||| neutral
+    id: a036a20f-8192-4af8-83cd-e56f60fd6a0f
+    jinja: '{{ words | join(" ") }} The sentiment expressed in this post is ||| {{
+      sa }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: true
+    name: express sentiment 2
+    reference: imdb


### PR DESCRIPTION
This new PR contains new prompt edits addressing previous PR comments:
> Does this same prompt apply to all other subsets of LinCE? Or are we only asked to evaluate the sa_spaeng subset?
> Some prompts are missing the field of Answer Choices: positive ||| negative ||| neutral
> This prompt's wording could be more natural
> The following post expresses what sentiment?
> 
> What sentiment does the following post express? Positive, negative, or neutral?
> 
> (in that case, you should also mark the "Choices in template" flag. That is, models are explicitly told the choices "Positive, negative, or neutral?" in the input.)
> 
> We're looking for at least 5 original task prompts. You're missing one.

Thanks a lot for the comments!

1. The templates in this PR would only apply to the sa_spaeng subset, other subsets are for linguistic structure tasks, namely, language identification, POS, NER. After standup, more work requires to be done on these tasks, More prompts for them are coming soon. I was thinking starting another PR for those since they're quite different from sentiment analysis task (requiring a label per word). 

2. For Answer Choices, apologize for the inconsistency. Would answer choices still be required if not referred in the target template?

3 & 4. The updated prompts in this PR improve wording and add an extra original task prompt.

