### PR TITLE
add back in wikilingua id & zh english prompts 

### DIFF
--- a/promptsource/templates/GEM/wiki_lingua/id/templates.yaml
+++ b/promptsource/templates/GEM/wiki_lingua/id/templates.yaml
@@ -92,7 +92,9 @@ templates:
     answer_choices: null
     id: 84797c73-2344-44df-adda-544084854d82
     jinja: 'Article in Indonesian: {{source}}
-        Summary in Indonesian: ||| {{target}}'
+
+
+      Summary in Indonesian: ||| {{target}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       languages: []
@@ -106,6 +108,8 @@ templates:
     answer_choices: null
     id: 845a7e34-0b16-40f1-a678-f3d3ade2dd5f
     jinja: '{{source}}
+
+
       How would you rephrase that briefly in Indonesian? ||| {{target}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -120,7 +124,11 @@ templates:
     answer_choices: null
     id: 83feedc1-06ae-44e2-b0b5-69421beb73de
     jinja: 'First, read the Indonesian article below.
+
+
       {{source}}
+
+
       Now, please write a short abstract for it in Indonesian. ||| {{target}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -135,6 +143,8 @@ templates:
     answer_choices: null
     id: 8884e1f2-bf14-4792-856a-abbcbd0d5fd8
     jinja: '{{source}}
+
+
       TL;DR in Indonesian: ||| {{target}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -149,7 +159,11 @@ templates:
     answer_choices: null
     id: 8e4e8de3-5c06-4e7d-b2b4-d7e65db71bcb
     jinja: '{{source}}
+
+
       ===
+
+
       Write a summary of the text above in Indonesian: ||| {{target}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false

--- a/promptsource/templates/GEM/wiki_lingua/id/templates.yaml
+++ b/promptsource/templates/GEM/wiki_lingua/id/templates.yaml
@@ -15,7 +15,7 @@ templates:
       - ROUGE
       - BLEU
       original_task: true
-    name: article_summary_id
+    name: target_lang_article_summary_id
     reference: xsum template
   945a7e34-0b16-40f1-a678-f3d3ade2dd5f: !Template
     answer_choices: null
@@ -32,7 +32,7 @@ templates:
       - ROUGE
       - BLEU
       original_task: true
-    name: rephrase_id
+    name: target_lang_rephrase_id
     reference: xsum templates
   d3feedc1-06ae-44e2-b0b5-69421beb73de: !Template
     answer_choices: null
@@ -51,7 +51,7 @@ templates:
       - ROUGE
       - BLEU
       original_task: true
-    name: write_abstract_id
+    name: target_lang_write_abstract_id
     reference: xsum templates
   e884e1f2-bf14-4792-856a-abbcbd0d5fd8: !Template
     answer_choices: null
@@ -67,7 +67,7 @@ templates:
       - ROUGE
       - BLEU
       original_task: true
-    name: tldr_id
+    name: target_lang_tldr_id
     reference: xsum template
   ee4e8de3-5c06-4e7d-b2b4-d7e65db71bcb: !Template
     answer_choices: null
@@ -85,6 +85,78 @@ templates:
       metrics:
       - ROUGE
       - BLEU
+      original_task: true
+    name: target_lang_summarize_above_id
+    reference: xsum templates
+  84797c73-2344-44df-adda-544084854d82: !Template
+    answer_choices: null
+    id: 84797c73-2344-44df-adda-544084854d82
+    jinja: 'Article in Indonesian: {{source}}
+        Summary in Indonesian: ||| {{target}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages: []
+      metrics:
+        - ROUGE
+        - BLEU
+      original_task: true
+    name: article_summary_id
+    reference: xsum template
+  845a7e34-0b16-40f1-a678-f3d3ade2dd5f: !Template
+    answer_choices: null
+    id: 845a7e34-0b16-40f1-a678-f3d3ade2dd5f
+    jinja: '{{source}}
+      How would you rephrase that briefly in Indonesian? ||| {{target}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages: []
+      metrics:
+        - ROUGE
+        - BLEU
+      original_task: true
+    name: rephrase_id
+    reference: xsum templates
+  83feedc1-06ae-44e2-b0b5-69421beb73de: !Template
+    answer_choices: null
+    id: 83feedc1-06ae-44e2-b0b5-69421beb73de
+    jinja: 'First, read the Indonesian article below.
+      {{source}}
+      Now, please write a short abstract for it in Indonesian. ||| {{target}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages: []
+      metrics:
+        - ROUGE
+        - BLEU
+      original_task: true
+    name: write_abstract_id
+    reference: xsum templates
+  8884e1f2-bf14-4792-856a-abbcbd0d5fd8: !Template
+    answer_choices: null
+    id: 8884e1f2-bf14-4792-856a-abbcbd0d5fd8
+    jinja: '{{source}}
+      TL;DR in Indonesian: ||| {{target}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages: []
+      metrics:
+        - ROUGE
+        - BLEU
+      original_task: true
+    name: tldr_id
+    reference: xsum template
+  8e4e8de3-5c06-4e7d-b2b4-d7e65db71bcb: !Template
+    answer_choices: null
+    id: 8e4e8de3-5c06-4e7d-b2b4-d7e65db71bcb
+    jinja: '{{source}}
+      ===
+      Write a summary of the text above in Indonesian: ||| {{target}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages: []
+      metrics:
+        - ROUGE
+        - BLEU
       original_task: true
     name: summarize_above_id
     reference: xsum templates

--- a/promptsource/templates/GEM/wiki_lingua/zh/templates.yaml
+++ b/promptsource/templates/GEM/wiki_lingua/zh/templates.yaml
@@ -14,7 +14,7 @@ templates:
       - ROUGE
       - BLEU
       original_task: true
-    name: write_abstract_zh
+    name: target_lang_write_abstract_zh
     reference: xsum templates
   82caf67f-cb5d-4b98-82d1-d06acef9fc86: !Template
     answer_choices: null
@@ -28,7 +28,7 @@ templates:
       - ROUGE
       - BLEU
       original_task: true
-    name: article_summary_zh
+    name: target_lang_article_summary_zh
     reference: xsum templates
   bd3ac25e-e317-4eee-a519-c0a6246b302a: !Template
     answer_choices: null
@@ -42,7 +42,7 @@ templates:
       - ROUGE
       - BLEU
       original_task: true
-    name: rephrase_zh
+    name: target_lang_rephrase_zh
     reference: xsum templates
   d54e5dc2-b40f-4fda-a9e1-2ea028c9985b: !Template
     answer_choices: null
@@ -55,7 +55,7 @@ templates:
       - ROUGE
       - BLEU
       original_task: true
-    name: tldr_zh
+    name: target_lang_tldr_zh
     reference: xsum templates
   e46ff821-f9bc-4054-9e6a-6df16291bacd: !Template
     answer_choices: null
@@ -68,6 +68,78 @@ templates:
       metrics:
       - ROUGE
       - BLEU
+      original_task: true
+    name: target_lang_summarize_above_zh
+    reference: xsum templates
+  895b8406-1f4c-47ba-b885-63251a80e965: !Template
+    answer_choices: null
+    id: 895b8406-1f4c-47ba-b885-63251a80e965
+    jinja: 'First, read the Chinese article below.
+      {{source}}
+      Now, please write a short abstract for it in Chinese. ||| {{target}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages: []
+      metrics:
+        - ROUGE
+        - BLEU
+      original_task: true
+    name: write_abstract_zh
+    reference: xsum templates
+  88caf67f-cb5d-4b98-82d1-d06acef9fc86: !Template
+    answer_choices: null
+    id: 88caf67f-cb5d-4b98-82d1-d06acef9fc86
+    jinja: 'Article in Chinese: {{source}}
+      Summary in Chinese: ||| {{target}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages: []
+      metrics:
+        - ROUGE
+        - BLEU
+      original_task: true
+    name: article_summary_zh
+    reference: xsum templates
+  8d3ac25e-e317-4eee-a519-c0a6246b302a: !Template
+    answer_choices: null
+    id: 8d3ac25e-e317-4eee-a519-c0a6246b302a
+    jinja: '{{source}}
+      How would you rephrase that briefly in Chinese? ||| {{target}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages: []
+      metrics:
+        - ROUGE
+        - BLEU
+      original_task: true
+    name: rephrase_zh
+    reference: xsum templates
+  854e5dc2-b40f-4fda-a9e1-2ea028c9985b: !Template
+    answer_choices: null
+    id: 854e5dc2-b40f-4fda-a9e1-2ea028c9985b
+    jinja: '{{source}}
+      TL;DR in Chinese: ||| {{target}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages: []
+      metrics:
+        - ROUGE
+        - BLEU
+      original_task: true
+    name: tldr_zh
+    reference: xsum templates
+  846ff821-f9bc-4054-9e6a-6df16291bacd: !Template
+    answer_choices: null
+    id: 846ff821-f9bc-4054-9e6a-6df16291bacd
+    jinja: '{{source}}
+      ===
+      Write a summary of the text above in Chinese: ||| {{target}}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      languages: []
+      metrics:
+        - ROUGE
+        - BLEU
       original_task: true
     name: summarize_above_zh
     reference: xsum templates

--- a/promptsource/templates/GEM/wiki_lingua/zh/templates.yaml
+++ b/promptsource/templates/GEM/wiki_lingua/zh/templates.yaml
@@ -75,7 +75,11 @@ templates:
     answer_choices: null
     id: 895b8406-1f4c-47ba-b885-63251a80e965
     jinja: 'First, read the Chinese article below.
+
+
       {{source}}
+
+
       Now, please write a short abstract for it in Chinese. ||| {{target}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -90,6 +94,8 @@ templates:
     answer_choices: null
     id: 88caf67f-cb5d-4b98-82d1-d06acef9fc86
     jinja: 'Article in Chinese: {{source}}
+
+
       Summary in Chinese: ||| {{target}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -104,6 +110,8 @@ templates:
     answer_choices: null
     id: 8d3ac25e-e317-4eee-a519-c0a6246b302a
     jinja: '{{source}}
+
+
       How would you rephrase that briefly in Chinese? ||| {{target}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -118,6 +126,8 @@ templates:
     answer_choices: null
     id: 854e5dc2-b40f-4fda-a9e1-2ea028c9985b
     jinja: '{{source}}
+
+
       TL;DR in Chinese: ||| {{target}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
@@ -132,7 +142,11 @@ templates:
     answer_choices: null
     id: 846ff821-f9bc-4054-9e6a-6df16291bacd
     jinja: '{{source}}
+
+
       ===
+
+
       Write a summary of the text above in Chinese: ||| {{target}}'
     metadata: !TemplateMetadata
       choices_in_prompt: false


### PR DESCRIPTION
This is to be consistent with other wikilingua splits. Left translated prompts with target_lang_ prepended to prompt name. So hopefully can be distinguished post inference.