### PR TITLE
fix empty documents - multi_news

### DIFF
--- a/promptsource/templates/multi_news/templates.yaml
+++ b/promptsource/templates/multi_news/templates.yaml
@@ -3,10 +3,10 @@ templates:
   12269bd1-1c3a-4865-9702-892782b593d9: !Template
     answer_choices: null
     id: 12269bd1-1c3a-4865-9702-892782b593d9
-    jinja: '{% if document != "" %}
-
-      {% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
       "") | list %}
+
+      {% if document != "" %}
 
       What are the key points across these news articles:
 
@@ -33,10 +33,10 @@ templates:
   940d0ce4-c1ef-4453-a47b-1abaaf811160: !Template
     answer_choices: null
     id: 940d0ce4-c1ef-4453-a47b-1abaaf811160
-    jinja: '{% if document != "" %}
-
-      {% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
       "") | list %}
+
+      {% if document != "" %}
 
       Synthesize these documents into a single one:
 
@@ -63,10 +63,10 @@ templates:
   9ab370ad-2b89-4d2a-bb40-ccc31accefad: !Template
     answer_choices: null
     id: 9ab370ad-2b89-4d2a-bb40-ccc31accefad
-    jinja: '{% if document != "" %}
-
-      {% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
       "") | list %}
+
+      {% if document != "" %}
 
       I want to edit the following articles into a more concise summary:
 
@@ -93,10 +93,10 @@ templates:
   b15485f5-2bd9-4ed4-98ce-4b241a341f99: !Template
     answer_choices: null
     id: b15485f5-2bd9-4ed4-98ce-4b241a341f99
-    jinja: '{% if document != "" %}
-
-      {% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
       "") | list %}
+
+      {% if document != "" %}
 
       Write a summary of the following articles:
 
@@ -123,10 +123,10 @@ templates:
   bc910e51-c0a9-473c-aa85-adcab21b9ba9: !Template
     answer_choices: null
     id: bc910e51-c0a9-473c-aa85-adcab21b9ba9
-    jinja: '{% if document != "" %}
-
-      {% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
       "") | list%}
+
+      {% if document != "" %}
 
       Write an expanded news article with plausible details from the following summary:
 
@@ -148,10 +148,10 @@ templates:
   d5a4bb2a-634a-4e9a-9f1f-b0803894ca0f: !Template
     answer_choices: null
     id: d5a4bb2a-634a-4e9a-9f1f-b0803894ca0f
-    jinja: '{% if document != "" %}
-
-      {% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
+    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
       "") | list %}
+
+      {% if document != "" %}
 
       I''m trying to distill these articles down into one:
 

--- a/promptsource/templates/multi_news/templates.yaml
+++ b/promptsource/templates/multi_news/templates.yaml
@@ -3,7 +3,9 @@ templates:
   12269bd1-1c3a-4865-9702-892782b593d9: !Template
     answer_choices: null
     id: 12269bd1-1c3a-4865-9702-892782b593d9
-    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
+    jinja: '{% if document != "" %}
+
+      {% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
       "") | list %}
 
       What are the key points across these news articles:
@@ -17,7 +19,9 @@ templates:
 
       |||
 
-      {{summary[2:]}}'
+      {{summary[2:]}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -29,7 +33,9 @@ templates:
   940d0ce4-c1ef-4453-a47b-1abaaf811160: !Template
     answer_choices: null
     id: 940d0ce4-c1ef-4453-a47b-1abaaf811160
-    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
+    jinja: '{% if document != "" %}
+
+      {% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
       "") | list %}
 
       Synthesize these documents into a single one:
@@ -43,7 +49,9 @@ templates:
 
       |||
 
-      {{summary[2:]}}'
+      {{summary[2:]}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -55,7 +63,9 @@ templates:
   9ab370ad-2b89-4d2a-bb40-ccc31accefad: !Template
     answer_choices: null
     id: 9ab370ad-2b89-4d2a-bb40-ccc31accefad
-    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
+    jinja: '{% if document != "" %}
+
+      {% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
       "") | list %}
 
       I want to edit the following articles into a more concise summary:
@@ -69,7 +79,9 @@ templates:
 
       |||
 
-      {{summary[2:]}}'
+      {{summary[2:]}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -81,7 +93,9 @@ templates:
   b15485f5-2bd9-4ed4-98ce-4b241a341f99: !Template
     answer_choices: null
     id: b15485f5-2bd9-4ed4-98ce-4b241a341f99
-    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
+    jinja: '{% if document != "" %}
+
+      {% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
       "") | list %}
 
       Write a summary of the following articles:
@@ -95,7 +109,9 @@ templates:
 
       |||
 
-      {{summary[2:]}}'
+      {{summary[2:]}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -107,7 +123,9 @@ templates:
   bc910e51-c0a9-473c-aa85-adcab21b9ba9: !Template
     answer_choices: null
     id: bc910e51-c0a9-473c-aa85-adcab21b9ba9
-    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
+    jinja: '{% if document != "" %}
+
+      {% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
       "") | list%}
 
       Write an expanded news article with plausible details from the following summary:
@@ -116,7 +134,9 @@ templates:
 
       |||
 
-      {{docs | choice}}'
+      {{docs | choice}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
@@ -128,7 +148,9 @@ templates:
   d5a4bb2a-634a-4e9a-9f1f-b0803894ca0f: !Template
     answer_choices: null
     id: d5a4bb2a-634a-4e9a-9f1f-b0803894ca0f
-    jinja: '{% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
+    jinja: '{% if document != "" %}
+
+      {% set docs = document.split("3ed2dface8203c4c9dfb1a5dc58e41e0||") | reject("equalto",
       "") | list %}
 
       I''m trying to distill these articles down into one:
@@ -142,7 +164,9 @@ templates:
 
       |||
 
-      {{summary[2:]}}'
+      {{summary[2:]}}
+
+      {% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:


### PR DESCRIPTION
Some example have empty `document` field (examples 453, 16290, 16489, 18812, 19279, 21620, 30735, 41993 in the train split).
Putting an if condition so that prompts return a blank result on these examples.