### PR TITLE
Fix blank results

### DIFF
--- a/promptsource/templates.py
+++ b/promptsource/templates.py
@@ -191,6 +191,10 @@ class Template(yaml.YAMLObject):
         # Splits on the separator, and then replaces back any occurrences of the
         # separator in the original example
         parts = [self._unescape_pipe(part).strip() for part in rendered_example.split("|||")]
+        if parts == [""]:
+            # Handles the case of blank results
+            # Example: `tydiqa` where prompts are conditionned on the language and thus most of the time will return a blank result
+            return parts
         if len(parts) < 2:
             raise ValueError("Prompt did not produce an input and at least one target.")
 

--- a/test/show_templates.py
+++ b/test/show_templates.py
@@ -62,7 +62,7 @@ else:
                 print("\tExample ", example)
                 print("\t--------")
                 output = template.apply(example)
-                if output[0].strip() == "" or (len(output) > 1 and output[1][0].strip() == ""):
+                if output == [""]:
                     print("\t Blank result")
                     continue
 


### PR DESCRIPTION
This is fixing is a bug in how we handle blank results (for instance `tydiqa` has a bunch of them).
+ standardize how we detect these blank results

Example: PR https://github.com/bigscience-workshop/promptsource/pull/766