### PR TITLE
Add null prompt for `gsarti/flores_101` 

### DIFF
--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -26,7 +26,7 @@ env.globals.update(zip=zip)
 
 # These are users whose datasets should be included in the results returned by
 # filter_english_datasets (regardless of their metadata)
-INCLUDED_USERS = {"Zaid", "craffel", "GEM"}
+INCLUDED_USERS = {"Zaid", "craffel", "GEM", "gsarti"}
 
 
 def highlight(input):

--- a/promptsource/templates/gsarti/flores_101/afr/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/afr/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: afr
+templates:
+  2f881c3b-5627-4cef-ab9f-14fe04d98580: !Template
+    answer_choices: null
+    id: 2f881c3b-5627-4cef-ab9f-14fe04d98580
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/amh/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/amh/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: amh
+templates:
+  cfb8b91b-c9bb-4eed-8dae-ff5188bebbcc: !Template
+    answer_choices: null
+    id: cfb8b91b-c9bb-4eed-8dae-ff5188bebbcc
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/ara/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/ara/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: ara
+templates:
+  2855eee7-294b-416a-9630-4097259053e3: !Template
+    answer_choices: null
+    id: 2855eee7-294b-416a-9630-4097259053e3
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/asm/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/asm/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: asm
+templates:
+  4885fb6b-7d59-4d48-8d30-b2f535afa0f6: !Template
+    answer_choices: null
+    id: 4885fb6b-7d59-4d48-8d30-b2f535afa0f6
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/ast/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/ast/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: ast
+templates:
+  62971beb-69b9-463b-a08e-4365dcc0533b: !Template
+    answer_choices: null
+    id: 62971beb-69b9-463b-a08e-4365dcc0533b
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/azj/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/azj/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: azj
+templates:
+  76ca186c-5000-4799-9825-a43b8b56bb5e: !Template
+    answer_choices: null
+    id: 76ca186c-5000-4799-9825-a43b8b56bb5e
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/bel/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/bel/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: bel
+templates:
+  aa4a0c70-1436-47ef-a740-f66c319c9ead: !Template
+    answer_choices: null
+    id: aa4a0c70-1436-47ef-a740-f66c319c9ead
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/ben/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/ben/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: ben
+templates:
+  4961b2ed-2be7-4711-ba92-3519109121a3: !Template
+    answer_choices: null
+    id: 4961b2ed-2be7-4711-ba92-3519109121a3
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/bos/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/bos/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: bos
+templates:
+  8d67a264-9451-4958-bab2-db1850e26c44: !Template
+    answer_choices: null
+    id: 8d67a264-9451-4958-bab2-db1850e26c44
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/bul/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/bul/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: bul
+templates:
+  d087b25d-34d7-4d02-b5f4-94071af90d9b: !Template
+    answer_choices: null
+    id: d087b25d-34d7-4d02-b5f4-94071af90d9b
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/cat/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/cat/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: cat
+templates:
+  2e64f4e0-d38f-4b73-a132-879887cfd5ec: !Template
+    answer_choices: null
+    id: 2e64f4e0-d38f-4b73-a132-879887cfd5ec
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/ceb/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/ceb/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: ceb
+templates:
+  008edee0-99f8-4973-8660-7de6c9658924: !Template
+    answer_choices: null
+    id: 008edee0-99f8-4973-8660-7de6c9658924
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/ces/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/ces/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: ces
+templates:
+  8a0723d8-7c55-47e8-bebc-93bbb9ffc0f2: !Template
+    answer_choices: null
+    id: 8a0723d8-7c55-47e8-bebc-93bbb9ffc0f2
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/ckb/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/ckb/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: ckb
+templates:
+  bbfef869-a0a0-41cc-a7cf-d5c23f2c6a14: !Template
+    answer_choices: null
+    id: bbfef869-a0a0-41cc-a7cf-d5c23f2c6a14
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/cym/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/cym/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: cym
+templates:
+  46520ce2-e62c-48d1-947c-e59af9db2473: !Template
+    answer_choices: null
+    id: 46520ce2-e62c-48d1-947c-e59af9db2473
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/dan/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/dan/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: dan
+templates:
+  f90f5481-9b8b-4d8c-a4d9-f1ce603a3efc: !Template
+    answer_choices: null
+    id: f90f5481-9b8b-4d8c-a4d9-f1ce603a3efc
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/deu/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/deu/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: deu
+templates:
+  e2ccbd54-ed54-47c9-8fe7-a063c9057ed5: !Template
+    answer_choices: null
+    id: e2ccbd54-ed54-47c9-8fe7-a063c9057ed5
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/ell/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/ell/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: ell
+templates:
+  e7e11300-f613-4868-b8e6-011c995d12d3: !Template
+    answer_choices: null
+    id: e7e11300-f613-4868-b8e6-011c995d12d3
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/eng/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/eng/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: eng
+templates:
+  78837e14-81af-48fe-acf7-0c78005ea7f9: !Template
+    answer_choices: null
+    id: 78837e14-81af-48fe-acf7-0c78005ea7f9
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/est/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/est/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: est
+templates:
+  0b21c6f7-a348-4f98-8fc3-fa4f4c17aaa8: !Template
+    answer_choices: null
+    id: 0b21c6f7-a348-4f98-8fc3-fa4f4c17aaa8
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/fas/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/fas/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: fas
+templates:
+  866f1d58-948d-44b4-b2af-46a3f015d870: !Template
+    answer_choices: null
+    id: 866f1d58-948d-44b4-b2af-46a3f015d870
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/fin/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/fin/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: fin
+templates:
+  eb9b0d89-921c-429f-b211-7659e3d55e41: !Template
+    answer_choices: null
+    id: eb9b0d89-921c-429f-b211-7659e3d55e41
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/fra/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/fra/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: fra
+templates:
+  d628bb02-a6b1-40a0-84a9-9bb3a19bf3a1: !Template
+    answer_choices: null
+    id: d628bb02-a6b1-40a0-84a9-9bb3a19bf3a1
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/ful/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/ful/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: ful
+templates:
+  1feab9ee-9e43-4866-be4e-e6451d8c910a: !Template
+    answer_choices: null
+    id: 1feab9ee-9e43-4866-be4e-e6451d8c910a
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/gle/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/gle/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: gle
+templates:
+  6bc197c7-83de-47e4-9421-54525ec0b45a: !Template
+    answer_choices: null
+    id: 6bc197c7-83de-47e4-9421-54525ec0b45a
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/glg/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/glg/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: glg
+templates:
+  042b59e2-65a4-4e2d-a3ee-ef6524985c78: !Template
+    answer_choices: null
+    id: 042b59e2-65a4-4e2d-a3ee-ef6524985c78
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/guj/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/guj/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: guj
+templates:
+  500b6989-ad13-46e1-96b7-7748ae82ebae: !Template
+    answer_choices: null
+    id: 500b6989-ad13-46e1-96b7-7748ae82ebae
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/hau/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/hau/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: hau
+templates:
+  98673ec8-2a17-45bb-b982-0713f47e714f: !Template
+    answer_choices: null
+    id: 98673ec8-2a17-45bb-b982-0713f47e714f
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/heb/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/heb/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: heb
+templates:
+  834547db-5216-4cf6-b206-d393fa1dacc5: !Template
+    answer_choices: null
+    id: 834547db-5216-4cf6-b206-d393fa1dacc5
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/hin/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/hin/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: hin
+templates:
+  fbe980da-9043-48a3-a453-3293d478550d: !Template
+    answer_choices: null
+    id: fbe980da-9043-48a3-a453-3293d478550d
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/hrv/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/hrv/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: hrv
+templates:
+  eec492d8-0bb2-44b9-a328-d2ffd12fe7ad: !Template
+    answer_choices: null
+    id: eec492d8-0bb2-44b9-a328-d2ffd12fe7ad
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/hun/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/hun/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: hun
+templates:
+  2fc1e81c-b319-4a3e-8d0d-6c33db78d2b8: !Template
+    answer_choices: null
+    id: 2fc1e81c-b319-4a3e-8d0d-6c33db78d2b8
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/hye/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/hye/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: hye
+templates:
+  9ecf933b-e354-4e14-b2cc-c4dc34510518: !Template
+    answer_choices: null
+    id: 9ecf933b-e354-4e14-b2cc-c4dc34510518
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/ibo/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/ibo/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: ibo
+templates:
+  7871c915-d378-4074-8728-1e024dad9e8c: !Template
+    answer_choices: null
+    id: 7871c915-d378-4074-8728-1e024dad9e8c
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/ind/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/ind/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: ind
+templates:
+  fff1da27-1ab1-46cd-baab-5631bd23b35c: !Template
+    answer_choices: null
+    id: fff1da27-1ab1-46cd-baab-5631bd23b35c
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/isl/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/isl/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: isl
+templates:
+  a9f1511a-2912-400c-b429-26bda7aa2898: !Template
+    answer_choices: null
+    id: a9f1511a-2912-400c-b429-26bda7aa2898
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/ita/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/ita/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: ita
+templates:
+  0a533c52-7638-4ec5-83ff-f3b829eb6588: !Template
+    answer_choices: null
+    id: 0a533c52-7638-4ec5-83ff-f3b829eb6588
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/jav/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/jav/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: jav
+templates:
+  89459850-f4cf-41d8-af6c-233cab6f1d30: !Template
+    answer_choices: null
+    id: 89459850-f4cf-41d8-af6c-233cab6f1d30
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/jpn/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/jpn/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: jpn
+templates:
+  55b98d9b-2d02-43b7-97e8-1ebe7d25de07: !Template
+    answer_choices: null
+    id: 55b98d9b-2d02-43b7-97e8-1ebe7d25de07
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/kam/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/kam/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: kam
+templates:
+  6725b22a-f792-4a03-be67-2f2e05b70acc: !Template
+    answer_choices: null
+    id: 6725b22a-f792-4a03-be67-2f2e05b70acc
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/kan/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/kan/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: kan
+templates:
+  376ba655-ba4a-4dbc-a315-e3a296f0ce63: !Template
+    answer_choices: null
+    id: 376ba655-ba4a-4dbc-a315-e3a296f0ce63
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/kat/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/kat/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: kat
+templates:
+  bd2d60ca-7fac-451f-bb61-fec21dd79241: !Template
+    answer_choices: null
+    id: bd2d60ca-7fac-451f-bb61-fec21dd79241
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/kaz/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/kaz/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: kaz
+templates:
+  e20ec8a6-9001-45c2-b948-fd55c098d48a: !Template
+    answer_choices: null
+    id: e20ec8a6-9001-45c2-b948-fd55c098d48a
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/kea/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/kea/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: kea
+templates:
+  5b941d37-9061-4dfa-b76d-7d4dab26166d: !Template
+    answer_choices: null
+    id: 5b941d37-9061-4dfa-b76d-7d4dab26166d
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/khm/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/khm/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: khm
+templates:
+  3e1f2425-05d9-4cdf-b57f-9f730af350cd: !Template
+    answer_choices: null
+    id: 3e1f2425-05d9-4cdf-b57f-9f730af350cd
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/kir/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/kir/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: kir
+templates:
+  3d27b9a3-c185-4730-abcc-214709e961b3: !Template
+    answer_choices: null
+    id: 3d27b9a3-c185-4730-abcc-214709e961b3
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/kor/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/kor/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: kor
+templates:
+  69b68a2f-b206-4d2e-946f-4a9f7680cf4b: !Template
+    answer_choices: null
+    id: 69b68a2f-b206-4d2e-946f-4a9f7680cf4b
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/lao/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/lao/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: lao
+templates:
+  3c0b5eb5-b399-41dd-84a6-af269eb695b8: !Template
+    answer_choices: null
+    id: 3c0b5eb5-b399-41dd-84a6-af269eb695b8
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/lav/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/lav/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: lav
+templates:
+  e6189a4c-6ebc-454f-b961-c82347951ec7: !Template
+    answer_choices: null
+    id: e6189a4c-6ebc-454f-b961-c82347951ec7
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/lin/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/lin/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: lin
+templates:
+  d200bc86-c825-4f86-a5b3-8fb8b67047fd: !Template
+    answer_choices: null
+    id: d200bc86-c825-4f86-a5b3-8fb8b67047fd
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/lit/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/lit/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: lit
+templates:
+  6bc83e00-42e2-401e-8b53-191d063d2e33: !Template
+    answer_choices: null
+    id: 6bc83e00-42e2-401e-8b53-191d063d2e33
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/ltz/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/ltz/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: ltz
+templates:
+  b0373987-1ef8-43b9-9fd6-763b66c254fe: !Template
+    answer_choices: null
+    id: b0373987-1ef8-43b9-9fd6-763b66c254fe
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/lug/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/lug/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: lug
+templates:
+  670e20bf-983c-45a2-b89d-1a86e488dbe5: !Template
+    answer_choices: null
+    id: 670e20bf-983c-45a2-b89d-1a86e488dbe5
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/luo/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/luo/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: luo
+templates:
+  7ff830c3-c07f-45e4-9384-e2a96e668630: !Template
+    answer_choices: null
+    id: 7ff830c3-c07f-45e4-9384-e2a96e668630
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/mal/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/mal/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: mal
+templates:
+  d141c155-e332-47c3-beab-580a8977d98b: !Template
+    answer_choices: null
+    id: d141c155-e332-47c3-beab-580a8977d98b
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/mar/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/mar/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: mar
+templates:
+  46278eb0-91aa-4af2-be4c-f64d34ee21c4: !Template
+    answer_choices: null
+    id: 46278eb0-91aa-4af2-be4c-f64d34ee21c4
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/mkd/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/mkd/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: mkd
+templates:
+  45832e0f-31c7-470b-ba2b-caed1a7c2ac9: !Template
+    answer_choices: null
+    id: 45832e0f-31c7-470b-ba2b-caed1a7c2ac9
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/mlt/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/mlt/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: mlt
+templates:
+  026f5f4a-99f5-4d76-be73-5a40d7a04b00: !Template
+    answer_choices: null
+    id: 026f5f4a-99f5-4d76-be73-5a40d7a04b00
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/mon/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/mon/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: mon
+templates:
+  ed670e95-a987-46a6-8f1a-b1e7bff9b4ec: !Template
+    answer_choices: null
+    id: ed670e95-a987-46a6-8f1a-b1e7bff9b4ec
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/mri/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/mri/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: mri
+templates:
+  57c46600-6c78-47a3-95d6-693beedf6341: !Template
+    answer_choices: null
+    id: 57c46600-6c78-47a3-95d6-693beedf6341
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/msa/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/msa/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: msa
+templates:
+  825f3ec2-881e-4279-9f80-54c84ace5b14: !Template
+    answer_choices: null
+    id: 825f3ec2-881e-4279-9f80-54c84ace5b14
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/mya/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/mya/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: mya
+templates:
+  5688b23c-16e6-4147-bac2-a8c4cab2e002: !Template
+    answer_choices: null
+    id: 5688b23c-16e6-4147-bac2-a8c4cab2e002
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/nld/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/nld/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: nld
+templates:
+  87d332a2-0f8d-47b9-ae9e-fe0c6c3f8c58: !Template
+    answer_choices: null
+    id: 87d332a2-0f8d-47b9-ae9e-fe0c6c3f8c58
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/nob/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/nob/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: nob
+templates:
+  2b54666d-18c4-4bc3-b714-239275826754: !Template
+    answer_choices: null
+    id: 2b54666d-18c4-4bc3-b714-239275826754
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/npi/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/npi/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: npi
+templates:
+  367c7c9c-53e7-4992-9e8a-f2593a1f4e3d: !Template
+    answer_choices: null
+    id: 367c7c9c-53e7-4992-9e8a-f2593a1f4e3d
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/nso/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/nso/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: nso
+templates:
+  bdab1329-8a31-4843-a3ff-ed54c14288c5: !Template
+    answer_choices: null
+    id: bdab1329-8a31-4843-a3ff-ed54c14288c5
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/nya/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/nya/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: nya
+templates:
+  1f3d173b-f2b1-4990-824f-d0868d2ef648: !Template
+    answer_choices: null
+    id: 1f3d173b-f2b1-4990-824f-d0868d2ef648
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/oci/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/oci/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: oci
+templates:
+  1e72a395-941d-4c8a-87d6-2dd7016ac8d9: !Template
+    answer_choices: null
+    id: 1e72a395-941d-4c8a-87d6-2dd7016ac8d9
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/orm/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/orm/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: orm
+templates:
+  34406574-f9b8-46f4-b314-a08006ddca66: !Template
+    answer_choices: null
+    id: 34406574-f9b8-46f4-b314-a08006ddca66
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/ory/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/ory/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: ory
+templates:
+  b5c99122-b250-4df5-8956-c65b99002cd3: !Template
+    answer_choices: null
+    id: b5c99122-b250-4df5-8956-c65b99002cd3
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/pan/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/pan/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: pan
+templates:
+  0752b561-94b5-43f4-a198-482fdb0bba0d: !Template
+    answer_choices: null
+    id: 0752b561-94b5-43f4-a198-482fdb0bba0d
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/pol/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/pol/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: pol
+templates:
+  c06a8dd8-0590-4b01-96ad-bec657e5bd22: !Template
+    answer_choices: null
+    id: c06a8dd8-0590-4b01-96ad-bec657e5bd22
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/por/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/por/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: por
+templates:
+  c9faccc7-494b-430d-ae68-5b5678111f25: !Template
+    answer_choices: null
+    id: c9faccc7-494b-430d-ae68-5b5678111f25
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/pus/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/pus/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: pus
+templates:
+  7a7b417e-0a63-4c97-a81e-05ad877b23c4: !Template
+    answer_choices: null
+    id: 7a7b417e-0a63-4c97-a81e-05ad877b23c4
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/ron/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/ron/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: ron
+templates:
+  cfcc5b8b-a429-49c8-972a-ee0ac0d1bff7: !Template
+    answer_choices: null
+    id: cfcc5b8b-a429-49c8-972a-ee0ac0d1bff7
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/rus/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/rus/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: rus
+templates:
+  f4105f9f-4cc7-48ff-a3f8-d5383cd9cd6c: !Template
+    answer_choices: null
+    id: f4105f9f-4cc7-48ff-a3f8-d5383cd9cd6c
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/slk/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/slk/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: slk
+templates:
+  82909ace-931f-4d61-8ab2-9c57b3885b6c: !Template
+    answer_choices: null
+    id: 82909ace-931f-4d61-8ab2-9c57b3885b6c
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/slv/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/slv/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: slv
+templates:
+  9c0c1e15-2602-49e1-9c69-d66fbd879475: !Template
+    answer_choices: null
+    id: 9c0c1e15-2602-49e1-9c69-d66fbd879475
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/sna/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/sna/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: sna
+templates:
+  4f67dde8-b361-4c2c-aedd-a964da2cbcf0: !Template
+    answer_choices: null
+    id: 4f67dde8-b361-4c2c-aedd-a964da2cbcf0
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/snd/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/snd/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: snd
+templates:
+  7db586f2-e32f-4642-b2d8-0b79c225262d: !Template
+    answer_choices: null
+    id: 7db586f2-e32f-4642-b2d8-0b79c225262d
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/som/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/som/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: som
+templates:
+  7c8bd979-88cd-481b-af64-4095d1b4e66a: !Template
+    answer_choices: null
+    id: 7c8bd979-88cd-481b-af64-4095d1b4e66a
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/spa/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/spa/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: spa
+templates:
+  40296e00-56e6-4014-ac4f-c8ab434c776e: !Template
+    answer_choices: null
+    id: 40296e00-56e6-4014-ac4f-c8ab434c776e
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/srp/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/srp/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: srp
+templates:
+  a959f425-53c6-4d66-af09-80ea7cc5eea2: !Template
+    answer_choices: null
+    id: a959f425-53c6-4d66-af09-80ea7cc5eea2
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/swe/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/swe/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: swe
+templates:
+  aba98d29-6b90-454f-a652-52a91e1fa807: !Template
+    answer_choices: null
+    id: aba98d29-6b90-454f-a652-52a91e1fa807
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/swh/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/swh/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: swh
+templates:
+  7d5a1de0-bd81-4ffe-9391-250a4cfb2ef7: !Template
+    answer_choices: null
+    id: 7d5a1de0-bd81-4ffe-9391-250a4cfb2ef7
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/tam/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/tam/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: tam
+templates:
+  09e46216-1589-40fa-861c-e921e38b6898: !Template
+    answer_choices: null
+    id: 09e46216-1589-40fa-861c-e921e38b6898
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/tel/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/tel/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: tel
+templates:
+  75517ad1-5063-47cb-af26-1cfd52879396: !Template
+    answer_choices: null
+    id: 75517ad1-5063-47cb-af26-1cfd52879396
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/tgk/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/tgk/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: tgk
+templates:
+  3d307b66-3753-46cb-a067-434c3a008346: !Template
+    answer_choices: null
+    id: 3d307b66-3753-46cb-a067-434c3a008346
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/tgl/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/tgl/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: tgl
+templates:
+  510c7589-335a-48ec-a948-7caffe6f3c97: !Template
+    answer_choices: null
+    id: 510c7589-335a-48ec-a948-7caffe6f3c97
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/tha/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/tha/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: tha
+templates:
+  fbb5c601-c525-4abd-bed1-a77cf9df25ea: !Template
+    answer_choices: null
+    id: fbb5c601-c525-4abd-bed1-a77cf9df25ea
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/tur/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/tur/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: tur
+templates:
+  ab9053cc-f588-4462-aa2e-a1ba932e6f83: !Template
+    answer_choices: null
+    id: ab9053cc-f588-4462-aa2e-a1ba932e6f83
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/ukr/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/ukr/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: ukr
+templates:
+  14011720-295a-4c99-b834-af7d4ba82717: !Template
+    answer_choices: null
+    id: 14011720-295a-4c99-b834-af7d4ba82717
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/umb/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/umb/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: umb
+templates:
+  26b3ce5e-eda6-4ddf-979b-63f3e86d415d: !Template
+    answer_choices: null
+    id: 26b3ce5e-eda6-4ddf-979b-63f3e86d415d
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/urd/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/urd/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: urd
+templates:
+  36a2f50c-3a61-4860-9d0c-b44a1ae7cf9a: !Template
+    answer_choices: null
+    id: 36a2f50c-3a61-4860-9d0c-b44a1ae7cf9a
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/uzb/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/uzb/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: uzb
+templates:
+  2cc4ee39-cf5b-4e4b-b054-77a1cd70f4db: !Template
+    answer_choices: null
+    id: 2cc4ee39-cf5b-4e4b-b054-77a1cd70f4db
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/vie/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/vie/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: vie
+templates:
+  9f1aa5ab-9860-4f96-b97c-d5155fec3dd6: !Template
+    answer_choices: null
+    id: 9f1aa5ab-9860-4f96-b97c-d5155fec3dd6
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/wol/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/wol/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: wol
+templates:
+  870e62d6-ea27-44b2-9b22-f7815567bffc: !Template
+    answer_choices: null
+    id: 870e62d6-ea27-44b2-9b22-f7815567bffc
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/xho/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/xho/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: xho
+templates:
+  c4f7d641-3d06-44d6-afc6-49ba16a8355f: !Template
+    answer_choices: null
+    id: c4f7d641-3d06-44d6-afc6-49ba16a8355f
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/yor/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/yor/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: yor
+templates:
+  d6f78ab2-2e45-4741-a7bf-ad97d417e186: !Template
+    answer_choices: null
+    id: d6f78ab2-2e45-4741-a7bf-ad97d417e186
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/zho_simpl/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/zho_simpl/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: zho_simpl
+templates:
+  6277b2d7-cdaa-4fcd-9ab8-fd7775fb69f1: !Template
+    answer_choices: null
+    id: 6277b2d7-cdaa-4fcd-9ab8-fd7775fb69f1
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/zho_trad/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/zho_trad/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: zho_trad
+templates:
+  6c2ede9b-400c-4cda-9666-2dd5f20c74d1: !Template
+    answer_choices: null
+    id: 6c2ede9b-400c-4cda-9666-2dd5f20c74d1
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''

--- a/promptsource/templates/gsarti/flores_101/zul/templates.yaml
+++ b/promptsource/templates/gsarti/flores_101/zul/templates.yaml
@@ -1,0 +1,14 @@
+dataset: gsarti/flores_101
+subset: zul
+templates:
+  5472409a-e90e-45dc-8922-1c1c7e1cf92b: !Template
+    answer_choices: null
+    id: 5472409a-e90e-45dc-8922-1c1c7e1cf92b
+    jinja: '{{sentence}} ||| '
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: 'Null'
+    reference: ''


### PR DESCRIPTION
[`gsarti/flores_101`](https://huggingface.co/datasets/gsarti/flores_101) is a dataset with 102 languages used for language modeling.
* Added the 102 language subsets
* The prompt is empty -- just the sentence itself -- as this dataset will be used for language modeling (LM).
* The metric is set to Other; downstream applications (eval harness) will select the LM metric.
* It was necessary to add `gsarti` to the user list because the dataset is listed under that user in hugging face datasets.